### PR TITLE
Automatic Tagging

### DIFF
--- a/src/html/settings.html
+++ b/src/html/settings.html
@@ -14,6 +14,10 @@
         <label for="show_post_start_popup">Show post-start popup</label>
       </li>
       <li>
+        <input type="checkbox" id="auto-tags">
+        <label for="auto-tags">Automatic tags</label>
+      </li>
+      <li>
         <input type="checkbox" id="websocket">
         <label for="websocket">Live updates (websocket)</label>
       </li>

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -433,7 +433,7 @@ var TogglButton = {
             if (wsHtml[key].hasOwnProperty(ckey) &&
                 wsHtml[key][ckey].indexOf("</option>") !== -1 &&
                 !!wsHtml[key][ckey] &&
-                (wsHtml[key][ckey].match(/\/option/g) || []).length > 1) {
+                (wsHtml[key][ckey].match(/\/option/g) || []).length > 0) {
               html += wsHtml[key][ckey] + "</optgroup>";
             }
           }
@@ -645,6 +645,11 @@ var TogglButton = {
     } else if (request.type === 'toggle-popup') {
       localStorage.setItem("showPostPopup", request.state);
       TogglButton.$showPostPopup = request.state;
+    } else if (request.type === 'toggle-autotags') {
+        localStorage.setItem("autoTagsEnabled", request.state);
+        TogglButton.$autoTagsEnabled = request.state;
+    } else if (request.type === 'getAutotagSetting') {
+        sendResponse({ success: true, autoTagsSetting: TogglButton.$autoTagsEnabled });
     } else if (request.type === 'toggle-socket') {
       TogglButton.setSocket(request.state);
     } else if (request.type === 'toggle-nanny') {
@@ -673,6 +678,7 @@ var TogglButton = {
 
 TogglButton.fetchUser();
 TogglButton.$showPostPopup = TogglButton.loadSetting("showPostPopup");
+TogglButton.$autoTagsEnabled = TogglButton.loadSetting("autoTagsEnabled");
 TogglButton.$socketEnabled = TogglButton.loadSetting("socketEnabled");
 TogglButton.$idleCheckEnabled = TogglButton.loadSetting("idleCheckEnabled");
 TogglButton.$idleInterval = !!localStorage.getItem("idleInterval") ? localStorage.getItem("idleInterval") : 360000;

--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -51,6 +51,7 @@ function getFullPageHeight() {
 
 var togglbutton = {
   isStarted: false,
+  autoTagsEnabled: true,
   element: null,
   serviceName: '',
   mousedownTrigger: null,
@@ -110,6 +111,15 @@ var togglbutton = {
         tags.push(tag);
       }
     }
+
+    //use auto-tags
+    if (togglbutton.autoTagsEnabled) {
+        if (togglbutton.autoTags && togglbutton.autoTags.length > 0) {
+            var combined = tags.concat(togglbutton.autoTags);
+            tags = combined.filter(function (item, pos) { return combined.indexOf(item) == pos });
+        }
+    }
+
     return tags;
   },
 
@@ -164,11 +174,16 @@ var togglbutton = {
       projectSelect = document.getElementById("toggl-button-project");
       $("#toggl-button-project-placeholder > div").innerHTML = (pid === 0) ? "Add project" : projectSelect.options[projectSelect.selectedIndex].text;
       togglbutton.resetTasks();
-      $("#toggl-button-tag-placeholder > div", editForm).innerHTML = "Add tags";
       $("#toggl-button-tag").value = "";
       editForm.style.left = position.left + "px";
       editForm.style.top = position.top + "px";
       editForm.style.display = "block";
+
+      //add auto-tags
+      var selectedTags = togglbutton.getSelectedTags();
+      $("#toggl-button-tag-placeholder > div", editForm).innerHTML = (selectedTags.length > 0 ? selectedTags.join(',') : "Add tags");
+
+
       return;
     }
 
@@ -280,6 +295,10 @@ var togglbutton = {
       dropdown.dispatchEvent(event);
     });
 
+    //add autotags
+    var selectedTags = togglbutton.getSelectedTags();
+    $("#toggl-button-tag-placeholder > div", editForm).innerHTML = (selectedTags.length > 0 ? selectedTags.join(',') : "Add tags");
+
     $("#toggl-button-tag-placeholder", editForm).addEventListener('click', function (e) {
       closeTagsList(false);
     });
@@ -388,6 +407,7 @@ var togglbutton = {
         };
       }
       togglbutton.element = e.target;
+      togglbutton.autoTags = invokeIfFunction(params.tags);
       chrome.extension.sendMessage(opts, togglbutton.addEditForm);
 
       return false;
@@ -451,5 +471,10 @@ window.addEventListener('focus', function (e) {
   // update button state
   chrome.extension.sendMessage({type: 'currentEntry'}, function (response) {
     togglbutton.updateTimerLink(response.currentEntry);
+  });
+
+  // get autotags setting
+  chrome.extension.sendMessage({ type: 'getAutotagSetting' }, function (response) {
+      togglbutton.autoTagsEnabled = response.autoTagsSetting;
   });
 });

--- a/src/scripts/content/asana.js
+++ b/src/scripts/content/asana.js
@@ -17,8 +17,22 @@ togglbutton.render('.details-pane-body:not(.toggl)', {observe: true}, function (
   link = togglbutton.createTimerLink({
     className: 'asana',
     description: descFunc,
-    projectName: project && project.textContent
+    projectName: project && project.textContent,
+    tags: getAsanaTags()
   });
 
   container.parentNode.insertBefore(link, container.nextSibling);
 });
+
+function getAsanaTags() {
+    var labels = [];
+    var label = null;
+    var labelElements = document.querySelectorAll('.tags .token_name');
+    for (var i = 0; i < labelElements.length; i++) {
+        label = labelElements[i].innerText;
+        if (label.trim().length > 0)
+            labels.push(label);
+    }
+
+    return labels;
+}

--- a/src/scripts/content/trello.js
+++ b/src/scripts/content/trello.js
@@ -12,8 +12,9 @@ togglbutton.render('.window-header:not(.toggl)', {observe: true}, function (elem
   link = togglbutton.createTimerLink({
     className: 'trello',
     description: titleElem.innerText,
-    projectName: projectElem.innerText
-  });
+    projectName: projectElem.innerText,
+    tags: getTrelloLabels()
+});
 
   container.appendChild(link);
   descriptionElem.parentNode.insertBefore(container, descriptionElem);
@@ -31,8 +32,22 @@ togglbutton.render('.checklist-item-details:not(.toggl)', {observe: true}, funct
     buttonType: 'minimal',
     projectName: projectElem.innerText,
     description: titleElem.innerText + ' - ' + taskElem.innerText,
+    tags: getTrelloLabels()
   });
 
   link.classList.add('checklist-item-button');
   elem.parentNode.appendChild(link);
 });
+
+function getTrelloLabels() {
+    var labels = [];
+    var label = null;
+    var labelElements = document.querySelectorAll('.js-card-detail-labels-list span.card-label');
+    for (var i = 0; i < labelElements.length; i++) {
+        label = labelElements[i].innerText;
+        if (label.trim().length > 0)
+            labels.push(label);
+    }
+
+    return labels;
+}

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -8,10 +8,12 @@ var Settings = {
   $postPopup: null,
   $socket: null,
   $nanny: null,
+  $autoTags: null,
   showPage: function () {
     Settings.setFromTo();
     document.querySelector("#nag-nanny-interval").value = TogglButton.$idleInterval / 60000;
     Settings.toggleState(Settings.$postPopup, TogglButton.$showPostPopup);
+    Settings.toggleState(Settings.$autoTags, TogglButton.$autoTagsEnabled);
     Settings.toggleState(Settings.$nanny, TogglButton.$idleCheckEnabled);
     Settings.toggleSetting(Settings.$socket, TogglButton.$socket);
 
@@ -43,9 +45,13 @@ document.addEventListener('DOMContentLoaded', function (e) {
   Settings.$postPopup = document.querySelector("#show_post_start_popup");
   Settings.$socket = document.querySelector("#websocket");
   Settings.$nanny = document.querySelector("#nag-nanny");
+  Settings.$autoTags = document.querySelector("#auto-tags");
   Settings.showPage();
   Settings.$postPopup.addEventListener('click', function (e) {
     Settings.toggleSetting(e.target, (localStorage.getItem("showPostPopup") !== "true"), "toggle-popup");
+  });
+  Settings.$autoTags.addEventListener('click', function (e) {
+      Settings.toggleSetting(e.target, (localStorage.getItem("autoTagsEnabled") !== "true"), "toggle-autotags");
   });
   Settings.$socket.addEventListener('click', function (e) {
     Settings.toggleSetting(e.target, (localStorage.getItem("socketEnabled") !== "true"), "toggle-socket");


### PR DESCRIPTION
- added generic tag recognition logic to the project
- added new option in settings screen to on/off this new feature ("Automatic Tags")
- added specific tag recognition for trello (using trello card labels) [ignores unnamed labels]
- added specific tag recognition for asana (using asana task tags)
- fixed bug: after fetching projects when constructing html to return there was a condition deleting projects from clients with only one project.
  previous conflicting condition was: (wsHtml[key][ckey].match(/\/option/g) || []).length > 1)
  changed to: (wsHtml[key][ckey].match(/\/option/g) || []).length > 0)
