### PR TITLE
Detect name for private Github projects

### DIFF
--- a/src/scripts/content/github.js
+++ b/src/scripts/content/github.js
@@ -6,7 +6,7 @@ togglbutton.render('#partial-discussion-header:not(.toggl)', {observe: true}, fu
   var link, description,
     numElem = $('.gh-header-number', elem),
     titleElem = $('.js-issue-title', elem),
-    projectElem = $('h1.public strong a');
+    projectElem = $('h1.public strong a, h1.private strong a');
 
   description = titleElem.innerText;
   if (numElem !== null) {


### PR DESCRIPTION
Project name detection is working only for public Github projects, and not for private ones.