### PR TITLE
Fix Toggl content script matcher

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -166,10 +166,7 @@
     },
     {
       "matches": [
-        "*://www.toggl.com/app/timer",
-        "*://www.toggl.com/",
-        "*://toggl.com/app/timer",
-        "*://toggl.com/"
+        "*://*.toggl.com/*"
       ],
       "js": ["scripts/content/toggl.js"]
     },


### PR DESCRIPTION
Toggl's matcher was causing its content script not to run when
navigating/entering the WebApp or website by a url different than
`toggl.com` or `toggl.com/app/timer`.

e.g., if entering the WebApp via `toggl.com/app/profile`, Toggl's content
script would fail to execute since the matcher wouldn't report a match.

This change also allows executing the content script under
`fubar.toggl.com`, which was required for testing purposes.
`toggl.space` will wait for later.