### PR TITLE
Added support for Rindle (rindle.com)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -86,6 +86,7 @@ Tambet Masik <tambet.masik@gmail.com>
 Taylor J. Meek <taylor@cloudboltsoftware.com>
 Thomas Oster <thomas.oster@rwth-aachen.de>
 Tomek Marcinkowski <tomasz.marcinkowski@rst.com.pl>
+Tom Planer <tom@rindle.com>
 Victor Boctor <vboctor@boctor-retina.local>
 Victor Shih <victor.shih@gmail.com>
 Ville Lahdenvuo <ville.lahdenvuo@luotta.fi>

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Add Toggl one-click time tracking to popular web tools.
   - [Zube][79]
   - [miniCRM.pl][80]
   - [AgenoCRM][81]
+  - [Rindle][82]
 
 ## Installing from the Web Store
 
@@ -104,7 +105,7 @@ List of all the changes and added features can be found at http://toggl.github.i
 2.  Go to your [TeamWeek][2], [Pivotal Tracker][3], [Github][4], [Asana][5], [Unfuddle][6], [Gitlab][7],
 [Trello][8], [Worksection][9], [Redbooth][10], [Podio][11], [Basecamp][12], [JIRA][13], [Producteev][14],
 [Bitbucket][15], [Stifer][16], [Google Docs][17], [Redmine][18], [YouTrack][19], [CapsuleCRM][20],
-[Xero][21], [Zendesk][22], [Any.do][23], [Todoist][24], [Trac][25], [Wunderlist][26], [Toodledo][27], [Teamwork.com][28], [Google Mail][29], [Taiga][30], [HabitRPG][31], [Axosoft][32], [Countersoft Gemini][33], [Drupal][34], [Esa][35], [Help Scout][36], [Flow][37], [Sprintly][38], [Google Calendar][39], [TestRail][40], [Bugzilla][41], [Breeze][42], [BamBam][43], [GQueue][44], [Wrike][45], [Assembla][46], [Waffle][47], [Codeable][48], [Eventum][49], [Salesforce][50], [Draftin][51], [FogBugz][52], [Google Keep][53], [Gingko][54], [Google Inbox][55], [Wordpress][56], [Kanbanery][57], [Planbox][58], [Zoho Books][59], [Slack][60], [Doit.im][61], [Sunrise Calendar][62], [Cloudes.me][63], [eProject.me][64], [Freshdesk][65], [Newsletter2Go][66], [Gogs][67], [DevDocs][68], [LiquidPlanner][69], [SourceLair][70], [Remember The Milk][71], [Evernote][72], [MantisHub][73], [TargetProcess][74], [VisualStudioOnline (TFS)][75], [SmartBoard][76], [Phabricator][77], [OpenProject][78], [Zube][79], [miniCRM.pl][80], [AgenoCRM][81] account and start your Toggl timer there.
+[Xero][21], [Zendesk][22], [Any.do][23], [Todoist][24], [Trac][25], [Wunderlist][26], [Toodledo][27], [Teamwork.com][28], [Google Mail][29], [Taiga][30], [HabitRPG][31], [Axosoft][32], [Countersoft Gemini][33], [Drupal][34], [Esa][35], [Help Scout][36], [Flow][37], [Sprintly][38], [Google Calendar][39], [TestRail][40], [Bugzilla][41], [Breeze][42], [BamBam][43], [GQueue][44], [Wrike][45], [Assembla][46], [Waffle][47], [Codeable][48], [Eventum][49], [Salesforce][50], [Draftin][51], [FogBugz][52], [Google Keep][53], [Gingko][54], [Google Inbox][55], [Wordpress][56], [Kanbanery][57], [Planbox][58], [Zoho Books][59], [Slack][60], [Doit.im][61], [Sunrise Calendar][62], [Cloudes.me][63], [eProject.me][64], [Freshdesk][65], [Newsletter2Go][66], [Gogs][67], [DevDocs][68], [LiquidPlanner][69], [SourceLair][70], [Remember The Milk][71], [Evernote][72], [MantisHub][73], [TargetProcess][74], [VisualStudioOnline (TFS)][75], [SmartBoard][76], [Phabricator][77], [OpenProject][78], [Zube][79], [miniCRM.pl][80], [AgenoCRM][81], [Rindle][82] account and start your Toggl timer there.
 
 
 Or start entry from the extension icon menu
@@ -210,6 +211,7 @@ Don't know how to start? Just check out the [user requested services][97] that h
 [79]: https://zube.io/
 [80]: https://minicrm.pl/
 [81]: https://agenocrm.com/
+[82]: https://rindle.com/
 
 [97]: https://github.com/toggl/toggl-button/wiki/User-requested-buttons
 [98]: https://github.com/toggl/toggl-button/wiki/Adding-custom-domains

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -131,7 +131,8 @@
     "*://*.visualstudio.com/*",
     "*://*.smartboard.cl/*",
     "*://*.openproject.com/*",
-    "*://zube.io/*"
+    "*://zube.io/*",
+    "*://*.rindle.com/*"
   ],
   "content_scripts": [
     {
@@ -234,7 +235,8 @@
         "*://*.openproject.com/*",
         "*://zube.io/*",
         "*://*.minicrm.pl/*",
-        "*://*.agenocrm.com/*"
+        "*://*.agenocrm.com/*",
+        "*://*.rindle.com/*"
       ],
       "css": ["styles/style.css"],
       "js": ["scripts/common.js"]
@@ -605,6 +607,10 @@
         "*://*.minicrm.pl/*"
       ],
       "js": ["scripts/content/minicrm.js"]
+    },
+    {
+      "matches": ["*://*.rindle.com/*"],
+      "js": ["scripts/content/rindle.js"]
     }
   ]
 }

--- a/src/scripts/content/rindle.js
+++ b/src/scripts/content/rindle.js
@@ -1,0 +1,21 @@
+/*jslint indent: 2 */
+/*global $: false, document: false, togglbutton: false*/
+'use strict';
+
+togglbutton.render('.time__tracker:not(.toggl)', { observe: true }, function (elem) {
+  var delay = 1000;
+  setTimeout(function () {
+    var link, cardTitle = $('.toggl__card-title', elem);
+
+    if (cardTitle === null) {
+      return;
+    }
+
+    link = togglbutton.createTimerLink({
+      className: 'rindle',
+      description: cardTitle.innerText
+    });
+
+    $('.toggl__container', elem).appendChild(link);
+  }, delay);
+});


### PR DESCRIPTION
This pull request adds support for Rindle. 

Currently you can start a timer for toggl from within a card view, here is a screenshot of the location:
![rindle-toggl](https://cloud.githubusercontent.com/assets/50652/15125963/b0e88b94-15fd-11e6-8944-9964d4b63d64.png)