### PR TITLE
Add Title to Link for better Project identification

### DIFF
--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -441,6 +441,7 @@ var togglbutton = {
     var link = createLink('toggl-button');
     togglbutton.currentDescription = invokeIfFunction(params.description);
     togglbutton.currentProject = invokeIfFunction(params.projectName);
+    link.title = togglbutton.currentProject+": "+togglbutton.currentDescription;
     if (!!params.calculateTotal) {
       togglbutton.mainDescription = invokeIfFunction(params.description);
     }


### PR DESCRIPTION
This adds a title-tag to the link, which makes ist much easier to see, which project I have to create in order to make this timer directly be attached to the right project.