### PR TITLE
Added keyboard command to stop/start timer

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -21,6 +21,14 @@
     "default_popup": "html/popup.html",
     "default_title": "Toggl Time Tracker"
   },
+  "commands": {
+    "quick-start-stop-entry": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+E"
+      },
+      "description": "Quick start/stop current entry"
+    }
+  },
   "icons": {
     "16": "images/icon-16.png",
     "48": "images/icon-48.png",

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -1640,3 +1640,15 @@ if (!FF) {
     }
   });
 }
+
+chrome.commands.onCommand.addListener(function (command) {
+  if (command === "quick-start-stop-entry") {
+    if (TogglButton.$curEntry !== null) {
+      TogglButton.stopTimeEntry(TogglButton.$curEntry);
+    } else {
+      if (TogglButton.$latestStoppedEntry !== null) {
+        TogglButton.createTimeEntry(TogglButton.$latestStoppedEntry, null);
+      }
+    }
+  }
+});


### PR DESCRIPTION
As discussed in #430

@IndrekV in the end `ctrl+shift+s` didn't work so I choose `ctrl+shift+e` (`cmd+shift+e` on mac) users can rebind the command by accessing chrome://extensions/configureCommands
