### PR TITLE
Update manifest.json

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -419,7 +419,7 @@
     },
     {
       "matches": ["*://*.visualstudio.com/*"],
-      "js": ["scripts/content/tfs.js"]
+      "js": ["scripts/content/TFS.js"]
     },
     {
       "matches": ["*://bugzilla.mozilla.org/*"],


### PR DESCRIPTION
fix broken manifest. #190

the file is uppercase TFS.js, but referenced as tfs.js in manifest. fix to match the case otherwise plugin does not load on linux