### PR TITLE
Default project setting added

### DIFF
--- a/src/html/settings.html
+++ b/src/html/settings.html
@@ -16,6 +16,12 @@
       <div class="tab tab-1 active">
         <ul class="list">
           <li>
+            <label for="default-project">Default Project</label>
+            <select id="default-project" name="default-project">
+            </select>
+            <div class="description">The selected project will be selected by default in when you start a new timer</div>
+          </li>
+          <li>
             <input type="checkbox" id="show_right_click_button">
             <label for="show_right_click_button">Show button in right click menu</label>
             <div class="description">Shows a "Start timer" button in the right click menu</div>

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -138,6 +138,8 @@ TogglButton = {
                 return false;
               });
             }
+            Db.set('projects', JSON.stringify(projectMap));
+            Db.set('clients', JSON.stringify(clientMap));
             TogglButton.$user = resp.data;
             TogglButton.$user.projectMap = projectMap;
             TogglButton.$user.clientMap = clientMap;
@@ -1228,7 +1230,7 @@ TogglButton = {
       if (request.type === 'activate') {
         TogglButton.checkDailyUpdate();
         TogglButton.setBrowserActionBadge();
-        sendResponse({success: TogglButton.$user !== null, user: TogglButton.$user, version: TogglButton.$fullVersion});
+        sendResponse({success: TogglButton.$user !== null, user: TogglButton.$user, version: TogglButton.$fullVersion, defaults: { project: parseInt(Db.get("defaultProject"), 10) }});
         TogglButton.triggerNotification();
       } else if (request.type === 'login') {
         TogglButton.loginUser(request, sendResponse);

--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -100,6 +100,7 @@ var togglbutton = {
   currentDescription: "",
   fullPageHeight: getFullPageHeight(),
   fullVersion: "TogglButton",
+  defaultProject: 0,
   render: function (selector, opts, renderer) {
     chrome.extension.sendMessage({type: 'activate'}, function (response) {
       if (response.success) {
@@ -108,6 +109,7 @@ var togglbutton = {
           togglbutton.projects = response.user.projectMap;
           togglbutton.fullVersion = response.version;
           togglbutton.duration_format = response.user.duration_format;
+          togglbutton.defaultProject = response.defaults.project;
           if (opts.observe) {
             var observer = new MutationObserver(function (mutations) {
               togglbutton.renderTo(selector, renderer);
@@ -215,7 +217,7 @@ var togglbutton = {
       return;
     }
 
-    var pid = (!!response.entry.pid) ? response.entry.pid : 0,
+    var pid = (!!response.entry.pid) ? response.entry.pid : togglbutton.defaultProject,
       projectSelect,
       placeholder,
       handler,

--- a/src/scripts/db.js
+++ b/src/scripts/db.js
@@ -20,6 +20,8 @@ var Db = {
     "pomodoroInterval": 25,
     "stopAtDayEnd": false,
     "dayEndTime": "17:00",
+    "defaultProject": "0",
+    "projects": "",
   },
 
   get: function (setting) {
@@ -115,6 +117,8 @@ var Db = {
         TogglButton.startCheckingDayEnd(request.state);
       } else if (request.type === 'toggle-day-end-time') {
         Db.updateSetting("dayEndTime", request.state);
+      } else if (request.type === 'change-default-project') {
+        Db.updateSetting("defaultProject", request.state);
       }
     } catch (e) {
       Bugsnag.notifyException(e);

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -167,7 +167,7 @@ var PopUp = {
 
   /* Edit form functions */
   updateEditForm: function (view) {
-    var pid = (!!TogglButton.$curEntry.pid) ? TogglButton.$curEntry.pid : 0,
+    var pid = (!!TogglButton.$curEntry.pid) ? TogglButton.$curEntry.pid : parseInt(Db.get('defaultProject'), 10),
       tid = (!!TogglButton.$curEntry.tid) ? TogglButton.$curEntry.tid : 0,
       togglButtonDescription = document.querySelector("#toggl-button-description"),
       projectSelect,


### PR DESCRIPTION
As requested in #480 
- Setting shows dropdown with caption in the same format as in desktop app, <project name> . <client name>
- Default project is selected in popup
- Default project is selected in popup for integrations
![screen shot 2016-04-22 at 12 54 17 am](https://cloud.githubusercontent.com/assets/1693000/14732062/e23535da-0824-11e6-9df1-3b7bccf99a10.png)
![screen shot 2016-04-22 at 12 54 30 am](https://cloud.githubusercontent.com/assets/1693000/14732063/e23f00ba-0824-11e6-83ec-026c1087e25b.png)
