### PR TITLE
Account for projects that don't have client assigned

### DIFF
--- a/scripts/common.js
+++ b/scripts/common.js
@@ -43,15 +43,16 @@ function createOption(id, cid, text) {
 }
 
 function createProjectSelect(userData, className) {
-  var clientName, option,
+  var clients, projectLabel, option,
     select = createTag('select', className);
 
   //add an empty (default) option
   select.appendChild(createOption("default", null, "Select a toggl project"));
 
   userData.projects.forEach(function (project) {
-    clientName = userData.clients.filter(function (elem, index, array) { return (elem.id === project.cid); })[0].name;
-    select.appendChild(createOption(project.id, project.cid, clientName + " - " + project.name));
+    clients = userData.clients.filter(function (elem, index, array) { return (elem.id === project.cid); });
+    projectLabel = (clients.length > 0 ? clients[0].name + " - " : "") + project.name;
+    select.appendChild(createOption(project.id, project.cid, projectLabel));
   });
 
   return select;


### PR DESCRIPTION
Fixes an issue in createProjectSelect that caused project select construction to fail for projects with no assigned client.

If the project has a client, show "[project name] - [client name]"
Otherwise, show "[project name]"
