### PR TITLE
Add billable editing and billable/tags icons to timer

### DIFF
--- a/src/html/popup.html
+++ b/src/html/popup.html
@@ -17,6 +17,7 @@
 
       <ul id="menu" class="view">
         <li class="timer">
+          <div class="tag-icon"></div>
           <div class="project-bullet"></div>
           <div class="edit-button"></div>
           <div class="stop-button">Stop</div>

--- a/src/html/popup.html
+++ b/src/html/popup.html
@@ -17,9 +17,10 @@
 
       <ul id="menu" class="view">
         <li class="timer">
-          <div class="tag-icon"></div>
           <div class="project-bullet"></div>
           <div class="edit-button"></div>
+          <div class="tag-icon"></div>
+          <div class="billable-icon" title="billable"></div>
           <div class="stop-button">Stop</div>
           <div class="resume-button" data-event="resume">Continue latest</div>
         </li>

--- a/src/scripts/autocomplete.js
+++ b/src/scripts/autocomplete.js
@@ -182,7 +182,7 @@ ProjectAutoComplete.prototype.selectProject = function (elem, silent, removeTask
   return false;
 };
 
-AutoComplete.prototype.toggleTaskList = function (elem) {
+ProjectAutoComplete.prototype.toggleTaskList = function (elem) {
   var opened = this.el.querySelector(".tasklist-opened");
   if (!!opened) {
     opened.classList.remove("tasklist-opened");

--- a/src/scripts/autocomplete.js
+++ b/src/scripts/autocomplete.js
@@ -179,6 +179,8 @@ ProjectAutoComplete.prototype.selectProject = function (elem, silent, removeTask
     // Close dropdown
     this.closeDropdown();
   }
+
+  this.elem.updateBillable(parseInt(val, 10));
   return false;
 };
 

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -109,7 +109,7 @@ TogglButton = {
         '<div class="tag-clear">Clear selected tags</div>' +
         '{tags}</div>' +
       '</div>' +
-      '<div class="toggl-button-row tb-billable">' +
+      '<div class="toggl-button-row tb-billable {billable}">' +
         '<div class="toggl-button-billable-label">Billable</div>' +
         '<div class="toggl-button-billable-flag"><span></span></div>' +
       '</div>' +
@@ -770,10 +770,6 @@ TogglButton = {
       }
     };
 
-    if (timeEntry.pid !== null && timeEntry.projectName !== null) {
-      project = TogglButton.$user.projectMap[timeEntry.projectName + timeEntry.pid];
-    }
-
     TogglButton.ajax("/time_entries/" + TogglButton.$curEntry.id, {
       method: 'PUT',
       payload: entry,
@@ -909,7 +905,16 @@ TogglButton = {
     }
     return TogglButton.$editForm
         .replace("{projects}", TogglButton.fillProjects())
-        .replace("{tags}", TogglButton.fillTags());
+        .replace("{tags}", TogglButton.fillTags())
+        .replace("{billable}", TogglButton.setupBillable());
+  },
+
+  setupBillable: function () {
+    if (!!TogglButton.canSeeBillable) {
+      return "";
+    }
+
+    return "no-billable";
   },
 
   fillProjects: function () {

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -425,6 +425,8 @@ TogglButton = {
     // set Default project if needed
     if (!entry.time_entry.pid && !!defaultProject) {
       entry.time_entry.pid = parseInt(defaultProject, 10);
+      project = TogglButton.findProjectByPid(entry.time_entry.pid);
+      entry.time_entry.billable = project && project.billable;
     }
 
     TogglButton.ajax('/time_entries', {

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -758,7 +758,7 @@ TogglButton = {
   },
 
   updateTimeEntry: function (timeEntry, sendResponse) {
-    var entry, project, error = "";
+    var entry, error = "";
     if (!TogglButton.$curEntry) { return; }
     entry = {
       time_entry: {

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -109,6 +109,10 @@ TogglButton = {
         '<div class="tag-clear">Clear selected tags</div>' +
         '{tags}</div>' +
       '</div>' +
+      '<div class="toggl-button-row tb-billable">' +
+        '<div class="toggl-button-billable-label">Billable</div>' +
+        '<div class="toggl-button-billable-flag"><span></span></div>' +
+      '</div>' +
       '<div id="toggl-button-update" tabindex="103">DONE</div>' +
       '<input type="submit" class="hidden">' +
       '</from>' +
@@ -186,6 +190,7 @@ TogglButton = {
             TogglButton.setupSocket();
             TogglButton.updateBugsnag();
             TogglButton.handleQueue();
+            TogglButton.setCanSeeBillable();
           } else if (!token) {
             apiToken = localStorage.getItem('userToken');
             if (apiToken) {
@@ -225,6 +230,22 @@ TogglButton = {
     Bugsnag.user = {
       id: TogglButton.$user.id
     };
+  },
+
+  setCanSeeBillable: function () {
+    var canSeeBillable = false,
+      ws,
+      k;
+    for (k in TogglButton.$user.workspaces) {
+      if (TogglButton.$user.workspaces.hasOwnProperty(k)) {
+        ws = TogglButton.$user.workspaces[k];
+        if (ws.premium) {
+          canSeeBillable = true;
+          break;
+        }
+      }
+    }
+    TogglButton.canSeeBillable = canSeeBillable;
   },
 
   setupSocket: function () {
@@ -742,13 +763,13 @@ TogglButton = {
         description: timeEntry.description,
         pid: timeEntry.pid,
         tags: timeEntry.tags,
-        tid: timeEntry.tid
+        tid: timeEntry.tid,
+        billable: timeEntry.billable
       }
     };
 
     if (timeEntry.pid !== null && timeEntry.projectName !== null) {
       project = TogglButton.$user.projectMap[timeEntry.projectName + timeEntry.pid];
-      entry.time_entry.billable = project && project.billable;
     }
 
     TogglButton.ajax("/time_entries/" + TogglButton.$curEntry.id, {

--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -88,6 +88,7 @@ function secondsToTime(duration, format) {
 }
 
 var togglbutton = {
+  $billable: null,
   isStarted: false,
   element: null,
   links: [],
@@ -98,6 +99,7 @@ var togglbutton = {
   hasTasks: false,
   entries: {},
   projects: {},
+  user: {},
   duration_format: "",
   currentDescription: "",
   fullPageHeight: getFullPageHeight(),
@@ -106,6 +108,7 @@ var togglbutton = {
     chrome.runtime.sendMessage({type: 'activate'}, function (response) {
       if (response.success) {
         try {
+          togglbutton.user = response.user;
           togglbutton.entries = response.user.time_entries;
           togglbutton.projects = response.user.projectMap;
           togglbutton.fullVersion = response.version;
@@ -163,6 +166,58 @@ var togglbutton = {
     return secondsToTime(duration, togglbutton.duration_format);
   },
 
+  findProjectByPid: function (pid) {
+    var key;
+    for (key in togglbutton.user.projectMap) {
+      if (togglbutton.user.projectMap.hasOwnProperty(key) && togglbutton.user.projectMap[key].id === pid) {
+        return togglbutton.user.projectMap[key];
+      }
+    }
+    return undefined;
+  },
+
+  updateBillable: function (pid, no_overwrite) {
+    var project, i,
+      pwid = togglbutton.user.default_wid,
+      ws = togglbutton.user.workspaces,
+      premium;
+
+    if (pid === 0) {
+      pwid = togglbutton.user.default_wid;
+    } else {
+      project = togglbutton.findProjectByPid(pid);
+      if (!project) {
+        return;
+      }
+      pwid = project.wid;
+    }
+
+    for (i = 0; i < ws.length; i++) {
+      if (ws[i].id === pwid) {
+        premium = ws[i].premium;
+        break;
+      }
+    }
+
+    togglbutton.toggleBillable(premium);
+
+    if (!no_overwrite && project.billable) {
+      togglbutton.$billable.classList.toggle("tb-checked", true);
+    }
+  },
+
+  toggleBillable: function (visible) {
+    togglbutton.$billable.classList.toggle("no-billable", !visible);
+    if (!visible) {
+      togglbutton.$billable.classList.toggle("tb-checked", visible);
+    }
+  },
+
+  setupBillable: function (billable, pid) {
+    togglbutton.updateBillable(pid, true);
+    togglbutton.$billable.classList.toggle("tb-checked", billable);
+  },
+
   addEditForm: function (response) {
     togglbutton.hasTasks = response.hasTasks;
     if (response === null || !response.showPostPopup) {
@@ -205,6 +260,7 @@ var togglbutton = {
     editForm.style.top = position.top + "px";
     editForm.classList.add("toggl-integration");
     document.body.appendChild(editForm);
+    togglbutton.$billable = $(".tb-billable", editForm);
 
     projectAutocomplete = new ProjectAutoComplete("project", "li", togglbutton);
     tagAutocomplete = new TagAutoComplete("tag", "li", togglbutton);
@@ -218,6 +274,7 @@ var togglbutton = {
 
     submitForm = function (that) {
       var selected = projectAutocomplete.getSelected(),
+        billable = !!document.querySelector(".tb-billable.tb-checked:not(.no-billable)"),
         request = {
           type: "update",
           description: $("#toggl-button-description").value,
@@ -225,6 +282,7 @@ var togglbutton = {
           projectName: selected.name,
           tags: tagAutocomplete.getSelected(),
           tid: selected.tid,
+          billable: billable,
           service: togglbutton.serviceName
         };
       chrome.runtime.sendMessage(request);
@@ -239,6 +297,8 @@ var togglbutton = {
     setCursorAtBeginning(togglButtonDescription);
     projectAutocomplete.setup(pid, tid);
     tagAutocomplete.setSelected(response.entry.tags);
+
+    togglbutton.setupBillable(!!response.entry.billable, pid);
 
     // Data fill end
     $("#toggl-button-hide", editForm).addEventListener('click', function (e) {
@@ -270,6 +330,10 @@ var togglbutton = {
       tagAutocomplete.closeDropdown();
       editForm.style.display = "none";
       return false;
+    });
+
+    togglbutton.$billable.addEventListener('click', function () {
+      this.classList.toggle("tb-checked");
     });
 
     document.addEventListener("click", handler);

--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -92,7 +92,6 @@ var togglbutton = {
   element: null,
   links: [],
   serviceName: '',
-  mousedownTrigger: null,
   projectBlurTrigger: null,
   taskBlurTrigger: null,
   tagsVisible: false,
@@ -271,12 +270,6 @@ var togglbutton = {
       tagAutocomplete.closeDropdown();
       editForm.style.display = "none";
       return false;
-    });
-    document.addEventListener('mousedown', function (e) {
-      togglbutton.mousedownTrigger = e.target;
-    });
-    document.addEventListener('mouseup', function (e) {
-      togglbutton.mousedownTrigger = null;
     });
 
     document.addEventListener("click", handler);

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -17,6 +17,7 @@ var PopUp = {
   $resumeButton: document.querySelector(".resume-button"),
   $errorLabel: document.querySelector(".error"),
   $editButton: document.querySelector(".edit-button"),
+  $tagIcon: document.querySelector(".tag-icon"),
   $projectBullet: document.querySelector(".timer .project-bullet"),
   $projectAutocomplete: null,
   $tagAutocomplete: null,
@@ -121,15 +122,23 @@ var PopUp = {
       description += PopUp.$projectAutocomplete.setProjectBullet(TogglButton.$curEntry.pid, TogglButton.$curEntry.tid, PopUp.$projectBullet);
       PopUp.$editButton.textContent = description;
       PopUp.$editButton.setAttribute('title', 'Click to edit "' + description + '"');
+      PopUp.setTagIcon(TogglButton.$curEntry.tags);
     }
   },
 
-  updateMenuTimer: function (desc, pid, tid) {
-    var description = desc || "(no description)";
+  updateMenuTimer: function (data) {
+    var description = data.description || "(no description)";
 
-    description += PopUp.$projectAutocomplete.setProjectBullet(pid, tid, PopUp.$projectBullet);
+    description += PopUp.$projectAutocomplete.setProjectBullet(data.pid, data.tid, PopUp.$projectBullet);
     PopUp.$editButton.textContent = description;
     PopUp.$editButton.setAttribute('title', 'Click to edit "' + description + '"');
+
+    PopUp.setTagIcon(data.tags);
+  },
+
+  setTagIcon: function (tags) {
+    PopUp.$tagIcon.classList.toggle("visible", !!tags.length);
+    PopUp.$tagIcon.setAttribute("title", tags.join(", "));
   },
 
   switchView: function (view) {
@@ -183,7 +192,7 @@ var PopUp = {
         service: "dropdown"
       };
     PopUp.sendMessage(request);
-    PopUp.updateMenuTimer(request.description, request.pid, request.tid);
+    PopUp.updateMenuTimer(request);
     PopUp.switchView(PopUp.$menuView);
   },
 

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -171,6 +171,8 @@ var PopUp = {
 
     PopUp.$projectAutocomplete.setup(pid, tid);
     PopUp.$tagAutocomplete.setup(TogglButton.$curEntry.tags);
+
+    PopUp.setupBillable(TogglButton.$curEntry.billable);
     PopUp.switchView(view);
 
     // Put focus to the beginning of desctiption field
@@ -179,8 +181,14 @@ var PopUp = {
     togglButtonDescription.scrollLeft = 0;
   },
 
+  setupBillable: function (billable) {
+    document.querySelector(".tb-billable").classList.toggle("no-billable", !TogglButton.canSeeBillable);
+    document.querySelector(".tb-billable").classList.toggle("tb-checked", billable);
+  },
+
   submitForm: function (that) {
     var selected = PopUp.$projectAutocomplete.getSelected(),
+      billable = !!document.querySelector(".tb-billable.tb-checked:not(.no-billable)"),
       request = {
         type: "update",
         description: document.querySelector("#toggl-button-description").value,
@@ -189,8 +197,10 @@ var PopUp = {
         tags: PopUp.$tagAutocomplete.getSelected(),
         tid: selected.tid,
         respond: true,
+        billable: billable,
         service: "dropdown"
       };
+
     PopUp.sendMessage(request);
     PopUp.updateMenuTimer(request);
     PopUp.switchView(PopUp.$menuView);
@@ -208,6 +218,10 @@ var PopUp = {
     document.querySelector("#entry-form form").addEventListener('submit', function (e) {
       PopUp.submitForm(this);
       e.preventDefault();
+    });
+
+    document.querySelector(".tb-billable").addEventListener('click', function () {
+      this.classList.toggle("tb-checked");
     });
   }
 };

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -137,8 +137,11 @@ var PopUp = {
   },
 
   setTagIcon: function (tags) {
-    PopUp.$tagIcon.classList.toggle("visible", !!tags.length);
-    PopUp.$tagIcon.setAttribute("title", tags.join(", "));
+    var t = !!tags && !!tags.length,
+      joinedTags = t ? tags.join(", ") : "";
+
+    PopUp.$tagIcon.classList.toggle("visible", t);
+    PopUp.$tagIcon.setAttribute("title", joinedTags);
   },
 
   switchView: function (view) {

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -123,7 +123,8 @@ var PopUp = {
       description += PopUp.$projectAutocomplete.setProjectBullet(TogglButton.$curEntry.pid, TogglButton.$curEntry.tid, PopUp.$projectBullet);
       PopUp.$editButton.textContent = description;
       PopUp.$editButton.setAttribute('title', 'Click to edit "' + description + '"');
-      PopUp.setTagIcon(TogglButton.$curEntry.tags);
+
+      PopUp.setupIcons(TogglButton.$curEntry);
     }
   },
 
@@ -137,12 +138,21 @@ var PopUp = {
     PopUp.setTagIcon(data.tags);
   },
 
+  setupIcons: function (data) {
+    PopUp.setTagIcon(data.tags);
+    PopUp.setBillableIcon(!!data.billable);
+  },
+
   setTagIcon: function (tags) {
     var t = !!tags && !!tags.length,
       joinedTags = t ? tags.join(", ") : "";
 
-    PopUp.$tagIcon.classList.toggle("visible", t);
+    PopUp.$timerRow.classList.toggle("tag-icon-visible", t);
     PopUp.$tagIcon.setAttribute("title", joinedTags);
+  },
+
+  setBillableIcon: function (billable) {
+    PopUp.$timerRow.classList.toggle("billable-icon-visible", billable);
   },
 
   switchView: function (view) {

--- a/src/styles/popup.css
+++ b/src/styles/popup.css
@@ -314,6 +314,27 @@ hr {
   font-size: 12px;
 }
 
+.tag-icon {
+  background-position: center;
+  background-repeat: no-repeat;
+  background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABEAAAARBAMAAADJQ1rJAAAAAXNSR0IArs4c6QAAACpQTFRFAAAA19fX0dHR0NDQz8/Pzs7Oz8/Pz8/Pzs7Oz8/Pz8/Pzs7Oz8/Pzs7Og6ZZ9AAAAA10Uk5TABMcPEp4e4CotuP8/rXdOgkAAABdSURBVAjXY/C6e3eFAQMIrL179+4xMOvuJM27dwvALAWmu3evw1lgQbAsWBCkAyLYC2FdZWCwgbBuCzCwwVkMtTBZBnaYDogg2GiwIFgIJAgRYmBg3R0AZTEIgggAaI1FSkguN/cAAAAASUVORK5CYII=');
+  width: 23px;
+  height: 29px;
+  position: absolute;
+  right: 65px;
+  bottom: 6px;
+  display: none;
+}
+
+.tag-icon.visible {
+  display: block;
+}
+
+.tag-icon.visible ~ .edit-button {
+  width: 124px;
+  padding-right: 20px;
+}
+
 .stop-button {
   width: 170px;
   padding-left: 30px;
@@ -361,9 +382,10 @@ hr {
 }
 
 .tracking .edit-button{
-  width: 144px;
+  width: 140px;
   padding-left: 30px;
   display: block;
+  padding-right: 4px;
 }
 
 .tracking .edit-button:hover {

--- a/src/styles/popup.css
+++ b/src/styles/popup.css
@@ -314,25 +314,51 @@ hr {
   font-size: 12px;
 }
 
-.tag-icon {
+.tag-icon,
+.billable-icon {
   background-position: center;
   background-repeat: no-repeat;
-  background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABEAAAARBAMAAADJQ1rJAAAAAXNSR0IArs4c6QAAACpQTFRFAAAA19fX0dHR0NDQz8/Pzs7Oz8/Pz8/Pzs7Oz8/Pz8/Pzs7Oz8/Pzs7Og6ZZ9AAAAA10Uk5TABMcPEp4e4CotuP8/rXdOgkAAABdSURBVAjXY/C6e3eFAQMIrL179+4xMOvuJM27dwvALAWmu3evw1lgQbAsWBCkAyLYC2FdZWCwgbBuCzCwwVkMtTBZBnaYDogg2GiwIFgIJAgRYmBg3R0AZTEIgggAaI1FSkguN/cAAAAASUVORK5CYII=');
-  width: 23px;
-  height: 29px;
-  position: absolute;
-  right: 65px;
-  bottom: 6px;
+  width: 20px;
+  height: 30px;
   display: none;
+  float: left;
 }
 
-.tag-icon.visible {
-  display: block;
+.tag-icon {
+  background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABEAAAARBAMAAADJQ1rJAAAAAXNSR0IArs4c6QAAACpQTFRFAAAArq6upKSkpqampaWlpKSkpKSko6OjpKSkpKSkpKSkpKSkpKSko6Ojxtw9PQAAAA10Uk5TABMcPEp4e4CotuP8/rXdOgkAAABdSURBVAjXY/C6e3eFAQMIrL179+4xMOvuJM27dwvALAWmu3evw1lgQbAsWBCkAyLYC2FdZWCwgbBuCzCwwVkMtTBZBnaYDogg2GiwIFgIJAgRYmBg3R0AZTEIgggAaI1FSkguN/cAAAAASUVORK5CYII=');
 }
 
 .tag-icon.visible ~ .edit-button {
   width: 124px;
   padding-right: 20px;
+}
+
+.billable-icon {
+  background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAUCAMAAACDMFxkAAAAAXNSR0IArs4c6QAAAFpQTFRFAAAA////qqqqp6enqqqqp6enqKioo6OjpqampaWlpKSkpaWlo6OjpKSkpKSko6OjpKSko6OjpKSkpKSkpKSkpKSko6OjpKSkpKSkpKSkpKSkpKSko6Ojo6OjwiB/AwAAAB10Uk5TAAEPGhsgJicrR3t/gJ+osrPDxMrS1Nzd5ebo8fVWC5UqAAAAaElEQVQI13VPRw7AMAyiTle6R9LN/7/ZdCpSVU5Y2IABh67FA/JDpTCkyQVQI08MChWtFtGWFVZGx1rEFRtj3IYNlyy9DMLe3UylDhwPdDm7qVeXlGYL6yc/4eabeRFe8F2nkN++70M7wSMIvPS86/IAAAAASUVORK5CYII=');
+}
+
+.timer.tag-icon-visible .tag-icon,
+.timer.billable-icon-visible .billable-icon {
+  display: block;
+}
+
+/* Only billable icon visible */
+.timer.billable-icon-visible:not(.tag-icon-visible) .edit-button {
+  width: 120px;
+}
+
+/* Only tag icon visible */
+.timer.tag-icon-visible:not(.billable-icon-visible) .edit-button {
+  width: 117px;
+}
+
+.timer.tag-icon-visible:not(.billable-icon-visible) .tag-icon {
+  width: 23px;
+}
+
+/* Both icons visible */
+.timer.tag-icon-visible.billable-icon-visible .edit-button {
+  width: 100px;
 }
 
 .stop-button {

--- a/src/styles/popup.css
+++ b/src/styles/popup.css
@@ -632,6 +632,59 @@ hr {
   font-size: 12px;
 }
 
+/** FIREFOX END **/
+
 .hidden {
   display: none;
+}
+
+/** Billable flag **/
+
+#toggl-button-edit-form .tb-billable {
+  outline: none;
+  height: 40px;
+  line-height: 40px;
+  vertical-align: middle;
+  padding-left: 10px;
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  color: #8a8989;
+  transition:height 200ms ease-in-out;
+  overflow: hidden;
+}
+
+#toggl-button-edit-form .tb-billable.no-billable {
+  height: 0;
+}
+
+#toggl-button-edit-form .toggl-button-billable-label {
+  float: left;
+}
+
+#toggl-button-edit-form .toggl-button-billable-flag {
+  width: 42px;
+  height: 24px;
+  border-radius: 100px;
+  background-color: #cecece;
+  float: right;
+  margin-top: 6px;
+  position: relative;
+}
+
+#toggl-button-edit-form .toggl-button-billable-flag span {
+  width: 18px;
+  height: 18px;
+  background-color: #ffffff;
+  border-radius: 100px;
+  position: absolute;
+  left: 4px;
+  top: 3px;
+  transition:left 200ms ease-in-out;
+}
+
+#toggl-button-edit-form .tb-billable.tb-checked .toggl-button-billable-flag {
+  background-color: #4bc800;
+}
+
+#toggl-button-edit-form .tb-billable.tb-checked .toggl-button-billable-flag span {
+  left: 20px;
 }

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -253,6 +253,57 @@ only screen and (min-resolution: 192dpi) {
   margin-top: 0px;
 }
 
+/** Billable flag **/
+
+#toggl-button-edit-form .tb-billable {
+  outline: none;
+  height: 40px;
+  line-height: 40px;
+  vertical-align: middle;
+  padding-left: 10px;
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  color: #8a8989;
+  transition:height 200ms ease-in-out;
+  overflow: hidden;
+}
+
+#toggl-button-edit-form .tb-billable.no-billable {
+  height: 0;
+}
+
+#toggl-button-edit-form .toggl-button-billable-label {
+  float: left;
+}
+
+#toggl-button-edit-form .toggl-button-billable-flag {
+  width: 42px;
+  height: 24px;
+  border-radius: 100px;
+  background-color: #cecece;
+  float: right;
+  margin-top: 6px;
+  position: relative;
+}
+
+#toggl-button-edit-form .toggl-button-billable-flag span {
+  width: 18px;
+  height: 18px;
+  background-color: #ffffff;
+  border-radius: 100px;
+  position: absolute;
+  left: 4px;
+  top: 3px;
+  transition:left 200ms ease-in-out;
+}
+
+#toggl-button-edit-form .tb-billable.tb-checked .toggl-button-billable-flag {
+  background-color: #4bc800;
+}
+
+#toggl-button-edit-form .tb-billable.tb-checked .toggl-button-billable-flag span {
+  left: 20px;
+}
+
 /********* PIVOTAL *********/
 .toggl-button.pivotal {
   margin-top: 10px;


### PR DESCRIPTION
This PR adds Billable and tags icon to popup running timer. Hovering tag icons shows tags in tooltip.

__popup timer with icons__

![screen shot 2016-07-22 at 12 17 29](https://cloud.githubusercontent.com/assets/842229/17052568/c1fd92e2-5006-11e6-8eec-5e678ca6fd52.png)

#### Editing billable
Billable editing is shown if:
- selected project is in pro workspace
- No project is selected and default project is from pro workspace

Actions:
- Selecting project should set billable enabled if project has billable enabled.
- If billable is enabled and selected project is not billable the billable flag should not be updated.
- If project is in free workspace set billable false and hide billable row.

__Integration page__

![screen shot 2016-07-22 at 12 17 55](https://cloud.githubusercontent.com/assets/842229/17052566/c1f3ef1c-5006-11e6-9c73-f737eac4c246.png)

__Popup__

![screen shot 2016-07-22 at 12 17 21](https://cloud.githubusercontent.com/assets/842229/17052567/c1fcbc64-5006-11e6-9ef3-1c230be32db5.png)
