### PR TITLE
Add LiquidPlanner support

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -95,6 +95,7 @@
     "*://*.salesforce.com/*",
     "*://*.draftin.com/*",
     "*://*.fogbugz.com/*"
+    "*://app.liquidplanner.com/*"
   ],
   "content_scripts": [
     {
@@ -160,6 +161,7 @@
         "*://*.salesforce.com/*",
         "*://*.draftin.com/*",
         "*://*.fogbugz.com/*"
+        "*://app.liquidplanner.com/*"
       ],
       "css": ["styles/style.css"],
       "js": ["scripts/common.js"]
@@ -391,6 +393,10 @@
     {
       "matches": ["*://*.fogbugz.com/*"],
       "js": ["scripts/content/fogbugz.js"]
+    },
+    {
+      "matches": ["*://app.liquidplanner.com/*"],
+      "js": ["scripts/content/liquidplanner.js"]
     }
   ]
 }

--- a/src/scripts/content/liquidplanner.js
+++ b/src/scripts/content/liquidplanner.js
@@ -1,0 +1,18 @@
+/*jslint indent: 2, unparam: true*/
+/*global $: false, document: false, togglbutton: false*/
+'use strict';
+
+document.getElementById('projects_split_view').addEventListener("DOMSubtreeModified", function() {
+  togglbutton.render('#section_title .panel_section_jump_links:not(.toggl)', {}, function (elem) {
+    console.log("render starts");
+    var link, description;
+    description = $('#treeitem_panel_name').innerText;
+
+    link = togglbutton.createTimerLink({
+      className: 'liquidplanner',
+      description: description
+    });
+
+    elem.insertBefore(link, elem.firstChild);
+  });
+});


### PR DESCRIPTION
Hello,

This PR adds some basic support for the LiquidPlanner project management tool. LiquidPlanner has its own timer, but I've found that lacking in flexibility compared to Toggl, that's why I've tried to integrate the Toggl button. I prefer logging my time in Toggl and then entering the data manually in the timesheet of LiquidPlanner.

This integration adds the Toggl button to the right pane, which shows the details of the selected package / project / task / milestone in LP. The task description is filled automatically.
![liquidplanner](https://cloud.githubusercontent.com/assets/236650/13379301/631c927e-de22-11e5-8ee8-1e1229d69f20.png)

I hope you'll find it useful - please let me know if there's any modification you would like to see.

Zoltán