### PR TITLE
Add Trac Support

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -37,7 +37,11 @@
     "*://*.zendesk.com/*",
     "*://go.xero.com/*",
     "*://web.any.do/*",
-    "*://*.todoist.com/*"
+    "*://*.todoist.com/*",
+    "*://trac.edgewall.org/*",
+    "*://trac-hacks.org/*",
+    "*://*.trac.wordpress.org/*",
+    "*://bugs.jquery.com/*"
   ],
   "icons": {
     "16": "images/icon-16.png",
@@ -69,7 +73,11 @@
         "*://*.zendesk.com/*",
         "*://go.xero.com/*",
         "*://web.any.do/*",
-        "*://*.todoist.com/app*"
+        "*://*.todoist.com/app*",
+        "*://trac.edgewall.org/*",
+        "*://trac-hacks.org/*",
+        "*://*.trac.wordpress.org/*",
+        "*://bugs.jquery.com/*"
       ],
       "css": ["styles/style.css"],
       "js": ["scripts/common.js"]
@@ -98,7 +106,7 @@
       "matches": ["*://*.bitbucket.org/*"],
       "js": ["scripts/content/bitbucket.js"]
     },
-	  {
+    {
       "matches": ["*://*.github.com/*"],
       "js": ["scripts/content/github.js"]
     },
@@ -173,6 +181,15 @@
     {
       "matches": ["https://*.todoist.com/app*"],
       "js": ["scripts/content/todoist.js"]
+    },
+    {
+      "matches": [
+        "*://trac.edgewall.org/*",
+        "*://trac-hacks.org/*",
+        "*://*.trac.wordpress.org/*",
+        "*://bugs.jquery.com/*"
+      ],
+      "js": ["scripts/content/trac.js"]
     }
   ]
 }

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -30,7 +30,11 @@ var TogglButton = {
       'zendesk\\.com',
       'capsulecrm\\.com',
       'web\\.any\\.do',
-      'todoist\\.com'
+      'todoist\\.com',
+      'trac\\.edgewall\\.org',
+      'trac-hacks\\.org',
+      'trac\\.wordpress\\.org',
+      'bugs\\.jquery\\.com'
     ].join('|')
   ),
 

--- a/src/scripts/content/trac.js
+++ b/src/scripts/content/trac.js
@@ -1,0 +1,32 @@
+/*jslint indent: 2, unparam: true*/
+/*global $: false, document: false, togglbutton: false*/
+
+'use strict';
+
+togglbutton.render('#main > #content.ticket:not(.toggl)', {observe: true}, function (elem) {
+  var
+    link,
+    tracTicketId = (
+	  $('#main > #content.ticket > #ticket > h2 > .trac-id') || // Trac v1.x
+	  $('#main > #content.ticket > h1#trac-ticket-title > a') // Trac v0.x 
+	).innerHTML,
+    tracTicketDescription = $('#main > #content.ticket > #ticket .summary', elem).textContent,
+    tracProjectName = (
+	  $('title').textContent.split('     – ').pop() || // First try to get project name from title tag
+	  $('#banner > #header > #logo > img').attr('alt') // If can't find in title tag, get from logo alt attribute
+	),
+	container = (
+	  $('#main > #content.ticket > #ticket > h2 > .trac-type', elem) || // Trac v1.x
+	  $('#main > #content.ticket > h1#trac-ticket-title > a', elem) // Trac v0.x
+	),
+    spanTag;
+
+  link = togglbutton.createTimerLink({
+    className: 'trac',
+    description: tracTicketId + " " + tracTicketDescription,
+    projectName: tracProjectName
+  });
+
+  spanTag = document.createElement("span");
+  container.parentNode.appendChild(spanTag.appendChild(link));
+});

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -160,9 +160,9 @@
 
 /****** Zendesk *********/
 .toggl-button.zendesk {
-	float: right;
-	padding-right: 3em;
-	margin-top: -1.5em;
+  float: right;
+  padding-right: 3em;
+  margin-top: -1.5em;
 } 
 
 /****** Anydo *********/
@@ -195,3 +195,118 @@
   padding-left: 22px;
 }
 
+/****** Trac v1.x *********/
+#content .toggl-button.trac {
+  display: inline;
+  background-color: #eee;
+  background-position: 0.1em 0.1em;
+  color: #222;
+  border: 1px outset #eee;
+  border-radius: .3em;
+  box-shadow: .1em .1em .4em 0 #888;
+  text-shadow: .1em .1em #ddd;
+  padding: .1em .3em 0 1.7em;
+  margin: 0 0 0 0.2em;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: normal;
+  text-decoration: none;
+}
+
+#content .toggl-button.trac:hover {
+  background-color: #f6f6f6;
+  box-shadow: .1em .1em .6em 0 #999;
+  text-shadow: .1em .1em #fcfcfc;
+}
+
+#content .toggl-button.trac:active {
+  position: relative;
+  top: .1em;
+  left: .1em;
+}
+
+#content .toggl-button.trac.active {
+  color: rgb(34, 34, 34) !important;
+  background-color: rgb(26, 179, 81);
+  border-color: rgb(26, 179, 81);
+  text-shadow: rgb(180, 180, 180) .1em .1em;
+}
+
+#content .toggl-button.trac.active:hover {
+  background-color: rgb(137, 224, 168);
+  border-color: rgb(137, 224, 168);
+}
+
+/****** Trac v0.x *********/
+#content > #trac-ticket-title > .toggl-button.trac {
+  border: 1px outset #ccc;
+  border-radius: 0;
+  box-shadow: none;
+  text-shadow: none;
+  cursor: default;
+}
+
+#content > #trac-ticket-title > .toggl-button.trac:hover {
+  background-color: #ccb;
+  box-shadow: none;
+  text-shadow: none;
+}
+
+#content > #trac-ticket-title > .toggl-button.trac:active {
+  top: 0;
+  left: 0;
+}
+
+#content > #trac-ticket-title > .toggl-button.trac.active {
+  background-color: rgb(137, 224, 168);
+  border-color: rgb(137, 224, 168);
+  text-shadow: none;
+}
+
+#content > #trac-ticket-title > .toggl-button.trac.active:hover {
+  background-color: rgb(26, 179, 81);
+  border-color: rgb(26, 179, 81);
+}
+
+/****** WordPress Trac *********/
+
+#wordpress-org #content .toggl-button.trac {
+  border: 1px solid #eee;
+  text-decoration: none;
+  font-size: 12px;
+  line-height: 23px;
+  height: 24px;
+  margin: 0;
+  padding: 0 10px 1px 28px;
+  cursor: pointer;
+  -webkit-appearance: none;
+  white-space: nowrap;
+  box-sizing: border-box;
+  background-color: #f3f3f3;
+  border-color: #bbb;
+  color: #333;
+  border-radius: 3px;
+  text-shadow: none;
+  box-shadow: none;
+  background-position: 7px 1px;
+}
+
+#wordpress-org #content .toggl-button.trac:hover {
+  border-color: #999;
+  color: #222;
+}
+
+#wordpress-org #content .toggl-button.trac:active {
+  top: 0;
+  left: 0;
+}
+
+#wordpress-org #content .toggl-button.trac.active {
+  color: rgb(34, 34, 34) !important;
+  background-color: rgb(137, 224, 168);
+  border-color: rgb(26, 179, 81);
+}
+
+#wordpress-org #content .toggl-button.trac.active:hover {
+  border-color: rgb(22, 148, 67);
+}


### PR DESCRIPTION
Add support for Edgewall Trac. Tested in versions 0.12 - 1.1.2dev of
Trac. Custom styles added for Trac v0.x, Trac v1.x, and WordPress Trac.
For now, supported domains are trac.edgewall.org, trac-hacks.org,
trac.wordpress.org, and bugs.jquery.org. We may want to add to this list
in the future or allow users to add their own custom domains in
extension options.
