### PR TITLE
Add eventum support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Add Toggl one-click time tracking to popular web tools.
   - [Google Mail][29]
   - [Taiga][30]
   - [HabitRPG][31]
+  - [Eventum][32]
 
 ## Installing from the Web Store
 
@@ -51,7 +52,7 @@ https://chrome.google.com/webstore/detail/toggl-button/oejgccbfbmkkpaidnkphaiaec
 [Trello][8], [Worksection][9], [Redbooth][10], [Podio][11], [Basecamp][12], [JIRA][13], [Producteev][14],
 [Bitbucket][15], [Stifer][16], [Google Docs][17], [Redmine][18], [YouTrack][19], [CapsuleCRM][20],
 [Xero][21], [Zendesk][22], [Any.do][23], [Todoist][24], [Trac][25], [Wunderlist][26], [Toodledo][27],
-[Teamwork.com][28], [Google Mail][29], [Taiga][30], [HabitRPG][31] account and start your Toggl timer there.
+[Teamwork.com][28], [Google Mail][29], [Taiga][30], [HabitRPG][31], [Eventum][32] account and start your Toggl timer there.
 3.  To stop the current running timer:
   - press the button again
   - start another time entry inside your account.
@@ -96,6 +97,7 @@ Don't know how to start? Just check out the [user requested services][97] that h
 [29]: https://mail.google.com
 [30]: https://taiga.io/
 [31]: https://habitrpg.com
+[32]: https://launchpad.net/eventum
 [97]: https://github.com/toggl/toggl-button/wiki/User-requested-buttons
 [98]: https://github.com/toggl/toggl-button/wiki/Adding-custom-domains
 [99]: https://github.com/toggl/toggl-button/pulls

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -22,6 +22,7 @@
     "idle",
     "*://*.toggl.com/*",
     "*://*.teamweek.com/*",
+    "*://eventum.example.org/view.php*",
     "*://*.pivotaltracker.com/*",
     "*://*.github.com/*",
     "*://*.gitlab.com/*",
@@ -65,6 +66,7 @@
       "matches": [
         "*://*.teamweek.com/*",
         "*://*.pivotaltracker.com/*",
+        "*://eventum.example.org/view.php*",
         "*://*.github.com/*",
         "*://*.gitlab.com/*",
         "*://*.bitbucket.org/*",
@@ -222,6 +224,13 @@
       ],
       "js": ["scripts/content/trac.js"]
     },
+    {
+      "matches": [
+        "*://eventum.example.org/view.php*"
+      ],
+      "js": ["scripts/content/eventum.js"]
+    },
+
     {
       "matches": ["https://*.wunderlist.com/*"],
       "js": ["scripts/content/wunderlist.js"]

--- a/src/scripts/content/eventum.js
+++ b/src/scripts/content/eventum.js
@@ -13,9 +13,9 @@ togglbutton.render('#issue_view:not(.toggl)', {}, function (elem) {
   // if the dropdown exists, its multiproject
   // otherwise take it from text value
   projectSelect = $('#project_chooser > form > select[name=current_project]', elem);
-  project = projectSelect ?
-    projectSelect.options[projectSelect.selectedIndex].text :
-    $('#project_chooser').textContent.replace(/^\s+Project:\s/, '');
+  project = projectSelect
+    ? projectSelect.options[projectSelect.selectedIndex].text
+    : $('#project_chooser').textContent.replace(/^\s+Project:\s/, '');
 
   link = togglbutton.createTimerLink({
     className: 'eventum',

--- a/src/scripts/content/eventum.js
+++ b/src/scripts/content/eventum.js
@@ -1,0 +1,26 @@
+/*jslint indent: 2, unparam: true*/
+/*global $: false, document: false, togglbutton: false*/
+
+'use strict';
+
+togglbutton.render('#issue_view:not(.toggl)', {}, function (elem) {
+  var
+    projectSelect, project, link, container, spanTag,
+    issue_id = $('#issue_overview > div.title > a', elem).innerHTML,
+    description = $('#issue_overview div#summary div.display', elem).textContent;
+
+  // find the project dropdown
+  projectSelect = $('#project_chooser > form > select[name=current_project]', elem);
+  // project is current value
+  project = projectSelect.options[projectSelect.selectedIndex].text;
+
+  link = togglbutton.createTimerLink({
+    className: 'eventum',
+    description: '#' + issue_id + ' ' + description,
+    projectName: project
+  });
+
+  container = $('#issue_overview div.title', elem);
+  spanTag = document.createElement("span");
+  container.appendChild(spanTag.appendChild(link));
+});

--- a/src/scripts/content/eventum.js
+++ b/src/scripts/content/eventum.js
@@ -10,9 +10,12 @@ togglbutton.render('#issue_view:not(.toggl)', {}, function (elem) {
     description = $('#issue_overview div#summary div.display', elem).textContent;
 
   // find the project dropdown
+  // if the dropdown exists, its multiproject
+  // otherwise take it from text value
   projectSelect = $('#project_chooser > form > select[name=current_project]', elem);
-  // project is current value
-  project = projectSelect.options[projectSelect.selectedIndex].text;
+  project = projectSelect ?
+    projectSelect.options[projectSelect.selectedIndex].text :
+    $('#project_chooser').textContent.replace(/^\s+Project:\s/, '');
 
   link = togglbutton.createTimerLink({
     className: 'eventum',


### PR DESCRIPTION
add support for [Eventum](https://launchpad.net/eventum) issue tracker.

as this particular issue tracker is not service, but you install it on your own, therefore added to `manifest.json` sample domain under [rfc2606](https://tools.ietf.org/html/rfc2606).

I wonder should this be somehow marked in README? the same problem exists for Trac based installations where you install Trac to your own infrastructure.