### PR TITLE
Add 'Start timer' to browser extension popup

### DIFF
--- a/src/html/popup.html
+++ b/src/html/popup.html
@@ -7,7 +7,10 @@
   <body>
     <div class="header"></div>
 
-    <ul class="menu view">   
+    <ul class="menu view">
+      <li>
+        <button class="start-button">Start timer</button>
+      </li>
       <li>
         <button class="stop-button">Stop timer</button>
       </li>

--- a/src/html/popup.html
+++ b/src/html/popup.html
@@ -9,9 +9,6 @@
 
     <ul class="menu view">
       <li>
-        <button class="start-button">Start timer</button>
-      </li>
-      <li>
         <button class="stop-button">Stop timer</button>
       </li>
       <li>

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -7,16 +7,16 @@ var TogglButton = chrome.extension.getBackgroundPage().TogglButton;
 var PopUp = {
   $postStartText: " post-start popup",
   $popUpButton: null,
-  $stopButton: null,
+  $togglButton: null,
   showPage: function () {
     if (TogglButton.$user !== null) {
       document.querySelector(".menu").style.display = 'block';
       if (TogglButton.$curEntry === null) {
-        PopUp.$stopButton.setAttribute("disabled", true);
-        PopUp.$startButton.removeAttribute("disabled");
+        PopUp.$togglButton.setAttribute('data-event', 'timeEntry')
+        PopUp.$togglButton.textContent = 'Start timer';
       } else {
-        PopUp.$stopButton.removeAttribute("disabled");
-        PopUp.$startButton.setAttribute("disabled", true);
+        PopUp.$togglButton.setAttribute('data-event', 'stop');
+        PopUp.$togglButton.textContent = 'Stop timer';
       }
     } else {
       document.querySelector("#login-form").style.display = 'block';
@@ -37,21 +37,12 @@ var PopUp = {
 };
 
 document.addEventListener('DOMContentLoaded', function () {
-  PopUp.$stopButton = document.querySelector(".stop-button");
-  PopUp.$startButton = document.querySelector(".start-button");
+  PopUp.$togglButton = document.querySelector(".stop-button");
   PopUp.showPage();
 
-  PopUp.$stopButton.addEventListener('click', function () {
+  PopUp.$togglButton.addEventListener('click', function () {
     var request = {
-      type: "stop",
-      respond: true
-    };
-    PopUp.sendMessage(request);
-  });
-
-  PopUp.$startButton.addEventListener('click', function () {
-    var request = {
-      type: "timeEntry",
+      type: this.getAttribute('data-event'),
       respond: true
     };
     PopUp.sendMessage(request);

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -45,6 +45,11 @@ document.addEventListener('DOMContentLoaded', function () {
       type: this.getAttribute('data-event'),
       respond: true
     };
+
+    if (request.type === 'timeEntry') {
+      request.description = 'Chrome';
+    }
+
     PopUp.sendMessage(request);
   });
 

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -13,6 +13,10 @@ var PopUp = {
       document.querySelector(".menu").style.display = 'block';
       if (TogglButton.$curEntry === null) {
         PopUp.$stopButton.setAttribute("disabled", true);
+        PopUp.$startButton.removeAttribute("disabled");
+      } else {
+        PopUp.$stopButton.removeAttribute("disabled");
+        PopUp.$startButton.setAttribute("disabled", true);
       }
     } else {
       document.querySelector("#login-form").style.display = 'block';
@@ -22,7 +26,7 @@ var PopUp = {
   sendMessage: function (request) {
     chrome.extension.sendMessage(request, function (response) {
       if (!!response.success) {
-        if (!!response.type && response.type === "Stop") {
+        if (!!response.type && (response.type === "Stop" || response.type === "New Entry")) {
           window.close();
         } else {
           window.location.reload();
@@ -34,11 +38,20 @@ var PopUp = {
 
 document.addEventListener('DOMContentLoaded', function () {
   PopUp.$stopButton = document.querySelector(".stop-button");
+  PopUp.$startButton = document.querySelector(".start-button");
   PopUp.showPage();
 
   PopUp.$stopButton.addEventListener('click', function () {
     var request = {
       type: "stop",
+      respond: true
+    };
+    PopUp.sendMessage(request);
+  });
+
+  PopUp.$startButton.addEventListener('click', function () {
+    var request = {
+      type: "timeEntry",
       respond: true
     };
     PopUp.sendMessage(request);


### PR DESCRIPTION
Makes the stop button in the extension popup a toggle button. Allows creating a timer event from the extension directly (defaults the name of the event to Chrome). 

Referenced in issue toggl/toggl-button#154