### PR TITLE
Enhance project and tag handling in Toodledo integration

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -601,6 +601,14 @@ var TogglButton = {
       }
     } else if (request.type === 'currentEntry') {
       sendResponse({success: TogglButton.$curEntry !== null, currentEntry: TogglButton.$curEntry});
+    } else if (request.type === 'getEditFormData') {
+      var success = TogglButton.$user && TogglButton.$user.projectMap && TogglButton.$user.tagMap;
+
+      sendResponse({
+        success: success,
+        projects: success ? TogglButton.$user.projectMap : '',
+        tags: success ? TogglButton.$user.tagMap : ''
+      });
     } else if (request.type === 'getTasksHtml') {
       var success = TogglButton.$user && TogglButton.$user.projectTaskList;
 

--- a/src/scripts/content/toodledo.js
+++ b/src/scripts/content/toodledo.js
@@ -3,28 +3,159 @@
 
 'use strict';
 
-togglbutton.render('.row:not(.toggl)', {observe: true}, function (elem) {
-  var link,
-    newElem,
-    landmarkElem,
-    taskElem = $('.task', elem),
-    goalElem = $('.col1024', elem),
-    folderElem = $('.col1', elem),
-    folderName = folderElem && folderElem.firstChild.textContent;
+var retrievingEditFormData = false
+var editFormDataRetrieved = false
+var projects
+var tags
+var elems = []
 
-  folderName = (!folderName || folderName === "No Folder") ? "" : " - " + folderName;
+function extractNames(objectMap) {
+  if (Set) {
+      var names = new Set()
+      for (var key in objectMap) {
+        names.add(objectMap[key].name)
+      }
+      return names
+  } else {
+      var names = []
+      for (var key in objectMap) {
+        names.push(objectMap[key].name)
+      }
+      return names
+  }
+}
 
-  link = togglbutton.createTimerLink({
+function hasName(objectSet, name) {
+    if (objectSet.has) {
+        return objectSet.has(name)
+    } else if (objectSet.indexOf) {
+        return objectSet.indexOf(name) >= 0
+    } else {
+        return false
+    }
+}
+
+function getColumnText(selector, elem) {
+    return elem.querySelector(selector).textContent
+}
+
+function getTask(elem) {
+    return getColumnText('.col0', elem)
+}
+
+function getFolder(elem) {
+    return getColumnText('.col1', elem)
+}
+
+function getContext(elem) {
+    return getColumnText('.col512', elem)
+}
+
+function getGoal(elem) {
+    return getColumnText('.col1024', elem)
+}
+
+function getTags(elem) {
+    var splitTags = getColumnText('.col128', elem).split(',')
+    var length = splitTags.length
+    var taskTags = []
+    for (var i = 0; i < length; ++i) {
+        taskTags.push(splitTags[i].trim())
+    }
+    return taskTags
+}
+
+function getTimerDescription(elem) {
+    return getTask(elem)
+}
+
+function getTimerProject(elem) {
+    
+    var project = getFolder(elem)
+    if (hasName(projects, project))
+    {
+        return project
+    }
+
+    project = getGoal(elem)
+    if (hasName(projects, project))
+    {
+        return project
+    }
+
+    project = getContext(elem)
+    if (hasName(projects, project))
+    {
+        return project
+    }
+
+    var taskTags = getTags(elem)
+    var length = taskTags.length
+    for (var i = 0; i < length; ++i) {
+        if (hasName(projects, taskTags[i]))
+        {
+            return taskTags[i]
+        }
+    }
+    return ''
+}
+
+function getTimerTags(elem) {
+
+    var taskTags = getTags(elem)
+    var length = taskTags.length
+    var timerTags = []
+    for (var i = 0; i < length; ++i) {
+        if (hasName(tags, taskTags[i]))
+        {
+            timerTags.push(taskTags[i])
+        }
+    }
+    return timerTags
+}
+
+function renderButton(elem) {
+
+  var link = togglbutton.createTimerLink({
     className: 'toodledo',
     buttonType: 'minimal',
-    description: taskElem.textContent + folderName,
-    projectName: goalElem && goalElem.textContent
+    description: getTimerDescription(elem),
+    projectName: getTimerProject(elem),
+    tags: getTimerTags(elem).join()
   });
 
-  newElem = document.createElement('div');
+  var newElem = document.createElement('div');
   newElem.appendChild(link);
-  newElem.setAttribute('style', 'float:left;width:30px;height:20px;');
-
-  landmarkElem = $('.subm', elem) || $('.subp', elem) || $('.ax', elem);
+  newElem.setAttribute('style', 'float:left;width:30px;height:20px;position:relative;');
+  var landmarkElem = $('.subm', elem) || $('.subp', elem) || $('.ax', elem);
   elem.insertBefore(newElem, landmarkElem.nextSibling);
+}
+
+function renderButtons() {
+    var length = elems.length
+    for (var i=0; i<length; ++i) {
+        renderButton(elems[i])
+    }
+    elems = []
+}
+
+togglbutton.render('.row:not(.toggl)', {observe: true}, function (elem) {
+  elems.push(elem)
+
+  if (!retrievingEditFormData) {
+    if (editFormDataRetrieved) {
+        renderButtons()
+    } else {
+        retrievingEditFormData  = true
+        chrome.extension.sendMessage({type: 'getEditFormData'}, function (response) {
+          if (response && response.success ) {
+              projects = extractNames(response.projects)
+              tags = extractNames(response.tags)
+              renderButtons()
+              retrievingEditFormData = false
+              editFormDataRetrieved = true
+          }
+        });
+    }
+  }
 });


### PR DESCRIPTION
Updated the Toodledo integration to handle projects differently.

Toodledo is a very flexible tool and there are a variety of ways that people handle projects.  If you monitor the Toodledo forums you will find that people will use the folder, goal, context or even a tag as the location to indicate the name of the project.

Updated the Toodledo integration to allow the Toggl project name to be entered in any of those locations.

The previous implementation just tacked the folder name onto the description which really clutters up the Toggl interface if you only use a few standard folders with uninteresting names (from a Toggl point of view).

Note: There is another option that people use to represent projects, task/subtask.  Was unable to come up with an integration for that type, but maybe someone else will.

Also, tried to implement ToodleDo tag -> Toggl tag integration, but it doesn't appear to be able to be integrated it yet.  It looks like tags can be specified in the edit form, but not specified through the integration?
