### PR TITLE
Add Discard Time Notification

### DIFF
--- a/src/html/settings.html
+++ b/src/html/settings.html
@@ -34,6 +34,10 @@
             </p>
           </div>
         </li>
+        <li class="discard-notification">
+          <input type="checkbox" id="discard-notification">
+          <label for="discard-notification">Discard idle time notification</label>
+        </li>
         <li class="pomodoro-mode">
           <input type="checkbox" id="pomodoro-mode">
           <label for="pomodoro-mode">Enable Pomodoro mode</label>

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -289,9 +289,9 @@ var TogglButton = {
     xhr.send(JSON.stringify(opts.payload));
   },
 
-  stopTimeEntry: function (timeEntry, sendResponse) {
+  stopTimeEntry: function (timeEntry, sendResponse, cb) {
     if (!TogglButton.$curEntry) { return; }
-    var stopTime = new Date(),
+    var stopTime = timeEntry.stopDate || new Date(),
       startTime = new Date(-TogglButton.$curEntry.duration * 1000);
 
     TogglButton.ajax("/time_entries/" + TogglButton.$curEntry.id, {
@@ -317,6 +317,9 @@ var TogglButton = {
 
           TogglButton.triggerNotification();
           TogglButton.analytics(timeEntry.type, timeEntry.service);
+          if (cb) {
+            cb();
+          }
         }
       }
     });

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -17,7 +17,7 @@ var Settings = {
     Settings.toggleState(Settings.$postPopup, TogglButton.$showPostPopup);
     Settings.toggleState(Settings.$nanny, TogglButton.$nannyCheckEnabled);
     Settings.toggleSetting(Settings.$socket, TogglButton.$socket);
-
+    Settings.toggleState(Settings.$discardNotification, TogglButton.$discardNotificationEnabled);
     Settings.toggleState(Settings.$pomodoroMode, TogglButton.$pomodoroModeEnabled);
     Settings.toggleState(Settings.$pomodoroSound, TogglButton.$pomodoroSoundEnabled);
     document.querySelector("#pomodoro-interval").value = TogglButton.$pomodoroInterval;
@@ -51,6 +51,7 @@ document.addEventListener('DOMContentLoaded', function (e) {
   Settings.$postPopup = document.querySelector("#show_post_start_popup");
   Settings.$socket = document.querySelector("#websocket");
   Settings.$nanny = document.querySelector("#nag-nanny");
+  Settings.$discardNotification = document.querySelector("#discard-notification");
   Settings.$pomodoroMode = document.querySelector("#pomodoro-mode");
   Settings.$pomodoroSound = document.querySelector("#enable-sound-signal");
   Settings.showPage();
@@ -64,8 +65,9 @@ document.addEventListener('DOMContentLoaded', function (e) {
   Settings.$nanny.addEventListener('click', function (e) {
     Settings.toggleSetting(e.target, (localStorage.getItem("nannyCheckEnabled") !== "true"), "toggle-nanny");
   });
+  Settings.$discardNotification.addEventListener('click', function (e) {
+    Settings.toggleSetting(e.target, (localStorage.getItem("discardNotificationEnabled") !== "true"), "toggle-discard");
   });
-
   Settings.$pomodoroMode.addEventListener('click', function (e) {
     Settings.toggleSetting(e.target, (localStorage.getItem("pomodoroModeEnabled") !== "true"), "toggle-pomodoro");
   });

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -13,9 +13,9 @@ var Settings = {
   showPage: function () {
     document.querySelector("#version").innerHTML = "<a href='http://toggl.github.io/toggl-button' title='Change log'>(" + chrome.runtime.getManifest().version + ")</a>";
     Settings.setFromTo();
-    document.querySelector("#nag-nanny-interval").value = TogglButton.$idleInterval / 60000;
+    document.querySelector("#nag-nanny-interval").value = TogglButton.$nannyInterval / 60000;
     Settings.toggleState(Settings.$postPopup, TogglButton.$showPostPopup);
-    Settings.toggleState(Settings.$nanny, TogglButton.$idleCheckEnabled);
+    Settings.toggleState(Settings.$nanny, TogglButton.$nannyCheckEnabled);
     Settings.toggleSetting(Settings.$socket, TogglButton.$socket);
 
     Settings.toggleState(Settings.$pomodoroMode, TogglButton.$pomodoroModeEnabled);
@@ -25,7 +25,7 @@ var Settings = {
     TogglButton.analytics("settings", null);
   },
   setFromTo: function () {
-    var fromTo = TogglButton.$idleFromTo.split("-");
+    var fromTo = TogglButton.$nannyFromTo.split("-");
     document.querySelector("#nag-nanny-from").value = fromTo[0];
     document.querySelector("#nag-nanny-to").value = fromTo[1];
   },
@@ -62,7 +62,8 @@ document.addEventListener('DOMContentLoaded', function (e) {
     Settings.toggleSetting(e.target, (localStorage.getItem("socketEnabled") !== "true"), "toggle-socket");
   });
   Settings.$nanny.addEventListener('click', function (e) {
-    Settings.toggleSetting(e.target, (localStorage.getItem("idleCheckEnabled") !== "true"), "toggle-nanny");
+    Settings.toggleSetting(e.target, (localStorage.getItem("nannyCheckEnabled") !== "true"), "toggle-nanny");
+  });
   });
 
   Settings.$pomodoroMode.addEventListener('click', function (e) {


### PR DESCRIPTION
Changes:

- Renames $timer/$idle to $nanny
- Adds suport for stop date and cb in #stopTimeEntry
- Add Discard Time Notification

Shows a notification to the user when she's been idle for at least 5min while
she was tracking some activity using Toggl.

The notification reads something like:

`You've been idle for 14m 53s while tracking "working on the landing
page".`

And two options are given to the user:

- Discard idle time
- Discard idle time and stop tracking

This notification/feature can be disabled via the new checkbox in the
eettings page, that reads like:

- [ ] Discard idle time notification