### PR TITLE
Adding toggl button to gitlab merge request page

### DIFF
--- a/src/scripts/content/gitlab.js
+++ b/src/scripts/content/gitlab.js
@@ -23,3 +23,24 @@ togglbutton.render('.issue-details .detail-page-description:not(.toggl)', {obser
 
   $(".detail-page-header").appendChild(link);
 });
+
+togglbutton.render('.merge-request-details .detail-page-description:not(.toggl)', {observe: true}, function (elem) {
+  var link, description,
+    numElem = $(".identifier"),
+    titleElem = $(".title", elem),
+    projectElem = $("h1 .project-item-select-holder");
+
+  description = titleElem.textContent.trim();
+  if (numElem !== null) {
+    description = "MR" + numElem.innerText.split(" ").pop().trim().replace("!", "") + "::"+ description;
+  }
+
+  link = togglbutton.createTimerLink({
+    className: 'gitlab',
+    description: description,
+    projectName: projectElem.textContent
+  });
+
+  $(".detail-page-header").appendChild(link);
+});
+


### PR DESCRIPTION
Hi there,

I've added the toggl button to the gitlab merge request page. When spending time on a merge request (e.g. reviewing it) I find it useful to have the toggl button available.