### PR TITLE
Adding eProject.me to Toggl Button chrome extention

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Add Toggl one-click time tracking to popular web tools.
   - [Salesforce][50]
   - [Draftin][51]
   - [FogBugz][52]
+  - [eProject.me][53]
 
 ## Installing from the Web Store
 
@@ -159,6 +160,7 @@ Don't know how to start? Just check out the [user requested services][97] that h
 [50]: http://www.salesforce.com/
 [51]: https://draftin.com/
 [52]: http://www.fogcreek.com/fogbugz/
+[53]: https://eproject.me/
 
 [97]: https://github.com/toggl/toggl-button/wiki/User-requested-buttons
 [98]: https://github.com/toggl/toggl-button/wiki/Adding-custom-domains

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -94,7 +94,8 @@
     "*://www.assembla.com/*",
     "*://*.salesforce.com/*",
     "*://*.draftin.com/*",
-    "*://*.fogbugz.com/*"
+    "*://*.fogbugz.com/*",
+    "*://*.eproject.me/*"
   ],
   "content_scripts": [
     {
@@ -159,7 +160,8 @@
         "*://www.assembla.com/*",
         "*://*.salesforce.com/*",
         "*://*.draftin.com/*",
-        "*://*.fogbugz.com/*"
+        "*://*.fogbugz.com/*",
+        "*://*.eproject.me/*"
       ],
       "css": ["styles/style.css"],
       "js": ["scripts/common.js"]
@@ -391,6 +393,12 @@
     {
       "matches": ["*://*.fogbugz.com/*"],
       "js": ["scripts/content/fogbugz.js"]
+    },
+    {
+      "matches": [
+        "*://*.eproject.me/*"
+      ],
+      "js": ["scripts/content/eproject.js"]
     }
   ]
 }

--- a/src/scripts/content/eproject.js
+++ b/src/scripts/content/eproject.js
@@ -1,0 +1,25 @@
+/*jslint indent: 2 */
+/*global $: false, document: false, togglbutton: false*/
+'use strict';
+
+
+togglbutton.render('.single-tasks .right-side:not(.toggl)', {observe: true}, function (elem) {
+	var link, description,
+		numElem = $('.task-id', elem),
+		titleElem = $('.entry-title', elem),
+		projectElem = $('.project a span.label');
+
+	description = titleElem.innerText;
+	if (numElem !== null) {
+		description = numElem.innerText + " " + description;
+	}
+
+	link = togglbutton.createTimerLink({
+		className: 'eproject',
+		description: description,
+		projectName: projectElem.innerText
+	});
+
+	$('.toggl-timer').appendChild(link);
+
+});


### PR DESCRIPTION
Adding the Toggl Button in my startup Project Management system.
It adds the button next to the project name in the task view. See screenshot.

If devs want to test it here is a demo task link https://demo.eproject.me/tasks/example-task/?key=108936fb960532518ba7c40f25bc920e

![screen shot 2016-02-12 at 11 59 04 am](https://cloud.githubusercontent.com/assets/195144/13016131/a20723a2-d182-11e5-977c-69b030810d50.png)
