### PR TITLE
relocated Toggl-button in Toodledo

### DIFF
--- a/src/scripts/content/toodledo.js
+++ b/src/scripts/content/toodledo.js
@@ -19,5 +19,10 @@ togglbutton.render('.row:not(.toggl)', {observe: true}, function (elem) {
     projectName: goalElem && goalElem.textContent
   });
 
-  taskElem.appendChild(link);
+  var newElem = document.createElement('div');
+  newElem.appendChild(link);
+  newElem.setAttribute('style', 'float:left;width:30px;height:20px;');
+
+  var landmarkElem = $('.subm', elem) || $('.subp', elem);
+  elem.insertBefore(newElem, landmarkElem.nextSibling);
 });


### PR DESCRIPTION
Now, in Toodledo, Toggl-buttons are not displayed orderly because they are after task titles that don't have the same length. So, I relocated Toggl-button after row's header which is always displayed even if you customize Toodledo in any way. Each task is displayed as a row of table in Toodledo.
