### PR TITLE
Added a resume last entry button as requested in #411

### DIFF
--- a/src/html/popup.html
+++ b/src/html/popup.html
@@ -10,7 +10,7 @@
     <div class="error"></div>
     <ul class="menu view">
       <li class='resume-button-container'>
-        <button class="resume-button">Resume last entry</button>
+        <button class="resume-button">Start latest entry</button>
       </li>
       <li>
         <div class="project-bullet"></div>

--- a/src/html/popup.html
+++ b/src/html/popup.html
@@ -8,7 +8,10 @@
     <div class="header" title="Open Toggl.com"></div>
     <div class="user-email" title="Open profile at Toggl.com"></div>
     <div class="error"></div>
-    <ul class="menu view">   
+    <ul class="menu view">
+      <li class='resume-button-container'>
+        <button class="resume-button">Resume last entry</button>
+      </li>
       <li>
         <div class="project-bullet"></div>
         <div class="edit-button"></div>

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -1003,6 +1003,9 @@ TogglButton = {
       } else if (request.type === 'timeEntry') {
         TogglButton.createTimeEntry(request, sendResponse);
         TogglButton.hideNotification('remind-to-track-time');
+      } else if (request.type === 'resume') {
+        TogglButton.createTimeEntry(TogglButton.$latestStoppedEntry, sendResponse);
+        TogglButton.hideNotification('remind-to-track-time');
       } else if (request.type === 'update') {
         TogglButton.updateTimeEntry(request, sendResponse);
       } else if (request.type === 'stop') {

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -9,6 +9,8 @@ var PopUp = {
   $postStartText: " post-start popup",
   $popUpButton: null,
   $togglButton: document.querySelector(".stop-button"),
+  $resumeButtonContainer: document.querySelector(".resume-button-container"),
+  $resumeButton: document.querySelector(".resume-button"),
   $errorLabel: document.querySelector(".error"),
   $editButton: document.querySelector(".edit-button"),
   $projectBullet: document.querySelector(".project-bullet"),
@@ -36,11 +38,16 @@ var PopUp = {
         PopUp.editFormAdded = true;
       }
       document.querySelector(".user-email").textContent = TogglButton.$user.email;
+      PopUp.$resumeButtonContainer.style.display = "none";
       if (TogglButton.$curEntry === null) {
         PopUp.$togglButton.setAttribute('data-event', 'timeEntry');
         PopUp.$togglButton.textContent = 'Start timer';
         PopUp.$togglButton.parentNode.classList.remove('tracking');
         PopUp.$projectBullet.className = "project-bullet";
+        if(TogglButton.$latestStoppedEntry){
+          PopUp.$resumeButton.setAttribute('data-event', 'resume');
+          PopUp.$resumeButtonContainer.style.display = "block";
+        }
       } else {
         PopUp.$togglButton.setAttribute('data-event', 'stop');
         PopUp.$togglButton.textContent = 'Stop';
@@ -409,8 +416,7 @@ document.addEventListener('DOMContentLoaded', function () {
   PopUp.$editButton.addEventListener('click', function () {
     PopUp.updateEditForm(PopUp.$editView);
   });
-
-  PopUp.$togglButton.addEventListener('click', function () {
+  var onClickSendMessage = function () {
     var request = {
       type: this.getAttribute('data-event'),
       respond: true,
@@ -420,7 +426,9 @@ document.addEventListener('DOMContentLoaded', function () {
     PopUp.$timer = null;
 
     PopUp.sendMessage(request);
-  });
+  };
+  PopUp.$togglButton.addEventListener('click', onClickSendMessage);
+  PopUp.$resumeButton.addEventListener('click', onClickSendMessage);
 
   document.querySelector(".settings-button").addEventListener('click', function () {
     chrome.runtime.openOptionsPage();

--- a/src/styles/popup.css
+++ b/src/styles/popup.css
@@ -204,7 +204,9 @@ hr {
   text-align: left;
   font-size: 11px;
 }
-
+.resume-button-container{
+  display:none;
+}
 .tracking .stop-button:hover:after{
   content: 'Stop';
   position: absolute;


### PR DESCRIPTION
As requested in issue #411 
At first everything looks the same
![screen shot 2016-03-08 at 9 05 47 am](https://cloud.githubusercontent.com/assets/1693000/13602499/6281923c-e50d-11e5-831b-e5259993b02e.png)
Then we start doing something:
![screen shot 2016-03-08 at 9 06 17 am](https://cloud.githubusercontent.com/assets/1693000/13602518/795024d8-e50d-11e5-8f7d-e5e255c8ea33.png)
![screen shot 2016-03-08 at 9 06 27 am](https://cloud.githubusercontent.com/assets/1693000/13602526/84eb2e8c-e50d-11e5-9bb3-76ffb4a43d22.png)
After we stop, the "Resume last entry" button appears:
![screen shot 2016-03-08 at 9 06 37 am](https://cloud.githubusercontent.com/assets/1693000/13602550/9c75b6a8-e50d-11e5-8255-6658845bd8e2.png)
When clicked the timer starts counting again with the same description, project and tags.
![screen shot 2016-03-08 at 9 06 48 am](https://cloud.githubusercontent.com/assets/1693000/13602580/cce88770-e50d-11e5-8f56-f1361291855b.png)
![screen shot 2016-03-08 at 9 06 55 am](https://cloud.githubusercontent.com/assets/1693000/13602581/ccf313f2-e50d-11e5-8d01-b4061ad7eb3e.png)




