### PR TITLE
Timer can now be stopped at workday end, as requested in #245 

### DIFF
--- a/src/html/settings.html
+++ b/src/html/settings.html
@@ -65,6 +65,17 @@
             <label for="discard-notification">Idle detection</label>
             <div class="description">Shows notification when timer was tracking but user has been idle and allows to discard idle time</div>
           </li>
+          <li class="stop-at-day-end">
+            <input type="checkbox" id="stop-at-day-end">
+            <label for="stop-at-day-end">Stop automatically at the end of the day</label>
+            <p class="description">The timer will be stopped automatically at this time of day</p>
+            <div class="subsettings-details">
+              <p>
+                <label for="day-end-time">End of day time:</label>
+                <input type="time" id="day-end-time">
+              </p>
+            </div>
+          </li>
         </ul>
       </div>
       <div class="tab tab-2">

--- a/src/scripts/db.js
+++ b/src/scripts/db.js
@@ -16,7 +16,9 @@ var Db = {
     "idleDetectionEnabled": false,
     "pomodoroModeEnabled": false,
     "pomodoroSoundEnabled": true,
-    "pomodoroInterval": 25
+    "pomodoroInterval": 25,
+    "stopAtDayEnd":false,
+    "dayEndTime": "17:00",
   },
 
   get: function (setting) {
@@ -105,6 +107,10 @@ var Db = {
         Db.updateSetting("startAutomatically", request.state);
       } else if (request.type === 'toggle-stop-automatically') {
         Db.updateSetting("stopAutomatically", request.state);
+      } else if  (request.type === 'toggle-stop-at-day-end') {
+        Db.updateSetting("stopAtDayEnd", request.state);
+      } else if  (request.type === 'toggle-day-end-time') {
+        Db.updateSetting("dayEndTime", request.state);
       }
     } catch (e) {
       Bugsnag.notifyException(e);

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -14,6 +14,7 @@ var Settings = {
   $nanny: null,
   $pomodoroMode: null,
   $pomodoroSound: null,
+  $stopAtDayEnd: null,
   showPage: function () {
     document.querySelector("#version").innerHTML = "<a href='http://toggl.github.io/toggl-button' title='Change log'>(" + chrome.runtime.getManifest().version + ")</a>";
     Settings.setFromTo();
@@ -28,6 +29,9 @@ var Settings = {
     Settings.toggleState(Settings.$pomodoroMode, Db.get("pomodoroModeEnabled"));
     Settings.toggleState(Settings.$pomodoroSound, Db.get("pomodoroSoundEnabled"));
     document.querySelector("#pomodoro-interval").value = Db.get("pomodoroInterval");
+
+    Settings.toggleState(Settings.$stopAtDayEnd, Db.get("stopAtDayEnd"));
+    document.querySelector("#day-end-time").value = Db.get("dayEndTime");
 
     TogglButton.analytics("settings", null);
   },
@@ -63,6 +67,7 @@ document.addEventListener('DOMContentLoaded', function (e) {
   Settings.$idleDetection = document.querySelector("#idle-detection");
   Settings.$pomodoroMode = document.querySelector("#pomodoro-mode");
   Settings.$pomodoroSound = document.querySelector("#enable-sound-signal");
+  Settings.$stopAtDayEnd = document.querySelector("#stop-at-day-end");
   Settings.showPage();
   Settings.$showRightClickButton.addEventListener('click', function (e) {
     Settings.toggleSetting(e.target, (localStorage.getItem("showRightClickButton") !== "true"), "toggle-right-click-button");
@@ -92,7 +97,9 @@ document.addEventListener('DOMContentLoaded', function (e) {
   Settings.$pomodoroSound.addEventListener('click', function (e) {
     Settings.toggleSetting(e.target, (localStorage.getItem("pomodoroSoundEnabled") !== "true"), "toggle-pomodoro-sound");
   });
-
+  Settings.$stopAtDayEnd.addEventListener('click', function (e) {
+    Settings.toggleSetting(e.target, (localStorage.getItem("stopAtDayEnd") !== "true"), "toggle-stop-at-day-end");
+  });
   document.querySelector(".tab-links").addEventListener('click', function (e) {
     var tab = e.target.getAttribute("data-tab");
     if (!document.querySelector(".tab-" + tab).classList.contains("active")) {
@@ -135,5 +142,13 @@ document.addEventListener('DOMContentLoaded', function (e) {
     }
     Settings.saveSetting(+(document.querySelector('#pomodoro-interval').value), "toggle-pomodoro-interval");
 
+  });
+
+  document.querySelector("#day-end-time").addEventListener('blur', function (e) {
+    if (e.target.value < 1) {
+      e.target.value = 1;
+      return;
+    }
+    Settings.saveSetting((document.querySelector('#day-end-time').value), "toggle-day-end-time");
   });
 });

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -10,7 +10,7 @@ input[type="number"], input[type="time"]{
   vertical-align: middle;
   padding: 0 0 0 10px !important;
   margin-left: 10px !important;
-  max-width: 70px;
+  max-width: 90px;
   border: 1px solid rgb(191, 191, 191);
   border-radius: 2px;
 }
@@ -25,7 +25,9 @@ input[type="number"] {
   padding: 0;
   color: #505050!important;
   float: left;
-  height: 380px;
+  min-height: 380px;
+  max-height: 400px;
+  overflow-y: scroll;
 }
 
 .list {
@@ -48,6 +50,9 @@ input[type="number"] {
   height: 200px;
 }
 
+.list li #stop-at-day-end:checked ~ div{
+  height:70px;
+}
 .list li label {
   font-size: 14px;
   height: 22px;


### PR DESCRIPTION
- Added settings option for checkbox to turn on/off the feature
- Added settings option to set the time the workday ends
- Tried to fix issue with settings screen, it overflows when options are expanded
- Added notification when timer stops
- Added button in notification to continue the recently stopped entry

The notification
![screen shot 2016-04-04 at 2 34 45 am](https://cloud.githubusercontent.com/assets/1693000/14240001/26fd5ae0-fa0f-11e5-9fb2-021308bfb814.png)

Checkbox and input field
![screen shot 2016-04-04 at 2 33 04 am](https://cloud.githubusercontent.com/assets/1693000/14240004/3539687e-fa0f-11e5-968c-0754c7246ee9.png)
