### PR TITLE
Avoid multiple start timer links in Redmine

### DIFF
--- a/src/scripts/content/redmine.js
+++ b/src/scripts/content/redmine.js
@@ -8,6 +8,10 @@ togglbutton.render('body.controller-issues.action-show h2:not(.toggl)', {}, func
     titleElem = $('.subject h3'),
     projectElem = $('h1');
 
+  if (!!$('.toggl-button')) {
+    return;
+  }
+
   description = titleElem.innerText;
   if (numElem !== null) {
     description = numElem.innerText + " " + description;


### PR DESCRIPTION
If an issue has h2 elements, toggl button appears multiple times.

For example:
http://demo.redmine.org/issues/130734

I referred to #501 and applied same solution.
The solution also worked.

Would you please check my pr?

Thank you.