### PR TITLE
Added pomodoro working when starting from elsewhere, as requested in #477

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -134,6 +134,9 @@ TogglButton = {
                   TogglButton.$curEntry = entry;
                   TogglButton.setBrowserAction(entry);
                   TogglButton.startCheckingUserState();
+                  if (Db.get("pomodoroModeEnabled")) {
+                    chrome.alarms.create('PomodoroTimer', {delayInMinutes: parseInt(Db.get("pomodoroInterval"), 10)});
+                  }
                   return true;
                 }
                 return false;


### PR DESCRIPTION
I literally just started the pomodoro timer when the fetchUser method is over if there is currently a time tracking entry. To test it I set the pomodoro time to a minute and used the android app to start the timer.