### PR TITLE
Infer project name for Basecamp.

### DIFF
--- a/scripts/content/basecamp.js
+++ b/scripts/content/basecamp.js
@@ -4,6 +4,7 @@
 
 (function () {
   var isStarted = false;
+  
   function addButtonTo(elem) {
     var alink, stag, cont = $('.pill', elem);
     if (cont === null) {


### PR DESCRIPTION
As long as your project names match in Basecamp and Toggl, it will select the right project in Toggl.

Tested and works well.
