### PR TITLE
[YouTrack] Fix project name fetch regression

### DIFF
--- a/src/scripts/content/youtrack.js
+++ b/src/scripts/content/youtrack.js
@@ -9,7 +9,7 @@ togglbutton.render('.fsi-toolbar-content:not(.toggl), .toolbar_fsi:not(.toggl)',
   var link, description,
     numElem = $('a.issueId'),
     titleElem = $(".issue-summary"),
-    projectElem = $('.fsi-properties .disabled.bold');
+    projectElem = $('.fsi-properties a[title^="Project"], .fsi-properties .disabled.bold');
 
   description = titleElem.textContent;
   description = numElem.firstChild.textContent.trim() + " " + description.trim();


### PR DESCRIPTION
Users can have permission to change the project field and in this case the project name is in an a tag. 
This PR fixes that case and it was working before 6c6b3fa3f857fecadac2f2e4e02dba90d1bdd9ab.