### PR TITLE
Gitlab: Include issue number in description, remove " · Issues" from …

### DIFF
--- a/src/scripts/content/gitlab.js
+++ b/src/scripts/content/gitlab.js
@@ -5,15 +5,19 @@
 
 togglbutton.render('.issue .detail-page-description .title:not(.toggl)', {observe: true}, function (elem) {
   var link, description,
+    numElem = $(".identifier"),
     titleElem = $(".issue .detail-page-description .title"),
     projectElem = $('.title').firstChild;
   description = titleElem.textContent;
   description = description.trim();
-
+  
+  if (numElem !== null) {
+    description = "#" + numElem.innerText.split("#").pop() + " " + description;
+  }
   link = togglbutton.createTimerLink({
     className: 'gitlab',
     description: description,
-    projectName: projectElem.textContent.split(' / ').pop()
+    projectName: projectElem.textContent.split(' / ').pop().split(' · ')[0]
   });
 
   $('.issue .detail-page-description h2.title').appendChild(link);


### PR DESCRIPTION
In order to make Gitlab's behavior equal to Github:
- Include Issue number in description
- Remove " · Issues" from projectName if present.