### PR TITLE
Adding slack.com, dropbox.com, duolingo.com, W3Schools.com, Udemy.com, alza.cz, inbox.google.com, linustechtips.com, pc-help.cz support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Add Toggl one-click time tracking to popular web tools.
   - [Slack][54]
   - [Alza][55]
   - [Duolingo][56]
+  - [W3Schools][57]
 
 ## Installing from the Web Store
 
@@ -87,7 +88,7 @@ List of all the changes and added features can be found at http://toggl.github.i
 2.  Go to your [TeamWeek][2], [Pivotal Tracker][3], [Github][4], [Asana][5], [Unfuddle][6], [Gitlab][7],
 [Trello][8], [Worksection][9], [Redbooth][10], [Podio][11], [Basecamp][12], [JIRA][13], [Producteev][14],
 [Bitbucket][15], [Stifer][16], [Google Docs][17], [Redmine][18], [YouTrack][19], [CapsuleCRM][20],
-[Xero][21], [Zendesk][22], [Any.do][23], [Todoist][24], [Trac][25], [Wunderlist][26], [Toodledo][27], [Teamwork.com][28], [Google Mail][29], [Taiga][30], [HabitRPG][31], [Axosoft][32], [Countersoft Gemini][33], [Drupal][34], [Esa][35], [Help Scout][36], [Flow][37], [Sprintly][38], [Google Calendar][39], [TestRail][40], [Bugzilla][41], [Breeze][42], [BamBam][43], [GQueue][44], [Wrike][45], [Assembla][46], [Waffle][47], [Codeable][48], [Eventum][49], [Salesforce][50], [Draftin][51], [FogBugz][52], [PC-HELP][53], [Slack][54], [Alza][55], [Duolingo][56] account and start your Toggl timer there.
+[Xero][21], [Zendesk][22], [Any.do][23], [Todoist][24], [Trac][25], [Wunderlist][26], [Toodledo][27], [Teamwork.com][28], [Google Mail][29], [Taiga][30], [HabitRPG][31], [Axosoft][32], [Countersoft Gemini][33], [Drupal][34], [Esa][35], [Help Scout][36], [Flow][37], [Sprintly][38], [Google Calendar][39], [TestRail][40], [Bugzilla][41], [Breeze][42], [BamBam][43], [GQueue][44], [Wrike][45], [Assembla][46], [Waffle][47], [Codeable][48], [Eventum][49], [Salesforce][50], [Draftin][51], [FogBugz][52], [PC-HELP][53], [Slack][54], [Alza][55], [Duolingo][56], [W3Schools][57] account and start your Toggl timer there.
 
 Or start entry from the extension icon menu
 
@@ -167,6 +168,7 @@ Don't know how to start? Just check out the [user requested services][97] that h
 [54]: https://slack.com/
 [55]: https://www.alza.cz/
 [56]: https://www.duolingo.com/
+[57]: http://www.w3schools.com/
 
 [97]: https://github.com/toggl/toggl-button/wiki/User-requested-buttons
 [98]: https://github.com/toggl/toggl-button/wiki/Adding-custom-domains

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Add Toggl one-click time tracking to popular web tools.
   - [Duolingo][56]
   - [W3Schools][57]
   - [Udemy][58]
+  - [Dropbox][59]
 
 ## Installing from the Web Store
 
@@ -89,7 +90,7 @@ List of all the changes and added features can be found at http://toggl.github.i
 2.  Go to your [TeamWeek][2], [Pivotal Tracker][3], [Github][4], [Asana][5], [Unfuddle][6], [Gitlab][7],
 [Trello][8], [Worksection][9], [Redbooth][10], [Podio][11], [Basecamp][12], [JIRA][13], [Producteev][14],
 [Bitbucket][15], [Stifer][16], [Google Docs][17], [Redmine][18], [YouTrack][19], [CapsuleCRM][20],
-[Xero][21], [Zendesk][22], [Any.do][23], [Todoist][24], [Trac][25], [Wunderlist][26], [Toodledo][27], [Teamwork.com][28], [Google Mail][29], [Taiga][30], [HabitRPG][31], [Axosoft][32], [Countersoft Gemini][33], [Drupal][34], [Esa][35], [Help Scout][36], [Flow][37], [Sprintly][38], [Google Calendar][39], [TestRail][40], [Bugzilla][41], [Breeze][42], [BamBam][43], [GQueue][44], [Wrike][45], [Assembla][46], [Waffle][47], [Codeable][48], [Eventum][49], [Salesforce][50], [Draftin][51], [FogBugz][52], [PC-HELP][53], [Slack][54], [Alza][55], [Duolingo][56], [W3Schools][57], [Udemy][58] account and start your Toggl timer there.
+[Xero][21], [Zendesk][22], [Any.do][23], [Todoist][24], [Trac][25], [Wunderlist][26], [Toodledo][27], [Teamwork.com][28], [Google Mail][29], [Taiga][30], [HabitRPG][31], [Axosoft][32], [Countersoft Gemini][33], [Drupal][34], [Esa][35], [Help Scout][36], [Flow][37], [Sprintly][38], [Google Calendar][39], [TestRail][40], [Bugzilla][41], [Breeze][42], [BamBam][43], [GQueue][44], [Wrike][45], [Assembla][46], [Waffle][47], [Codeable][48], [Eventum][49], [Salesforce][50], [Draftin][51], [FogBugz][52], [PC-HELP][53], [Slack][54], [Alza][55], [Duolingo][56], [W3Schools][57], [Udemy][58], [Dropbox][59] account and start your Toggl timer there.
 
 Or start entry from the extension icon menu
 
@@ -171,6 +172,7 @@ Don't know how to start? Just check out the [user requested services][97] that h
 [56]: https://www.duolingo.com/
 [57]: http://www.w3schools.com/
 [58]: https://www.udemy.com/courses/
+[59]: https://www.dropbox.com/
 
 [97]: https://github.com/toggl/toggl-button/wiki/User-requested-buttons
 [98]: https://github.com/toggl/toggl-button/wiki/Adding-custom-domains

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Add Toggl one-click time tracking to popular web tools.
   - [Alza][55]
   - [Duolingo][56]
   - [W3Schools][57]
+  - [Udemy][58]
 
 ## Installing from the Web Store
 
@@ -88,7 +89,7 @@ List of all the changes and added features can be found at http://toggl.github.i
 2.  Go to your [TeamWeek][2], [Pivotal Tracker][3], [Github][4], [Asana][5], [Unfuddle][6], [Gitlab][7],
 [Trello][8], [Worksection][9], [Redbooth][10], [Podio][11], [Basecamp][12], [JIRA][13], [Producteev][14],
 [Bitbucket][15], [Stifer][16], [Google Docs][17], [Redmine][18], [YouTrack][19], [CapsuleCRM][20],
-[Xero][21], [Zendesk][22], [Any.do][23], [Todoist][24], [Trac][25], [Wunderlist][26], [Toodledo][27], [Teamwork.com][28], [Google Mail][29], [Taiga][30], [HabitRPG][31], [Axosoft][32], [Countersoft Gemini][33], [Drupal][34], [Esa][35], [Help Scout][36], [Flow][37], [Sprintly][38], [Google Calendar][39], [TestRail][40], [Bugzilla][41], [Breeze][42], [BamBam][43], [GQueue][44], [Wrike][45], [Assembla][46], [Waffle][47], [Codeable][48], [Eventum][49], [Salesforce][50], [Draftin][51], [FogBugz][52], [PC-HELP][53], [Slack][54], [Alza][55], [Duolingo][56], [W3Schools][57] account and start your Toggl timer there.
+[Xero][21], [Zendesk][22], [Any.do][23], [Todoist][24], [Trac][25], [Wunderlist][26], [Toodledo][27], [Teamwork.com][28], [Google Mail][29], [Taiga][30], [HabitRPG][31], [Axosoft][32], [Countersoft Gemini][33], [Drupal][34], [Esa][35], [Help Scout][36], [Flow][37], [Sprintly][38], [Google Calendar][39], [TestRail][40], [Bugzilla][41], [Breeze][42], [BamBam][43], [GQueue][44], [Wrike][45], [Assembla][46], [Waffle][47], [Codeable][48], [Eventum][49], [Salesforce][50], [Draftin][51], [FogBugz][52], [PC-HELP][53], [Slack][54], [Alza][55], [Duolingo][56], [W3Schools][57], [Udemy][58] account and start your Toggl timer there.
 
 Or start entry from the extension icon menu
 
@@ -169,6 +170,7 @@ Don't know how to start? Just check out the [user requested services][97] that h
 [55]: https://www.alza.cz/
 [56]: https://www.duolingo.com/
 [57]: http://www.w3schools.com/
+[58]: https://www.udemy.com/courses/
 
 [97]: https://github.com/toggl/toggl-button/wiki/User-requested-buttons
 [98]: https://github.com/toggl/toggl-button/wiki/Adding-custom-domains

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Add Toggl one-click time tracking to popular web tools.
   - [Draftin][51]
   - [FogBugz][52]
   - [PC-HELP][53]
+  - [Slack][54]
+  - [Alza][55]
 
 ## Installing from the Web Store
 
@@ -84,7 +86,7 @@ List of all the changes and added features can be found at http://toggl.github.i
 2.  Go to your [TeamWeek][2], [Pivotal Tracker][3], [Github][4], [Asana][5], [Unfuddle][6], [Gitlab][7],
 [Trello][8], [Worksection][9], [Redbooth][10], [Podio][11], [Basecamp][12], [JIRA][13], [Producteev][14],
 [Bitbucket][15], [Stifer][16], [Google Docs][17], [Redmine][18], [YouTrack][19], [CapsuleCRM][20],
-[Xero][21], [Zendesk][22], [Any.do][23], [Todoist][24], [Trac][25], [Wunderlist][26], [Toodledo][27], [Teamwork.com][28], [Google Mail][29], [Taiga][30], [HabitRPG][31], [Axosoft][32], [Countersoft Gemini][33], [Drupal][34], [Esa][35], [Help Scout][36], [Flow][37], [Sprintly][38], [Google Calendar][39], [TestRail][40], [Bugzilla][41], [Breeze][42], [BamBam][43], [GQueue][44], [Wrike][45], [Assembla][46], [Waffle][47], [Codeable][48], [Eventum][49], [Salesforce][50], [Draftin][51], [FogBugz][52], [PC-HELP][53] account and start your Toggl timer there.
+[Xero][21], [Zendesk][22], [Any.do][23], [Todoist][24], [Trac][25], [Wunderlist][26], [Toodledo][27], [Teamwork.com][28], [Google Mail][29], [Taiga][30], [HabitRPG][31], [Axosoft][32], [Countersoft Gemini][33], [Drupal][34], [Esa][35], [Help Scout][36], [Flow][37], [Sprintly][38], [Google Calendar][39], [TestRail][40], [Bugzilla][41], [Breeze][42], [BamBam][43], [GQueue][44], [Wrike][45], [Assembla][46], [Waffle][47], [Codeable][48], [Eventum][49], [Salesforce][50], [Draftin][51], [FogBugz][52], [PC-HELP][53], [Slack][54], [Alza][55] account and start your Toggl timer there.
 
 Or start entry from the extension icon menu
 
@@ -161,6 +163,8 @@ Don't know how to start? Just check out the [user requested services][97] that h
 [51]: https://draftin.com/
 [52]: http://www.fogcreek.com/fogbugz/
 [53]: http://www.pc-help.cz/index.php
+[54]: https://slack.com/
+[55]: https://www.alza.cz/
 
 [97]: https://github.com/toggl/toggl-button/wiki/User-requested-buttons
 [98]: https://github.com/toggl/toggl-button/wiki/Adding-custom-domains

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Add Toggl one-click time tracking to popular web tools.
   - [PCPartPicker][62]
   - [Nedatluj][63]
   - [Google Developers][64]
+  - [Google Inbox][65]
+  - [LinusTechTips][66]
 
 ## Installing from the Web Store
 
@@ -95,7 +97,7 @@ List of all the changes and added features can be found at http://toggl.github.i
 2.  Go to your [TeamWeek][2], [Pivotal Tracker][3], [Github][4], [Asana][5], [Unfuddle][6], [Gitlab][7],
 [Trello][8], [Worksection][9], [Redbooth][10], [Podio][11], [Basecamp][12], [JIRA][13], [Producteev][14],
 [Bitbucket][15], [Stifer][16], [Google Docs][17], [Redmine][18], [YouTrack][19], [CapsuleCRM][20],
-[Xero][21], [Zendesk][22], [Any.do][23], [Todoist][24], [Trac][25], [Wunderlist][26], [Toodledo][27], [Teamwork.com][28], [Google Mail][29], [Taiga][30], [HabitRPG][31], [Axosoft][32], [Countersoft Gemini][33], [Drupal][34], [Esa][35], [Help Scout][36], [Flow][37], [Sprintly][38], [Google Calendar][39], [TestRail][40], [Bugzilla][41], [Breeze][42], [BamBam][43], [GQueue][44], [Wrike][45], [Assembla][46], [Waffle][47], [Codeable][48], [Eventum][49], [Salesforce][50], [Draftin][51], [FogBugz][52], [PC-HELP][53], [Slack][54], [Alza][55], [Duolingo][56], [W3Schools][57], [Udemy][58], [Dropbox][59], [Lego][60], [GoProForums][61], [PCPartPicker][62], [Nedatluj][63], [Google Developers][64] account and start your Toggl timer there.
+[Xero][21], [Zendesk][22], [Any.do][23], [Todoist][24], [Trac][25], [Wunderlist][26], [Toodledo][27], [Teamwork.com][28], [Google Mail][29], [Taiga][30], [HabitRPG][31], [Axosoft][32], [Countersoft Gemini][33], [Drupal][34], [Esa][35], [Help Scout][36], [Flow][37], [Sprintly][38], [Google Calendar][39], [TestRail][40], [Bugzilla][41], [Breeze][42], [BamBam][43], [GQueue][44], [Wrike][45], [Assembla][46], [Waffle][47], [Codeable][48], [Eventum][49], [Salesforce][50], [Draftin][51], [FogBugz][52], [PC-HELP][53], [Slack][54], [Alza][55], [Duolingo][56], [W3Schools][57], [Udemy][58], [Dropbox][59], [Lego][60], [GoProForums][61], [PCPartPicker][62], [Nedatluj][63], [Google Developers][64], [Google Inbox][65], [LinusTechTips][66] account and start your Toggl timer there.
 
 Or start entry from the extension icon menu
 
@@ -183,6 +185,8 @@ Don't know how to start? Just check out the [user requested services][97] that h
 [62]: https://pcpartpicker.com/
 [63]: http://www.nedatluj.cz/
 [64]: https://developers.google.com/
+[65]: https://inbox.google.com/
+[66]: https://linustechtips.com/main/
 
 [97]: https://github.com/toggl/toggl-button/wiki/User-requested-buttons
 [98]: https://github.com/toggl/toggl-button/wiki/Adding-custom-domains

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Add Toggl one-click time tracking to popular web tools.
   - [Udemy][58]
   - [Dropbox][59]
   - [Lego][60]
+  - [GoProForums][61]
 
 ## Installing from the Web Store
 
@@ -91,7 +92,7 @@ List of all the changes and added features can be found at http://toggl.github.i
 2.  Go to your [TeamWeek][2], [Pivotal Tracker][3], [Github][4], [Asana][5], [Unfuddle][6], [Gitlab][7],
 [Trello][8], [Worksection][9], [Redbooth][10], [Podio][11], [Basecamp][12], [JIRA][13], [Producteev][14],
 [Bitbucket][15], [Stifer][16], [Google Docs][17], [Redmine][18], [YouTrack][19], [CapsuleCRM][20],
-[Xero][21], [Zendesk][22], [Any.do][23], [Todoist][24], [Trac][25], [Wunderlist][26], [Toodledo][27], [Teamwork.com][28], [Google Mail][29], [Taiga][30], [HabitRPG][31], [Axosoft][32], [Countersoft Gemini][33], [Drupal][34], [Esa][35], [Help Scout][36], [Flow][37], [Sprintly][38], [Google Calendar][39], [TestRail][40], [Bugzilla][41], [Breeze][42], [BamBam][43], [GQueue][44], [Wrike][45], [Assembla][46], [Waffle][47], [Codeable][48], [Eventum][49], [Salesforce][50], [Draftin][51], [FogBugz][52], [PC-HELP][53], [Slack][54], [Alza][55], [Duolingo][56], [W3Schools][57], [Udemy][58], [Dropbox][59], [Lego][60] account and start your Toggl timer there.
+[Xero][21], [Zendesk][22], [Any.do][23], [Todoist][24], [Trac][25], [Wunderlist][26], [Toodledo][27], [Teamwork.com][28], [Google Mail][29], [Taiga][30], [HabitRPG][31], [Axosoft][32], [Countersoft Gemini][33], [Drupal][34], [Esa][35], [Help Scout][36], [Flow][37], [Sprintly][38], [Google Calendar][39], [TestRail][40], [Bugzilla][41], [Breeze][42], [BamBam][43], [GQueue][44], [Wrike][45], [Assembla][46], [Waffle][47], [Codeable][48], [Eventum][49], [Salesforce][50], [Draftin][51], [FogBugz][52], [PC-HELP][53], [Slack][54], [Alza][55], [Duolingo][56], [W3Schools][57], [Udemy][58], [Dropbox][59], [Lego][60], [GoProForums][61] account and start your Toggl timer there.
 
 Or start entry from the extension icon menu
 
@@ -175,6 +176,7 @@ Don't know how to start? Just check out the [user requested services][97] that h
 [58]: https://www.udemy.com/courses/
 [59]: https://www.dropbox.com/
 [60]: http://www.lego.com/
+[61]: http://www.goproforums.com/index.php
 
 [97]: https://github.com/toggl/toggl-button/wiki/User-requested-buttons
 [98]: https://github.com/toggl/toggl-button/wiki/Adding-custom-domains

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Add Toggl one-click time tracking to popular web tools.
   - [Lego][60]
   - [GoProForums][61]
   - [PCPartPicker][62]
+  - [Nedatluj][63]
 
 ## Installing from the Web Store
 
@@ -93,7 +94,7 @@ List of all the changes and added features can be found at http://toggl.github.i
 2.  Go to your [TeamWeek][2], [Pivotal Tracker][3], [Github][4], [Asana][5], [Unfuddle][6], [Gitlab][7],
 [Trello][8], [Worksection][9], [Redbooth][10], [Podio][11], [Basecamp][12], [JIRA][13], [Producteev][14],
 [Bitbucket][15], [Stifer][16], [Google Docs][17], [Redmine][18], [YouTrack][19], [CapsuleCRM][20],
-[Xero][21], [Zendesk][22], [Any.do][23], [Todoist][24], [Trac][25], [Wunderlist][26], [Toodledo][27], [Teamwork.com][28], [Google Mail][29], [Taiga][30], [HabitRPG][31], [Axosoft][32], [Countersoft Gemini][33], [Drupal][34], [Esa][35], [Help Scout][36], [Flow][37], [Sprintly][38], [Google Calendar][39], [TestRail][40], [Bugzilla][41], [Breeze][42], [BamBam][43], [GQueue][44], [Wrike][45], [Assembla][46], [Waffle][47], [Codeable][48], [Eventum][49], [Salesforce][50], [Draftin][51], [FogBugz][52], [PC-HELP][53], [Slack][54], [Alza][55], [Duolingo][56], [W3Schools][57], [Udemy][58], [Dropbox][59], [Lego][60], [GoProForums][61], [PCPartPicker][62] account and start your Toggl timer there.
+[Xero][21], [Zendesk][22], [Any.do][23], [Todoist][24], [Trac][25], [Wunderlist][26], [Toodledo][27], [Teamwork.com][28], [Google Mail][29], [Taiga][30], [HabitRPG][31], [Axosoft][32], [Countersoft Gemini][33], [Drupal][34], [Esa][35], [Help Scout][36], [Flow][37], [Sprintly][38], [Google Calendar][39], [TestRail][40], [Bugzilla][41], [Breeze][42], [BamBam][43], [GQueue][44], [Wrike][45], [Assembla][46], [Waffle][47], [Codeable][48], [Eventum][49], [Salesforce][50], [Draftin][51], [FogBugz][52], [PC-HELP][53], [Slack][54], [Alza][55], [Duolingo][56], [W3Schools][57], [Udemy][58], [Dropbox][59], [Lego][60], [GoProForums][61], [PCPartPicker][62], [Nedatluj][63] account and start your Toggl timer there.
 
 Or start entry from the extension icon menu
 
@@ -179,6 +180,7 @@ Don't know how to start? Just check out the [user requested services][97] that h
 [60]: http://www.lego.com/
 [61]: http://www.goproforums.com/index.php
 [62]: https://pcpartpicker.com/
+[63]: http://www.nedatluj.cz/
 
 [97]: https://github.com/toggl/toggl-button/wiki/User-requested-buttons
 [98]: https://github.com/toggl/toggl-button/wiki/Adding-custom-domains

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Add Toggl one-click time tracking to popular web tools.
   - [Dropbox][59]
   - [Lego][60]
   - [GoProForums][61]
+  - [PCPartPicker][62]
 
 ## Installing from the Web Store
 
@@ -92,7 +93,7 @@ List of all the changes and added features can be found at http://toggl.github.i
 2.  Go to your [TeamWeek][2], [Pivotal Tracker][3], [Github][4], [Asana][5], [Unfuddle][6], [Gitlab][7],
 [Trello][8], [Worksection][9], [Redbooth][10], [Podio][11], [Basecamp][12], [JIRA][13], [Producteev][14],
 [Bitbucket][15], [Stifer][16], [Google Docs][17], [Redmine][18], [YouTrack][19], [CapsuleCRM][20],
-[Xero][21], [Zendesk][22], [Any.do][23], [Todoist][24], [Trac][25], [Wunderlist][26], [Toodledo][27], [Teamwork.com][28], [Google Mail][29], [Taiga][30], [HabitRPG][31], [Axosoft][32], [Countersoft Gemini][33], [Drupal][34], [Esa][35], [Help Scout][36], [Flow][37], [Sprintly][38], [Google Calendar][39], [TestRail][40], [Bugzilla][41], [Breeze][42], [BamBam][43], [GQueue][44], [Wrike][45], [Assembla][46], [Waffle][47], [Codeable][48], [Eventum][49], [Salesforce][50], [Draftin][51], [FogBugz][52], [PC-HELP][53], [Slack][54], [Alza][55], [Duolingo][56], [W3Schools][57], [Udemy][58], [Dropbox][59], [Lego][60], [GoProForums][61] account and start your Toggl timer there.
+[Xero][21], [Zendesk][22], [Any.do][23], [Todoist][24], [Trac][25], [Wunderlist][26], [Toodledo][27], [Teamwork.com][28], [Google Mail][29], [Taiga][30], [HabitRPG][31], [Axosoft][32], [Countersoft Gemini][33], [Drupal][34], [Esa][35], [Help Scout][36], [Flow][37], [Sprintly][38], [Google Calendar][39], [TestRail][40], [Bugzilla][41], [Breeze][42], [BamBam][43], [GQueue][44], [Wrike][45], [Assembla][46], [Waffle][47], [Codeable][48], [Eventum][49], [Salesforce][50], [Draftin][51], [FogBugz][52], [PC-HELP][53], [Slack][54], [Alza][55], [Duolingo][56], [W3Schools][57], [Udemy][58], [Dropbox][59], [Lego][60], [GoProForums][61], [PCPartPicker][62] account and start your Toggl timer there.
 
 Or start entry from the extension icon menu
 
@@ -177,6 +178,7 @@ Don't know how to start? Just check out the [user requested services][97] that h
 [59]: https://www.dropbox.com/
 [60]: http://www.lego.com/
 [61]: http://www.goproforums.com/index.php
+[62]: https://pcpartpicker.com/
 
 [97]: https://github.com/toggl/toggl-button/wiki/User-requested-buttons
 [98]: https://github.com/toggl/toggl-button/wiki/Adding-custom-domains

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Add Toggl one-click time tracking to popular web tools.
   - [W3Schools][57]
   - [Udemy][58]
   - [Dropbox][59]
+  - [Lego][60]
 
 ## Installing from the Web Store
 
@@ -90,7 +91,7 @@ List of all the changes and added features can be found at http://toggl.github.i
 2.  Go to your [TeamWeek][2], [Pivotal Tracker][3], [Github][4], [Asana][5], [Unfuddle][6], [Gitlab][7],
 [Trello][8], [Worksection][9], [Redbooth][10], [Podio][11], [Basecamp][12], [JIRA][13], [Producteev][14],
 [Bitbucket][15], [Stifer][16], [Google Docs][17], [Redmine][18], [YouTrack][19], [CapsuleCRM][20],
-[Xero][21], [Zendesk][22], [Any.do][23], [Todoist][24], [Trac][25], [Wunderlist][26], [Toodledo][27], [Teamwork.com][28], [Google Mail][29], [Taiga][30], [HabitRPG][31], [Axosoft][32], [Countersoft Gemini][33], [Drupal][34], [Esa][35], [Help Scout][36], [Flow][37], [Sprintly][38], [Google Calendar][39], [TestRail][40], [Bugzilla][41], [Breeze][42], [BamBam][43], [GQueue][44], [Wrike][45], [Assembla][46], [Waffle][47], [Codeable][48], [Eventum][49], [Salesforce][50], [Draftin][51], [FogBugz][52], [PC-HELP][53], [Slack][54], [Alza][55], [Duolingo][56], [W3Schools][57], [Udemy][58], [Dropbox][59] account and start your Toggl timer there.
+[Xero][21], [Zendesk][22], [Any.do][23], [Todoist][24], [Trac][25], [Wunderlist][26], [Toodledo][27], [Teamwork.com][28], [Google Mail][29], [Taiga][30], [HabitRPG][31], [Axosoft][32], [Countersoft Gemini][33], [Drupal][34], [Esa][35], [Help Scout][36], [Flow][37], [Sprintly][38], [Google Calendar][39], [TestRail][40], [Bugzilla][41], [Breeze][42], [BamBam][43], [GQueue][44], [Wrike][45], [Assembla][46], [Waffle][47], [Codeable][48], [Eventum][49], [Salesforce][50], [Draftin][51], [FogBugz][52], [PC-HELP][53], [Slack][54], [Alza][55], [Duolingo][56], [W3Schools][57], [Udemy][58], [Dropbox][59], [Lego][60] account and start your Toggl timer there.
 
 Or start entry from the extension icon menu
 
@@ -173,6 +174,7 @@ Don't know how to start? Just check out the [user requested services][97] that h
 [57]: http://www.w3schools.com/
 [58]: https://www.udemy.com/courses/
 [59]: https://www.dropbox.com/
+[60]: http://www.lego.com/
 
 [97]: https://github.com/toggl/toggl-button/wiki/User-requested-buttons
 [98]: https://github.com/toggl/toggl-button/wiki/Adding-custom-domains

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Add Toggl one-click time tracking to popular web tools.
   - [GoProForums][61]
   - [PCPartPicker][62]
   - [Nedatluj][63]
+  - [Google Developers][64]
 
 ## Installing from the Web Store
 
@@ -94,7 +95,7 @@ List of all the changes and added features can be found at http://toggl.github.i
 2.  Go to your [TeamWeek][2], [Pivotal Tracker][3], [Github][4], [Asana][5], [Unfuddle][6], [Gitlab][7],
 [Trello][8], [Worksection][9], [Redbooth][10], [Podio][11], [Basecamp][12], [JIRA][13], [Producteev][14],
 [Bitbucket][15], [Stifer][16], [Google Docs][17], [Redmine][18], [YouTrack][19], [CapsuleCRM][20],
-[Xero][21], [Zendesk][22], [Any.do][23], [Todoist][24], [Trac][25], [Wunderlist][26], [Toodledo][27], [Teamwork.com][28], [Google Mail][29], [Taiga][30], [HabitRPG][31], [Axosoft][32], [Countersoft Gemini][33], [Drupal][34], [Esa][35], [Help Scout][36], [Flow][37], [Sprintly][38], [Google Calendar][39], [TestRail][40], [Bugzilla][41], [Breeze][42], [BamBam][43], [GQueue][44], [Wrike][45], [Assembla][46], [Waffle][47], [Codeable][48], [Eventum][49], [Salesforce][50], [Draftin][51], [FogBugz][52], [PC-HELP][53], [Slack][54], [Alza][55], [Duolingo][56], [W3Schools][57], [Udemy][58], [Dropbox][59], [Lego][60], [GoProForums][61], [PCPartPicker][62], [Nedatluj][63] account and start your Toggl timer there.
+[Xero][21], [Zendesk][22], [Any.do][23], [Todoist][24], [Trac][25], [Wunderlist][26], [Toodledo][27], [Teamwork.com][28], [Google Mail][29], [Taiga][30], [HabitRPG][31], [Axosoft][32], [Countersoft Gemini][33], [Drupal][34], [Esa][35], [Help Scout][36], [Flow][37], [Sprintly][38], [Google Calendar][39], [TestRail][40], [Bugzilla][41], [Breeze][42], [BamBam][43], [GQueue][44], [Wrike][45], [Assembla][46], [Waffle][47], [Codeable][48], [Eventum][49], [Salesforce][50], [Draftin][51], [FogBugz][52], [PC-HELP][53], [Slack][54], [Alza][55], [Duolingo][56], [W3Schools][57], [Udemy][58], [Dropbox][59], [Lego][60], [GoProForums][61], [PCPartPicker][62], [Nedatluj][63], [Google Developers][64] account and start your Toggl timer there.
 
 Or start entry from the extension icon menu
 
@@ -181,6 +182,7 @@ Don't know how to start? Just check out the [user requested services][97] that h
 [61]: http://www.goproforums.com/index.php
 [62]: https://pcpartpicker.com/
 [63]: http://www.nedatluj.cz/
+[64]: https://developers.google.com/
 
 [97]: https://github.com/toggl/toggl-button/wiki/User-requested-buttons
 [98]: https://github.com/toggl/toggl-button/wiki/Adding-custom-domains

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Add Toggl one-click time tracking to popular web tools.
   - [PC-HELP][53]
   - [Slack][54]
   - [Alza][55]
+  - [Duolingo][56]
 
 ## Installing from the Web Store
 
@@ -86,7 +87,7 @@ List of all the changes and added features can be found at http://toggl.github.i
 2.  Go to your [TeamWeek][2], [Pivotal Tracker][3], [Github][4], [Asana][5], [Unfuddle][6], [Gitlab][7],
 [Trello][8], [Worksection][9], [Redbooth][10], [Podio][11], [Basecamp][12], [JIRA][13], [Producteev][14],
 [Bitbucket][15], [Stifer][16], [Google Docs][17], [Redmine][18], [YouTrack][19], [CapsuleCRM][20],
-[Xero][21], [Zendesk][22], [Any.do][23], [Todoist][24], [Trac][25], [Wunderlist][26], [Toodledo][27], [Teamwork.com][28], [Google Mail][29], [Taiga][30], [HabitRPG][31], [Axosoft][32], [Countersoft Gemini][33], [Drupal][34], [Esa][35], [Help Scout][36], [Flow][37], [Sprintly][38], [Google Calendar][39], [TestRail][40], [Bugzilla][41], [Breeze][42], [BamBam][43], [GQueue][44], [Wrike][45], [Assembla][46], [Waffle][47], [Codeable][48], [Eventum][49], [Salesforce][50], [Draftin][51], [FogBugz][52], [PC-HELP][53], [Slack][54], [Alza][55] account and start your Toggl timer there.
+[Xero][21], [Zendesk][22], [Any.do][23], [Todoist][24], [Trac][25], [Wunderlist][26], [Toodledo][27], [Teamwork.com][28], [Google Mail][29], [Taiga][30], [HabitRPG][31], [Axosoft][32], [Countersoft Gemini][33], [Drupal][34], [Esa][35], [Help Scout][36], [Flow][37], [Sprintly][38], [Google Calendar][39], [TestRail][40], [Bugzilla][41], [Breeze][42], [BamBam][43], [GQueue][44], [Wrike][45], [Assembla][46], [Waffle][47], [Codeable][48], [Eventum][49], [Salesforce][50], [Draftin][51], [FogBugz][52], [PC-HELP][53], [Slack][54], [Alza][55], [Duolingo][56] account and start your Toggl timer there.
 
 Or start entry from the extension icon menu
 
@@ -165,6 +166,7 @@ Don't know how to start? Just check out the [user requested services][97] that h
 [53]: http://www.pc-help.cz/index.php
 [54]: https://slack.com/
 [55]: https://www.alza.cz/
+[56]: https://www.duolingo.com/
 
 [97]: https://github.com/toggl/toggl-button/wiki/User-requested-buttons
 [98]: https://github.com/toggl/toggl-button/wiki/Adding-custom-domains

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Add Toggl one-click time tracking to popular web tools.
   - [Salesforce][50]
   - [Draftin][51]
   - [FogBugz][52]
+  - [PC-HELP][53]
 
 ## Installing from the Web Store
 
@@ -83,7 +84,7 @@ List of all the changes and added features can be found at http://toggl.github.i
 2.  Go to your [TeamWeek][2], [Pivotal Tracker][3], [Github][4], [Asana][5], [Unfuddle][6], [Gitlab][7],
 [Trello][8], [Worksection][9], [Redbooth][10], [Podio][11], [Basecamp][12], [JIRA][13], [Producteev][14],
 [Bitbucket][15], [Stifer][16], [Google Docs][17], [Redmine][18], [YouTrack][19], [CapsuleCRM][20],
-[Xero][21], [Zendesk][22], [Any.do][23], [Todoist][24], [Trac][25], [Wunderlist][26], [Toodledo][27], [Teamwork.com][28], [Google Mail][29], [Taiga][30], [HabitRPG][31], [Axosoft][32], [Countersoft Gemini][33], [Drupal][34], [Esa][35], [Help Scout][36], [Flow][37], [Sprintly][38], [Google Calendar][39], [TestRail][40], [Bugzilla][41], [Breeze][42], [BamBam][43], [GQueue][44], [Wrike][45], [Assembla][46], [Waffle][47], [Codeable][48], [Eventum][49], [Salesforce][50], [Draftin][51], [FogBugz][52] account and start your Toggl timer there.
+[Xero][21], [Zendesk][22], [Any.do][23], [Todoist][24], [Trac][25], [Wunderlist][26], [Toodledo][27], [Teamwork.com][28], [Google Mail][29], [Taiga][30], [HabitRPG][31], [Axosoft][32], [Countersoft Gemini][33], [Drupal][34], [Esa][35], [Help Scout][36], [Flow][37], [Sprintly][38], [Google Calendar][39], [TestRail][40], [Bugzilla][41], [Breeze][42], [BamBam][43], [GQueue][44], [Wrike][45], [Assembla][46], [Waffle][47], [Codeable][48], [Eventum][49], [Salesforce][50], [Draftin][51], [FogBugz][52], [PC-HELP][53] account and start your Toggl timer there.
 
 Or start entry from the extension icon menu
 
@@ -159,6 +160,7 @@ Don't know how to start? Just check out the [user requested services][97] that h
 [50]: http://www.salesforce.com/
 [51]: https://draftin.com/
 [52]: http://www.fogcreek.com/fogbugz/
+[53]: http://www.pc-help.cz/index.php
 
 [97]: https://github.com/toggl/toggl-button/wiki/User-requested-buttons
 [98]: https://github.com/toggl/toggl-button/wiki/Adding-custom-domains

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -100,7 +100,9 @@
     "*://*.slack.com/*",
     "*://*.duolingo.com/*",
     "*://*.w3schools.com/*",
-    "*://*.udemy.com/*"
+    "*://*.udemy.com/*",
+    "*://*.dropbox.com/*"
+
 
   ],
   "content_scripts": [
@@ -172,7 +174,9 @@
         "*://*.slack.com/*",
         "*://*.duolingo.com/*",
         "*://*.w3schools.com/*",
-        "*://*.udemy.com/*"
+        "*://*.udemy.com/*",
+        "*://*.dropbox.com/*"
+
       ],
       "css": ["styles/style.css"],
       "js": ["scripts/common.js"]
@@ -428,6 +432,10 @@
     {
       "matches": ["*://*.udemy.com/*"],
       "js": ["scripts/content/udemy.js"]
+    },
+    {
+      "matches": ["*://*.dropbox.com/*"],
+      "js": ["scripts/content/dropbox.js"]
     }
 
   ]

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -106,7 +106,9 @@
     "*://*.goproforums.com/*",
     "*://*.pcpartpicker.com/*",
     "*://*.nedatluj.cz/*",
-    "*://developers.google.com/*"
+    "*://developers.google.com/*",
+    "*://inbox.google.com/*",
+    "*://*.linustechtips.com/*"
 
 
 
@@ -186,7 +188,9 @@
         "*://*.goproforums.com/*",
         "*://*.pcpartpicker.com/*",
         "*://*.nedatluj.cz/*",
-        "*://developers.google.com/*"
+        "*://developers.google.com/*",
+        "*://inbox.google.com/*",
+        "*://*.linustechtips.com/*"
 
       ],
       "css": ["styles/style.css"],
@@ -467,8 +471,15 @@
     {
       "matches": ["*://developers.google.com/*"],
       "js": ["scripts/content/googledevelopers.js"]
+    },
+    {
+      "matches": ["*://inbox.google.com/*"],
+      "js": ["scripts/content/google-inbox.js"]
+    },
+    {
+      "matches": ["*://*.linustechtips.com/*"],
+      "js": ["scripts/content/linustechtips.js"]
     }
-
 
 
   ]

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -94,7 +94,8 @@
     "*://www.assembla.com/*",
     "*://*.salesforce.com/*",
     "*://*.draftin.com/*",
-    "*://*.fogbugz.com/*"
+    "*://*.fogbugz.com/*",
+    "*://*.pc-help.cz/*"
   ],
   "content_scripts": [
     {
@@ -159,7 +160,8 @@
         "*://www.assembla.com/*",
         "*://*.salesforce.com/*",
         "*://*.draftin.com/*",
-        "*://*.fogbugz.com/*"
+        "*://*.fogbugz.com/*",
+        "*://*.pc-help.cz/*"
       ],
       "css": ["styles/style.css"],
       "js": ["scripts/common.js"]
@@ -391,6 +393,10 @@
     {
       "matches": ["*://*.fogbugz.com/*"],
       "js": ["scripts/content/fogbugz.js"]
+    },
+    {
+      "matches": ["*://*.pc-help.cz/*"],
+      "js": ["scripts/content/pc-help.js"]
     }
   ]
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -98,7 +98,10 @@
     "*://*.pc-help.cz/*",
     "*://*.alza.cz/*",
     "*://*.slack.com/*",
-    "*://*.duolingo.com/*"
+    "*://*.duolingo.com/*",
+    "*://*.w3schools.com/*",
+    "*://*.udemy.com/*"
+
   ],
   "content_scripts": [
     {
@@ -168,7 +171,8 @@
         "*://*.alza.cz/*",
         "*://*.slack.com/*",
         "*://*.duolingo.com/*",
-        "*://*.w3schools.com/*"
+        "*://*.w3schools.com/*",
+        "*://*.udemy.com/*"
       ],
       "css": ["styles/style.css"],
       "js": ["scripts/common.js"]
@@ -420,6 +424,10 @@
     {
       "matches": ["*://*.w3schools.com/*"],
       "js": ["scripts/content/w3schools.js"]
+    },
+    {
+      "matches": ["*://*.udemy.com/*"],
+      "js": ["scripts/content/udemy.js"]
     }
 
   ]

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -97,7 +97,8 @@
     "*://*.fogbugz.com/*",
     "*://*.pc-help.cz/*",
     "*://*.alza.cz/*",
-    "*://*.slack.com/*"
+    "*://*.slack.com/*",
+    "*://*.duolingo.com/*"
   ],
   "content_scripts": [
     {
@@ -165,7 +166,8 @@
         "*://*.fogbugz.com/*",
         "*://*.pc-help.cz/*",
         "*://*.alza.cz/*",
-        "*://*.slack.com/*"
+        "*://*.slack.com/*",
+        "*://*.duolingo.com/*"
       ],
       "css": ["styles/style.css"],
       "js": ["scripts/common.js"]
@@ -409,6 +411,10 @@
     {
       "matches": ["*://*.slack.com/*"],
       "js": ["scripts/content/slack.js"]
+    },
+    {
+      "matches": ["*://*.duolingo.com/*"],
+      "js": ["scripts/content/duolingo.js"]
     }
   ]
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -167,7 +167,8 @@
         "*://*.pc-help.cz/*",
         "*://*.alza.cz/*",
         "*://*.slack.com/*",
-        "*://*.duolingo.com/*"
+        "*://*.duolingo.com/*",
+        "*://*.w3schools.com/*"
       ],
       "css": ["styles/style.css"],
       "js": ["scripts/common.js"]
@@ -415,6 +416,11 @@
     {
       "matches": ["*://*.duolingo.com/*"],
       "js": ["scripts/content/duolingo.js"]
+    },
+    {
+      "matches": ["*://*.w3schools.com/*"],
+      "js": ["scripts/content/w3schools.js"]
     }
+
   ]
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -105,7 +105,8 @@
     "*://*.lego.com/*",
     "*://*.goproforums.com/*",
     "*://*.pcpartpicker.com/*",
-    "*://*.nedatluj.cz/*"
+    "*://*.nedatluj.cz/*",
+    "*://developers.google.com/*"
 
 
 
@@ -184,7 +185,8 @@
         "*://*.lego.com/*",
         "*://*.goproforums.com/*",
         "*://*.pcpartpicker.com/*",
-        "*://*.nedatluj.cz/*"
+        "*://*.nedatluj.cz/*",
+        "*://developers.google.com/*"
 
       ],
       "css": ["styles/style.css"],
@@ -461,7 +463,13 @@
     {
       "matches": ["*://*.nedatluj.cz/*"],
       "js": ["scripts/content/nedatluj.js"]
+    },
+    {
+      "matches": ["*://developers.google.com/*"],
+      "js": ["scripts/content/googledevelopers.js"]
     }
+
+
 
   ]
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -101,7 +101,8 @@
     "*://*.duolingo.com/*",
     "*://*.w3schools.com/*",
     "*://*.udemy.com/*",
-    "*://*.dropbox.com/*"
+    "*://*.dropbox.com/*",
+    "*://*.lego.com/*"
 
 
   ],
@@ -175,7 +176,8 @@
         "*://*.duolingo.com/*",
         "*://*.w3schools.com/*",
         "*://*.udemy.com/*",
-        "*://*.dropbox.com/*"
+        "*://*.dropbox.com/*",
+        "*://*.lego.com/*"
 
       ],
       "css": ["styles/style.css"],
@@ -436,6 +438,10 @@
     {
       "matches": ["*://*.dropbox.com/*"],
       "js": ["scripts/content/dropbox.js"]
+    },
+    {
+      "matches": ["*://*.lego.com/*"],
+      "js": ["scripts/content/lego.js"]
     }
 
   ]

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -95,7 +95,9 @@
     "*://*.salesforce.com/*",
     "*://*.draftin.com/*",
     "*://*.fogbugz.com/*",
-    "*://*.pc-help.cz/*"
+    "*://*.pc-help.cz/*",
+    "*://*.alza.cz/*",
+    "*://*.slack.com/*"
   ],
   "content_scripts": [
     {
@@ -161,7 +163,9 @@
         "*://*.salesforce.com/*",
         "*://*.draftin.com/*",
         "*://*.fogbugz.com/*",
-        "*://*.pc-help.cz/*"
+        "*://*.pc-help.cz/*",
+        "*://*.alza.cz/*",
+        "*://*.slack.com/*"
       ],
       "css": ["styles/style.css"],
       "js": ["scripts/common.js"]
@@ -397,6 +401,14 @@
     {
       "matches": ["*://*.pc-help.cz/*"],
       "js": ["scripts/content/pc-help.js"]
+    },
+    {
+      "matches": ["*://*.alza.cz/*"],
+      "js": ["scripts/content/alza.js"]
+    },
+    {
+      "matches": ["*://*.slack.com/*"],
+      "js": ["scripts/content/slack.js"]
     }
   ]
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -102,7 +102,8 @@
     "*://*.w3schools.com/*",
     "*://*.udemy.com/*",
     "*://*.dropbox.com/*",
-    "*://*.lego.com/*"
+    "*://*.lego.com/*",
+    "*://*.goproforums.com/*"
 
 
   ],
@@ -177,7 +178,8 @@
         "*://*.w3schools.com/*",
         "*://*.udemy.com/*",
         "*://*.dropbox.com/*",
-        "*://*.lego.com/*"
+        "*://*.lego.com/*",
+        "*://*.goproforums.com/*"
 
       ],
       "css": ["styles/style.css"],
@@ -442,6 +444,10 @@
     {
       "matches": ["*://*.lego.com/*"],
       "js": ["scripts/content/lego.js"]
+    },
+    {
+      "matches": ["*://*.goproforums.com/*"],
+      "js": ["scripts/content/goproforums.js"]
     }
 
   ]

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -104,7 +104,8 @@
     "*://*.dropbox.com/*",
     "*://*.lego.com/*",
     "*://*.goproforums.com/*",
-    "*://*.pcpartpicker.com/*"
+    "*://*.pcpartpicker.com/*",
+    "*://*.nedatluj.cz/*"
 
 
 
@@ -182,7 +183,8 @@
         "*://*.dropbox.com/*",
         "*://*.lego.com/*",
         "*://*.goproforums.com/*",
-          "*://*.pcpartpicker.com/*"
+        "*://*.pcpartpicker.com/*",
+        "*://*.nedatluj.cz/*"
 
       ],
       "css": ["styles/style.css"],
@@ -455,8 +457,11 @@
     {
       "matches": ["*://*.pcpartpicker.com/*"],
       "js": ["scripts/content/pcpartpicker.js"]
+    },
+    {
+      "matches": ["*://*.nedatluj.cz/*"],
+      "js": ["scripts/content/nedatluj.js"]
     }
-
 
   ]
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -103,7 +103,9 @@
     "*://*.udemy.com/*",
     "*://*.dropbox.com/*",
     "*://*.lego.com/*",
-    "*://*.goproforums.com/*"
+    "*://*.goproforums.com/*",
+    "*://*.pcpartpicker.com/*"
+
 
 
   ],
@@ -179,7 +181,8 @@
         "*://*.udemy.com/*",
         "*://*.dropbox.com/*",
         "*://*.lego.com/*",
-        "*://*.goproforums.com/*"
+        "*://*.goproforums.com/*",
+          "*://*.pcpartpicker.com/*"
 
       ],
       "css": ["styles/style.css"],
@@ -448,7 +451,12 @@
     {
       "matches": ["*://*.goproforums.com/*"],
       "js": ["scripts/content/goproforums.js"]
+    },
+    {
+      "matches": ["*://*.pcpartpicker.com/*"],
+      "js": ["scripts/content/pcpartpicker.js"]
     }
+
 
   ]
 }

--- a/src/scripts/content/alza.js
+++ b/src/scripts/content/alza.js
@@ -1,0 +1,21 @@
+/*jslint indent: 2 */
+/*global $: false, document: false, togglbutton: false*/
+'use strict';
+
+togglbutton.render('.textlinks:not(.toggl)', {}, function (elem) {
+  var link,
+    description = $('Description', elem),
+    project = $('Projects name', elem);
+
+
+  link = togglbutton.createTimerLink({
+    className: 'alza',
+    description: description,
+    projectName: project
+  });
+
+  $('.textlinks').appendChild(link);
+
+
+
+});

--- a/src/scripts/content/alza.js
+++ b/src/scripts/content/alza.js
@@ -4,14 +4,12 @@
 
 togglbutton.render('.textlinks:not(.toggl)', {}, function (elem) {
   var link,
-    description = $('Description', elem),
-    project = $('Projects name', elem);
+    description = 'Shopping';
 
 
   link = togglbutton.createTimerLink({
     className: 'alza',
-    description: description,
-    projectName: project
+    description: description
   });
 
   $('.textlinks').appendChild(link);

--- a/src/scripts/content/dropbox.js
+++ b/src/scripts/content/dropbox.js
@@ -2,7 +2,7 @@
 /*global $: false, document: false, togglbutton: false*/
 'use strict';
 
-togglbutton.render('.general-header-right:not(.toggl)', {}, function (elem) {
+togglbutton.render('#main-nav:not(.toggl)', {}, function (elem) {
   var link,
     description = $('Description', elem),
     project = $('Projects name', elem);
@@ -15,6 +15,6 @@ togglbutton.render('.general-header-right:not(.toggl)', {}, function (elem) {
   });
 
 
-  $('.general-header-right').appendChild(link);
+  $('#main-nav').appendChild(link);
 
 });

--- a/src/scripts/content/dropbox.js
+++ b/src/scripts/content/dropbox.js
@@ -4,14 +4,12 @@
 
 togglbutton.render('#main-nav:not(.toggl)', {}, function (elem) {
   var link,
-    description = $('Description', elem),
-    project = $('Projects name', elem);
+    description = 'Dropbox';
 
 
   link = togglbutton.createTimerLink({
-    className: 'udemy',
-    description: description,
-    projectName: project
+    className: 'dropbox',
+    description: description
   });
 
 

--- a/src/scripts/content/duolingo.js
+++ b/src/scripts/content/duolingo.js
@@ -1,0 +1,21 @@
+/*jslint indent: 2 */
+/*global $: false, document: false, togglbutton: false*/
+'use strict';
+
+togglbutton.render('.skill-tree-header:not(.toggl)', {}, function (elem) {
+  var link,
+    description = $('Description', elem),
+    project = $('Projects name', elem);
+
+
+  link = togglbutton.createTimerLink({
+    className: 'duolingo',
+    description: description,
+    projectName: project
+  });
+
+  //skill-tree-header
+  //var htmlElement = document.querySelector("h1");
+  $('.skill-tree-header').appendChild(link);
+
+});

--- a/src/scripts/content/duolingo.js
+++ b/src/scripts/content/duolingo.js
@@ -4,18 +4,15 @@
 
 togglbutton.render('.skill-tree-header:not(.toggl)', {}, function (elem) {
   var link,
-    description = $('Description', elem),
-    project = $('Projects name', elem);
+    description = $('h1').textContent;
 
 
   link = togglbutton.createTimerLink({
     className: 'duolingo',
-    description: description,
-    projectName: project
+    description: description
+
   });
 
-  //skill-tree-header
-  //var htmlElement = document.querySelector("h1");
   $('.skill-tree-header').appendChild(link);
 
 });

--- a/src/scripts/content/google-inbox.js
+++ b/src/scripts/content/google-inbox.js
@@ -4,14 +4,12 @@
 
 togglbutton.render('.pa.Y:not(.toggl)', {}, function (elem) {
   var link,
-    description = $('Description', elem),
-    project = $('Projects name', elem);
+    description = 'Handling e-mails';
 
 
   link = togglbutton.createTimerLink({
     className: 'google-inbox',
-    description: description,
-    projectName: project
+    description: description
   });
 
   $('.pa.Y').appendChild(link);

--- a/src/scripts/content/google-inbox.js
+++ b/src/scripts/content/google-inbox.js
@@ -1,0 +1,21 @@
+/*jslint indent: 2 */
+/*global $: false, document: false, togglbutton: false*/
+'use strict';
+
+togglbutton.render('.pa.Y:not(.toggl)', {}, function (elem) {
+  var link,
+    description = $('Description', elem),
+    project = $('Projects name', elem);
+
+
+  link = togglbutton.createTimerLink({
+    className: 'google-inbox',
+    description: description,
+    projectName: project
+  });
+
+  $('.pa.Y').appendChild(link);
+
+
+
+});

--- a/src/scripts/content/googledevelopers.js
+++ b/src/scripts/content/googledevelopers.js
@@ -4,14 +4,12 @@
 
 togglbutton.render('.devsite-page-title:not(.toggl)', {}, function (elem) {
   var link,
-    description = $('Description', elem),
-    project = $('Projects name', elem);
+    description = $('h1').textContent;
 
 
   link = togglbutton.createTimerLink({
     className: 'developers-google',
-    description: description,
-    projectName: project
+    description: description
   });
 
 

--- a/src/scripts/content/googledevelopers.js
+++ b/src/scripts/content/googledevelopers.js
@@ -1,0 +1,20 @@
+/*jslint indent: 2 */
+/*global $: false, document: false, togglbutton: false*/
+'use strict';
+
+togglbutton.render('.devsite-page-title:not(.toggl)', {}, function (elem) {
+  var link,
+    description = $('Description', elem),
+    project = $('Projects name', elem);
+
+
+  link = togglbutton.createTimerLink({
+    className: 'developers-google',
+    description: description,
+    projectName: project
+  });
+
+
+  $('.devsite-page-title').appendChild(link);
+
+});

--- a/src/scripts/content/goproforums.js
+++ b/src/scripts/content/goproforums.js
@@ -4,14 +4,12 @@
 
 togglbutton.render('.socialIcons:not(.toggl)', {}, function (elem) {
   var link,
-    description = $('Description', elem),
-    project = $('Projects name', elem);
+    description = $('strong').textContent;
 
 
   link = togglbutton.createTimerLink({
     className: 'goproforums',
-    description: description,
-    projectName: project
+    description: description
   });
 
 

--- a/src/scripts/content/goproforums.js
+++ b/src/scripts/content/goproforums.js
@@ -2,19 +2,19 @@
 /*global $: false, document: false, togglbutton: false*/
 'use strict';
 
-togglbutton.render('.collapse-wrapper:not(.toggl)', {}, function (elem) {
+togglbutton.render('.socialIcons:not(.toggl)', {}, function (elem) {
   var link,
     description = $('Description', elem),
     project = $('Projects name', elem);
 
 
   link = togglbutton.createTimerLink({
-    className: 'lego',
+    className: 'goproforums',
     description: description,
     projectName: project
   });
 
 
-  $('.collapse-wrapper').appendChild(link);
+  $('.socialIcons').appendChild(link);
 
 });

--- a/src/scripts/content/lego.js
+++ b/src/scripts/content/lego.js
@@ -1,0 +1,20 @@
+/*jslint indent: 2 */
+/*global $: false, document: false, togglbutton: false*/
+'use strict';
+
+togglbutton.render('.collapse-wrapper:not(.toggl)', {}, function (elem) {
+  var link,
+    description = $('Description', elem),
+    project = $('Projects name', elem);
+
+
+  link = togglbutton.createTimerLink({
+    className: 'udemy',
+    description: description,
+    projectName: project
+  });
+
+
+  $('.collapse-wrapper').appendChild(link);
+
+});

--- a/src/scripts/content/lego.js
+++ b/src/scripts/content/lego.js
@@ -4,8 +4,8 @@
 
 togglbutton.render('.collapse-wrapper:not(.toggl)', {}, function (elem) {
   var link,
-    description = $('Description', elem),
-    project = $('Projects name', elem);
+    description = 'Looking at Lego.com',
+    project = 'Lego.com';
 
 
   link = togglbutton.createTimerLink({

--- a/src/scripts/content/linustechtips.js
+++ b/src/scripts/content/linustechtips.js
@@ -1,0 +1,21 @@
+/*jslint indent: 2 */
+/*global $: false, document: false, togglbutton: false*/
+'use strict';
+
+togglbutton.render('.ipsType_pageTitle:not(.toggl)', {}, function (elem) {
+  var link,
+    description = $('Description', elem),
+    project = $('Projects name', elem);
+
+
+  link = togglbutton.createTimerLink({
+    className: 'linustechtips',
+    description: description,
+    projectName: project
+  });
+
+  $('.ipsType_pageTitle').appendChild(link);
+
+
+
+});

--- a/src/scripts/content/linustechtips.js
+++ b/src/scripts/content/linustechtips.js
@@ -4,14 +4,12 @@
 
 togglbutton.render('.ipsType_pageTitle:not(.toggl)', {}, function (elem) {
   var link,
-    description = $('Description', elem),
-    project = $('Projects name', elem);
+    description = $('h1').textContent;
 
 
   link = togglbutton.createTimerLink({
     className: 'linustechtips',
-    description: description,
-    projectName: project
+    description: description
   });
 
   $('.ipsType_pageTitle').appendChild(link);

--- a/src/scripts/content/nedatluj.js
+++ b/src/scripts/content/nedatluj.js
@@ -4,14 +4,13 @@
 
 togglbutton.render('.lesson-bread.center-block:not(.toggl)', {}, function (elem) {
   var link,
-    description = $('Description', elem),
+    description = $('.active').innerText,
     project = $('Projects name', elem);
 
 
   link = togglbutton.createTimerLink({
     className: 'nedatluj',
-    description: description,
-    projectName: project
+    description: description
   });
 
 

--- a/src/scripts/content/nedatluj.js
+++ b/src/scripts/content/nedatluj.js
@@ -1,0 +1,20 @@
+/*jslint indent: 2 */
+/*global $: false, document: false, togglbutton: false*/
+'use strict';
+
+togglbutton.render('.lesson-bread.center-block:not(.toggl)', {}, function (elem) {
+  var link,
+    description = $('Description', elem),
+    project = $('Projects name', elem);
+
+
+  link = togglbutton.createTimerLink({
+    className: 'nedatluj',
+    description: description,
+    projectName: project
+  });
+
+
+  $('.lesson-bread.center-block').appendChild(link);
+
+});

--- a/src/scripts/content/pc-help.js
+++ b/src/scripts/content/pc-help.js
@@ -1,0 +1,20 @@
+/*jslint indent: 2 */
+/*global $: false, document: false, togglbutton: false*/
+'use strict';
+
+togglbutton.render('.share-buttons:not(.toggl)', {}, function (elem) {
+  var link,
+    description = $('Description', elem),
+    project = $('Projects name', elem);
+
+
+  link = togglbutton.createTimerLink({
+    className: 'pc-help',
+    description: description,
+    projectName: project
+  });
+
+  $('.share-buttons').appendChild(link);
+
+
+});

--- a/src/scripts/content/pc-help.js
+++ b/src/scripts/content/pc-help.js
@@ -4,14 +4,13 @@
 
 togglbutton.render('.share-buttons:not(.toggl)', {}, function (elem) {
   var link,
-    description = $('Description', elem),
-    project = $('Projects name', elem);
+    description = $('.first').innerText;
 
 
   link = togglbutton.createTimerLink({
     className: 'pc-help',
     description: description,
-    projectName: project
+    projectName: 'PC-HELP.cz - České diskuzní fórum'
   });
 
   $('.share-buttons').appendChild(link);

--- a/src/scripts/content/pcpartpicker.js
+++ b/src/scripts/content/pcpartpicker.js
@@ -4,14 +4,12 @@
 
 togglbutton.render('.user-nav:not(.toggl)', {}, function (elem) {
   var link,
-    description = $('Description', elem),
-    project = $('Projects name', elem);
+    description = $('h1').textContent;
 
 
   link = togglbutton.createTimerLink({
     className: 'pcpartpicker',
-    description: description,
-    projectName: project
+    description: description
   });
 
 

--- a/src/scripts/content/pcpartpicker.js
+++ b/src/scripts/content/pcpartpicker.js
@@ -1,0 +1,20 @@
+/*jslint indent: 2 */
+/*global $: false, document: false, togglbutton: false*/
+'use strict';
+
+togglbutton.render('.user-nav:not(.toggl)', {}, function (elem) {
+  var link,
+    description = $('Description', elem),
+    project = $('Projects name', elem);
+
+
+  link = togglbutton.createTimerLink({
+    className: 'pcpartpicker',
+    description: description,
+    projectName: project
+  });
+
+
+  $('.user-nav').appendChild(link);
+
+});

--- a/src/scripts/content/slack.js
+++ b/src/scripts/content/slack.js
@@ -1,0 +1,21 @@
+/*jslint indent: 2 */
+/*global $: false, document: false, togglbutton: false*/
+'use strict';
+
+togglbutton.render('#channel_header_actions:not(.toggl)', {}, function (elem) {
+  var link,
+    description = $('Description', elem),
+    project = $('Projects name', elem);
+
+
+  link = togglbutton.createTimerLink({
+    className: 'slack',
+    description: description,
+    projectName: project
+  });
+
+
+
+  $('#channel_header_actions').appendChild(link);
+
+});

--- a/src/scripts/content/slack.js
+++ b/src/scripts/content/slack.js
@@ -4,8 +4,8 @@
 
 togglbutton.render('#channel_header_actions:not(.toggl)', {}, function (elem) {
   var link,
-    description = $('Description', elem),
-    project = $('Projects name', elem);
+    description = $('.name').textContent,
+    project = $('#team_name').textContent;
 
 
   link = togglbutton.createTimerLink({

--- a/src/scripts/content/udemy.js
+++ b/src/scripts/content/udemy.js
@@ -4,14 +4,12 @@
 
 togglbutton.render('.general-header-right:not(.toggl)', {}, function (elem) {
   var link,
-    description = $('Description', elem),
-    project = $('Projects name', elem);
+    description = 'Learning at Udemy.com';
 
 
   link = togglbutton.createTimerLink({
     className: 'udemy',
-    description: description,
-    projectName: project
+    description: description
   });
 
 

--- a/src/scripts/content/udemy.js
+++ b/src/scripts/content/udemy.js
@@ -1,0 +1,21 @@
+/*jslint indent: 2 */
+/*global $: false, document: false, togglbutton: false*/
+'use strict';
+
+togglbutton.render('.general-header-right:not(.toggl)', {}, function (elem) {
+  var link,
+    description = $('Description', elem),
+    project = $('Projects name', elem);
+
+
+  link = togglbutton.createTimerLink({
+    className: 'udemy',
+    description: description,
+    projectName: project
+  });
+
+  //skill-tree-header
+  //var htmlElement = document.querySelector("h1");
+  $('.general-header-right').appendChild(link);
+
+});

--- a/src/scripts/content/w3schools.js
+++ b/src/scripts/content/w3schools.js
@@ -4,14 +4,12 @@
 
 togglbutton.render('.color_h1:not(.toggl)', {}, function (elem) {
   var link,
-    description = $('Description', elem),
-    project = $('Projects name', elem);
+    description = $('h1').textContent;
 
 
   link = togglbutton.createTimerLink({
     className: 'w3schools',
-    description: description,
-    projectName: project
+    description: description
   });
 
 

--- a/src/scripts/content/w3schools.js
+++ b/src/scripts/content/w3schools.js
@@ -9,13 +9,12 @@ togglbutton.render('.color_h1:not(.toggl)', {}, function (elem) {
 
 
   link = togglbutton.createTimerLink({
-    className: 'duolingo',
+    className: 'w3schools',
     description: description,
     projectName: project
   });
 
-  //skill-tree-header
-  //var htmlElement = document.querySelector("h1");
+
   $('.color_h1').appendChild(link);
 
 });

--- a/src/scripts/content/w3schools.js
+++ b/src/scripts/content/w3schools.js
@@ -1,0 +1,21 @@
+/*jslint indent: 2 */
+/*global $: false, document: false, togglbutton: false*/
+'use strict';
+
+togglbutton.render('.color_h1:not(.toggl)', {}, function (elem) {
+  var link,
+    description = $('Description', elem),
+    project = $('Projects name', elem);
+
+
+  link = togglbutton.createTimerLink({
+    className: 'duolingo',
+    description: description,
+    projectName: project
+  });
+
+  //skill-tree-header
+  //var htmlElement = document.querySelector("h1");
+  $('.color_h1').appendChild(link);
+
+});


### PR DESCRIPTION
Added Toggl button support for these websites:

- Slack.com

- Dropbox.com

- Duolingo.com

- W3Schools.com

- Udemy.com

- GoProForums.com

- PCPartPicker.com

- Developers.google.com

- Lego.com

- Nedatluj.cz

- Alza.cz

- Inbox.google.com

- LinusTechTips.com

- PC-HELP.cz
