### PR TITLE
Change the Wunderlist integration to be more subtle and out of the way

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -434,19 +434,21 @@ only screen and (min-resolution: 192dpi) {
   color: #737373;
   margin: 0px;
   display: inline;
+  opacity: 0.2;
 }
 
 .taskItem-toggl {
   z-index: 1;
   display: inline;
-  margin-bottom: -20px;
+  margin-bottom: 0px;
   padding-top: -5px;
   padding-right: 10px;
   line-height: 100%;
-  position: absolute;
-  top: 8px;
+  position: relative;
+  top: -2px;
   bottom: 0;
   left: 0;
+  float: right;
 }
 
 .detailItem-toggl {


### PR DESCRIPTION
The way the icon was displayed in Wunderlist was sharp. I've adapted it to have the look and feel similar to other icons that are attached to task items in Wunderlist. 

I think this works better because the Toggl button does not distract the user from their task, by blending into the interface style.

![image](https://cloud.githubusercontent.com/assets/4137844/7099752/bcf8efba-dfb1-11e4-9a8c-57d0e77b55d3.png)
