### PR TITLE
Add support for some Blackboard sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Add Toggl one-click time tracking to popular web tools.
   - [Salesforce][50]
   - [Draftin][51]
   - [FogBugz][52]
+  - [Blackboard Learn][53]
 
 ## Installing from the Web Store
 
@@ -83,7 +84,7 @@ List of all the changes and added features can be found at http://toggl.github.i
 2.  Go to your [TeamWeek][2], [Pivotal Tracker][3], [Github][4], [Asana][5], [Unfuddle][6], [Gitlab][7],
 [Trello][8], [Worksection][9], [Redbooth][10], [Podio][11], [Basecamp][12], [JIRA][13], [Producteev][14],
 [Bitbucket][15], [Stifer][16], [Google Docs][17], [Redmine][18], [YouTrack][19], [CapsuleCRM][20],
-[Xero][21], [Zendesk][22], [Any.do][23], [Todoist][24], [Trac][25], [Wunderlist][26], [Toodledo][27], [Teamwork.com][28], [Google Mail][29], [Taiga][30], [HabitRPG][31], [Axosoft][32], [Countersoft Gemini][33], [Drupal][34], [Esa][35], [Help Scout][36], [Flow][37], [Sprintly][38], [Google Calendar][39], [TestRail][40], [Bugzilla][41], [Breeze][42], [BamBam][43], [GQueue][44], [Wrike][45], [Assembla][46], [Waffle][47], [Codeable][48], [Eventum][49], [Salesforce][50], [Draftin][51], [FogBugz][52] account and start your Toggl timer there.
+[Xero][21], [Zendesk][22], [Any.do][23], [Todoist][24], [Trac][25], [Wunderlist][26], [Toodledo][27], [Teamwork.com][28], [Google Mail][29], [Taiga][30], [HabitRPG][31], [Axosoft][32], [Countersoft Gemini][33], [Drupal][34], [Esa][35], [Help Scout][36], [Flow][37], [Sprintly][38], [Google Calendar][39], [TestRail][40], [Bugzilla][41], [Breeze][42], [BamBam][43], [GQueue][44], [Wrike][45], [Assembla][46], [Waffle][47], [Codeable][48], [Eventum][49], [Salesforce][50], [Draftin][51], [FogBugz][52], [Blackboard Learn][53] account and start your Toggl timer there.
 
 Or start entry from the extension icon menu
 
@@ -159,6 +160,7 @@ Don't know how to start? Just check out the [user requested services][97] that h
 [50]: http://www.salesforce.com/
 [51]: https://draftin.com/
 [52]: http://www.fogcreek.com/fogbugz/
+[53]: https://en-us.help.blackboard.com/Learn/9.1_2014_04/Student/020_Get_Started/020_Login
 
 [97]: https://github.com/toggl/toggl-button/wiki/User-requested-buttons
 [98]: https://github.com/toggl/toggl-button/wiki/Adding-custom-domains

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -94,7 +94,9 @@
     "*://www.assembla.com/*",
     "*://*.salesforce.com/*",
     "*://*.draftin.com/*",
-    "*://*.fogbugz.com/*"
+    "*://*.fogbugz.com/*",
+    "*://blackboard.*.edu/*",
+    "*://*.blackboard.com/*"
   ],
   "content_scripts": [
     {
@@ -159,7 +161,9 @@
         "*://www.assembla.com/*",
         "*://*.salesforce.com/*",
         "*://*.draftin.com/*",
-        "*://*.fogbugz.com/*"
+        "*://*.fogbugz.com/*",
+        "*://blackboard.*.edu/*",
+        "*://*.blackboard.com/*"
       ],
       "css": ["styles/style.css"],
       "js": ["scripts/common.js"]
@@ -391,6 +395,13 @@
     {
       "matches": ["*://*.fogbugz.com/*"],
       "js": ["scripts/content/fogbugz.js"]
+    },
+    {
+      "matches": [
+        "*://blackboard.*.edu/*",
+        "*://*.blackboard.com/*",
+      ],
+      "js": ["scripts/content/blackboard.js"]
     }
   ]
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -95,8 +95,7 @@
     "*://*.salesforce.com/*",
     "*://*.draftin.com/*",
     "*://*.fogbugz.com/*",
-    "*://blackboard.*.edu/*",
-    "*://*.blackboard.com/*"
+    "*://*/webapps/blackboard/*"
   ],
   "content_scripts": [
     {
@@ -162,8 +161,7 @@
         "*://*.salesforce.com/*",
         "*://*.draftin.com/*",
         "*://*.fogbugz.com/*",
-        "*://blackboard.*.edu/*",
-        "*://*.blackboard.com/*"
+        "*://*/webapps/blackboard/*"
       ],
       "css": ["styles/style.css"],
       "js": ["scripts/common.js"]
@@ -397,10 +395,7 @@
       "js": ["scripts/content/fogbugz.js"]
     },
     {
-      "matches": [
-        "*://blackboard.*.edu/*",
-        "*://*.blackboard.com/*",
-      ],
+      "matches": ["*://*/webapps/blackboard/*"],
       "js": ["scripts/content/blackboard.js"]
     }
   ]

--- a/src/scripts/content/blackboard.js
+++ b/src/scripts/content/blackboard.js
@@ -1,0 +1,17 @@
+/*jslint indent: 2 */
+/*global $: false, document: false, togglbutton: false*/
+'use strict';
+
+togglbutton.render('[id^=contentListItem]:not(.toggl)', {observe: true}, function (elem) {
+  var link,
+    description = $("div", elem).textContent.trim(),
+    project = $("#pageTitleText").textContent;
+
+  link = togglbutton.createTimerLink({
+    className: 'blackboard',
+    description: description,
+    projectName: project
+  });
+
+  $('.alignPanel', elem).appendChild(link);
+});

--- a/src/scripts/content/blackboard.js
+++ b/src/scripts/content/blackboard.js
@@ -13,5 +13,5 @@ togglbutton.render('[id^=contentListItem]:not(.toggl)', {observe: true}, functio
     projectName: project
   });
 
-  $('.alignPanel', elem).appendChild(link);
+  $('.details', elem).appendChild(link);
 });


### PR DESCRIPTION
This adds a Toggl button to all items in lists, such as lists of assignments, for students.

Because Blackboard is hosted, not all Blackboard sites are included.  The link also does not go to a specific Blackboard site, but Blackboard's help page for logging in.  Only sites that follow this format are included in this specific integration.
- blackboard.*.edu
- *.blackboard.com
