### PR TITLE
Add a `options_page` field to the manifest

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -72,6 +72,7 @@
     "48": "images/icon-48.png",
     "128": "images/icon-128.png"
   },
+  "options_page": "html/settings.html",
   "content_scripts": [
     {
       "matches": [


### PR DESCRIPTION
There's a native way to support extensions' settings pages. This is
defined in the extension's manifest.json [1]. Currently the option is
disabled when right clicking on the Toggl button, which is a little
confusing:

![](https://www.dropbox.com/s/c1a5hzqlw1sycs5/Screenshot%202015-08-09%2019.53.00.png?dl=1)

This commit makes it so the context menu shows "Options":

![](https://www.dropbox.com/s/1rgbtgv5jc8po9d/Screenshot%202015-08-09%2019.53.22.png?dl=1)