### PR TITLE
Let Toggl's WebApp know that Toggl Button is installed

### DIFF
--- a/src/scripts/content/toggl.js
+++ b/src/scripts/content/toggl.js
@@ -16,6 +16,15 @@ if (offlineUser) {
   }
 }
 
+(function () {
+  var version, source, s;
+  version = chrome.runtime.getManifest().version;
+  source = 'window.TogglButton = { version: "' + version + '" }';
+  s = document.createElement('script');
+  s.innerHTML = source;
+  document.body.appendChild(s);
+}());
+
 document.addEventListener('webkitvisibilitychange', function () {
   if (!document.webkitHidden) {
     chrome.extension.sendMessage({type: "sync"}, function () {return; });


### PR DESCRIPTION
Toggl's WebApp could offer a better user experience if it knew whether
the Toggl Button is installed or not. e.g., it could stop upselling /
advertising the existance of the Toggl Button to those users who are
already using it. It also provides additional information to draw a
better conclusion out of A/B experiments.

Toggl's WebApp and website can now tell whether the Toggl Button is
installed or not via checking the existence of `document.TogglButton`.