### PR TITLE
Add Drupal.org issue node support.

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -54,7 +54,8 @@
     "*://*.teamworkpm.net/*",
     "*://*.habitrpg.com/*",
     "*://*.taiga.io/*",
-    "*://*.axosoft.com/*"
+    "*://*.axosoft.com/*",
+    "*://*.drupal.org/*"
   ],
   "icons": {
     "16": "images/icon-16.png",
@@ -100,7 +101,8 @@
         "*://mail.google.com/*",
         "*://*.habitrpg.com/*",
         "*://*.taiga.io/*",
-        "*://*.axosoft.com/*"
+        "*://*.axosoft.com/*",
+        "*://*.drupal.org/*"
       ],
       "css": ["styles/style.css"],
       "js": ["scripts/common.js"]
@@ -248,6 +250,10 @@
     {
       "matches": ["*://*.axosoft.com/*"],
       "js": ["scripts/content/axosoft.js"]
+    },
+    {
+      "matches": ["*://*.drupal.org/*"],
+      "js": ["scripts/content/drupalorg.js"]
     }
   ]
 }

--- a/src/scripts/content/drupalorg.js
+++ b/src/scripts/content/drupalorg.js
@@ -1,0 +1,13 @@
+/*jslint indent: 2, unparam: true*/
+/*global $: false, document: false, togglbutton: false*/
+'use strict';
+
+togglbutton.render('body.node-type-project-issue #tabs ul', {}, function (elem) {
+
+  var link = togglbutton.createTimerLink({
+    className: 'drupalorg',
+    description: elem.textContent
+  });
+
+  elem.appendChild(document.createElement('li').appendChild(link));
+});


### PR DESCRIPTION
This adds the timer link into the node tabs on Drupal.org project issues. Useful when developers are paid bounties on contributed project code. Screenshot: http://imgur.com/SVwf1JM