### PR TITLE
Button in sidebar for github

### DIFF
--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -104,7 +104,7 @@ var togglbutton = {
   currentDescription: "",
   fullPageHeight: getFullPageHeight(),
   fullVersion: "TogglButton",
-  render: function (selector, opts, renderer, mutationClass) {
+  render: function (selector, opts, renderer, mutationSelector) {
     chrome.runtime.sendMessage({type: 'activate'}, function (response) {
       if (response.success) {
         try {
@@ -115,9 +115,9 @@ var togglbutton = {
           togglbutton.duration_format = response.user.duration_format;
           if (opts.observe) {
             var observer = new MutationObserver(function (mutations) {
-              // If mutationClass is defined render the start timer link only when this element is changed
-              if (!!mutationClass
-                  && mutations[0].target.className.indexOf(mutationClass) === -1) {
+              // If mutationSelector is defined render the start timer link only when this element is changed
+              if (!!mutationSelector
+                  && !mutations[0].target.matches(mutationSelector)) {
                 return;
               }
               togglbutton.renderTo(selector, renderer);

--- a/src/scripts/content/github.js
+++ b/src/scripts/content/github.js
@@ -2,16 +2,29 @@
 /*global $: false, document: false, togglbutton: false*/
 'use strict';
 
-togglbutton.render('#partial-discussion-header:not(.toggl)', {observe: true}, function (elem) {
-  var link, description,
-    numElem = $('.gh-header-number', elem),
-    titleElem = $('.js-issue-title', elem),
-    projectElem = $('h1.public strong a, h1.private strong a');
+togglbutton.render('#partial-discussion-sidebar', {observe: true}, function (elem) {
+  var div, link, description,
+    numElem = $('.gh-header-number'),
+    titleElem = $('.js-issue-title'),
+    projectElem = $('h1.public strong a, h1.private strong a'),
+    existingTag = $('.discussion-sidebar-item.toggl');
+
+  // Check for existing tag, create a new one if one doesn't exist or is not the first one
+  // We want button to be the first one because it looks different from the other sidebar items
+  // and looks very weird between them.
+  if (existingTag && existingTag.parentNode.firstChild.classList.contains('toggl')) {
+    return
+  } else if(existingTag) {
+    existingTag.parentNode.removeChild(existingTag)
+  }
 
   description = titleElem.textContent;
   if (numElem !== null) {
     description = numElem.textContent + " " + description.trim();
   }
+
+  div = document.createElement("div");
+  div.classList.add("discussion-sidebar-item", "toggl");
 
   link = togglbutton.createTimerLink({
     className: 'github',
@@ -19,5 +32,6 @@ togglbutton.render('#partial-discussion-header:not(.toggl)', {observe: true}, fu
     projectName: projectElem && projectElem.textContent
   });
 
-  $('.TableObject-item--primary').appendChild(link);
-});
+  div.appendChild(link);
+  elem.prepend(div);
+}, '#partial-discussion-sidebar:not(.toggl), .discussion-sidebar-item:not(.toggl');

--- a/src/scripts/content/trello.js
+++ b/src/scripts/content/trello.js
@@ -45,7 +45,7 @@ togglbutton.render('.window-header:not(.toggl)', {observe: true}, function (elem
   trackedContainer.appendChild(p);
   trackedElem.parentNode.insertBefore(trackedContainer, trackedElem);
   */
-}, "window-wrapper");
+}, ".window-wrapper");
 
 /* Checklist buttons */
 togglbutton.render('.checklist-item-details:not(.toggl)', {observe: true}, function (elem) {
@@ -63,4 +63,4 @@ togglbutton.render('.checklist-item-details:not(.toggl)', {observe: true}, funct
 
   link.classList.add('checklist-item-button');
   elem.parentNode.appendChild(link);
-}, "window-wrapper");
+}, ".window-wrapper");

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -343,8 +343,13 @@ only screen and (min-resolution: 192dpi) {
 
 /********* GITHUB *********/
 .toggl-button.github {
-  padding-left: 21px;
-  margin-left: 5px;
+  padding-left: 25px;
+  color: #767676;
+  font-size: 12px;
+}
+.toggl-button.github:hover {
+  color: #4078c0;
+  text-decoration: none;
 }
 
 /********* YOUTRACK *********/


### PR DESCRIPTION
Also modifies `togglbutton.render` to accept `mutationSelector` instead of `mutationClass` and trello content script since that was the only one that used `mutationClass`.

*Note: github's sidebar doesn't seem to slide down with the page anymore like it used to so having the button on the sidebar is not that much of a benefit anymore but meh...*

closes #669