### PR TITLE
fix toggl-button for new teamweek subdomain

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -136,7 +136,7 @@
       "js": ["scripts/content/teamweek.js"]
     },
     {
-      "matches": ["*://new.teamweek.com/*"],
+      "matches": ["*://app.teamweek.com/*"],
       "js": ["scripts/content/teamweek_new.js"]
     },
     {


### PR DESCRIPTION
In Teamweek users are now redirected to app.teamweek.com not to new.teamweek.com.