### PR TITLE
Add Feedly support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Add Toggl one-click time tracking to popular web tools.
   - [Overv][90]
   - [Clubhouse][91]
   - [Desk.com][92]
+  - [Feedly][93]
 
 ## Installing from the Web Store/Addons page
 
@@ -119,7 +120,7 @@ List of all the changes and added features can be found at http://toggl.github.i
 2.  Go to your [TeamWeek][2], [Pivotal Tracker][3], [Github][4], [Asana][5], [Unfuddle][6], [Gitlab][7],
 [Trello][8], [Worksection][9], [Redbooth][10], [Podio][11], [Basecamp][12], [JIRA][13], [Producteev][14],
 [Bitbucket][15], [Stifer][16], [Google Docs][17], [Redmine][18], [YouTrack][19], [CapsuleCRM][20],
-[Xero][21], [Zendesk][22], [Any.do][23], [Todoist][24], [Trac][25], [Wunderlist][26], [Toodledo][27], [Teamwork.com][28], [Google Mail][29], [Taiga][30], [HabitRPG][31], [Axosoft][32], [Countersoft Gemini][33], [Drupal][34], [Esa][35], [Help Scout][36], [Flow][37], [Sprintly][38], [Google Calendar][39], [TestRail][40], [Bugzilla][41], [Breeze][42], [BamBam][43], [GQueue][44], [Wrike][45], [Assembla][46], [Waffle][47], [Codeable][48], [Eventum][49], [Salesforce][50], [Draftin][51], [FogBugz][52], [Google Keep][53], [Gingko][54], [Google Inbox][55], [Wordpress][56], [Kanbanery][57], [Planbox][58], [Zoho Books][59], [Slack][60], [Doit.im][61], [Cloudes.me][63], [eProject.me][64], [Freshdesk][65], [Newsletter2Go][66], [Gogs][67], [DevDocs][68], [LiquidPlanner][69], [SourceLair][70], [Remember The Milk][71], [Evernote][72], [MantisHub][73], [TargetProcess][74], [VisualStudioOnline (TFS)][75], [SmartBoard][76], [Phabricator][77], [OpenProject][78], [Zube][79], [miniCRM.pl][80], [AgenoCRM][81], [Bitrix24][82], [Rindle][83], [TickTick][84], [Exana][85], [SherpaDesk][86], [Workfront][87], [OnlyOffice][88], [MeisterTask][89], [Overv][90], [Clubhouse][91], [Desk.com][92] account and start your Toggl timer there.
+[Xero][21], [Zendesk][22], [Any.do][23], [Todoist][24], [Trac][25], [Wunderlist][26], [Toodledo][27], [Teamwork.com][28], [Google Mail][29], [Taiga][30], [HabitRPG][31], [Axosoft][32], [Countersoft Gemini][33], [Drupal][34], [Esa][35], [Help Scout][36], [Flow][37], [Sprintly][38], [Google Calendar][39], [TestRail][40], [Bugzilla][41], [Breeze][42], [BamBam][43], [GQueue][44], [Wrike][45], [Assembla][46], [Waffle][47], [Codeable][48], [Eventum][49], [Salesforce][50], [Draftin][51], [FogBugz][52], [Google Keep][53], [Gingko][54], [Google Inbox][55], [Wordpress][56], [Kanbanery][57], [Planbox][58], [Zoho Books][59], [Slack][60], [Doit.im][61], [Cloudes.me][63], [eProject.me][64], [Freshdesk][65], [Newsletter2Go][66], [Gogs][67], [DevDocs][68], [LiquidPlanner][69], [SourceLair][70], [Remember The Milk][71], [Evernote][72], [MantisHub][73], [TargetProcess][74], [VisualStudioOnline (TFS)][75], [SmartBoard][76], [Phabricator][77], [OpenProject][78], [Zube][79], [miniCRM.pl][80], [AgenoCRM][81], [Bitrix24][82], [Rindle][83], [TickTick][84], [Exana][85], [SherpaDesk][86], [Workfront][87], [OnlyOffice][88], [MeisterTask][89], [Overv][90], [Clubhouse][91], [Desk.com][92], [Feedly][93] account and start your Toggl timer there.
 
 _See this article for reference where the start timer link is located in all the tools: [Where can I find the Button?][100]_
 
@@ -237,6 +238,7 @@ Don't know how to start? Just check out the [user requested services][98] that h
 [90]: https://overv.io/
 [91]: https://clubhouse.io/
 [92]: https://www.desk.com/
+[93]: http://feedly.com/
 
 [98]: https://github.com/toggl/toggl-button/wiki/User-requested-buttons
 [99]: https://github.com/toggl/toggl-button/pulls

--- a/src/scripts/content/feedly.js
+++ b/src/scripts/content/feedly.js
@@ -1,0 +1,17 @@
+/*jslint indent: 2 */
+/*global $: false, document: false, togglbutton: false, createTag: false*/
+'use strict';
+
+togglbutton.render('.entryHeader:not(.toggl)', {observe: true}, function (elem) {
+  var link,
+    textnode = document.createTextNode("\u00A0//\u00A0 "),
+    description = $('.entryTitle', elem).textContent;
+
+  link = togglbutton.createTimerLink({
+    className: 'feedly',
+    description: description
+  });
+
+  $('.entryHeader > .metadata').appendChild(textnode);
+  $('.entryHeader > .metadata').appendChild(link);
+});

--- a/src/scripts/origins.json
+++ b/src/scripts/origins.json
@@ -124,6 +124,10 @@
     "url": "*://*.exana.io/*",
     "name": "Phabricator"
   },
+  "feedly.com": {
+    "url": "*://*.feedly.com/*",
+    "name": "Feedly"
+  },
   "fogbugz.com": {
     "url": "*://*.fogbugz.com/*",
     "name": "Fogbugz"


### PR DESCRIPTION
This PR adds support for Feedly.

The timer locates right below the title in the metadata section of each story:
<img width="693" alt="toggl_feedly" src="https://cloud.githubusercontent.com/assets/4539360/21423238/e1876258-c876-11e6-8739-2a7e7f2f8edc.png">
