### PR TITLE
Fixed initial timer link initalization in gitlab

### DIFF
--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -52,9 +52,8 @@ var togglbutton = {
             togglbutton.renderTo(selector, renderer);
           });
           observer.observe(document, {childList: true, subtree: true});
-        } else {
-          togglbutton.renderTo(selector, renderer);
         }
+        togglbutton.renderTo(selector, renderer);
       }
     });
   },


### PR DESCRIPTION
When you go to an issue page directly the timer link won't be loaded. I think it's because the renderTo method never called just an observer will be registered and that will not run until the DOM is updated. This patch fixes that.
