### PR TITLE
Fix missing / temperamental Trello buttons

### DIFF
--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -115,11 +115,16 @@ var togglbutton = {
           togglbutton.duration_format = response.user.duration_format;
           if (opts.observe) {
             var observer = new MutationObserver(function (mutations) {
-              // If mutationSelector is defined render the start timer link only when this element is changed
-              if (!!mutationSelector
-                  && !mutations[0].target.matches(mutationSelector)) {
+              // If mutationSelector is defined, render the start timer link only when an element
+              // matching the selector changes.
+              // Multiple selectors can be used by comma separating them.
+              var matches = mutations.filter(function (mutation) {
+                return mutation.target.matches(mutationSelector);
+              });
+              if (!!mutationSelector && !matches.length) {
                 return;
               }
+
               togglbutton.renderTo(selector, renderer);
             });
             observer.observe(document, {childList: true, subtree: true});

--- a/src/scripts/content/github.js
+++ b/src/scripts/content/github.js
@@ -12,10 +12,12 @@ togglbutton.render('#partial-discussion-sidebar', {observe: true}, function (ele
   // Check for existing tag, create a new one if one doesn't exist or is not the first one
   // We want button to be the first one because it looks different from the other sidebar items
   // and looks very weird between them.
-  if (existingTag && existingTag.parentNode.firstChild.classList.contains('toggl')) {
-    return
-  } else if(existingTag) {
-    existingTag.parentNode.removeChild(existingTag)
+
+  if (existingTag) {
+    if (existingTag.parentNode.firstChild.classList.contains('toggl')) {
+      return;
+    }
+    existingTag.parentNode.removeChild(existingTag);
   }
 
   description = titleElem.textContent;

--- a/src/scripts/content/trello.js
+++ b/src/scripts/content/trello.js
@@ -63,4 +63,4 @@ togglbutton.render('.checklist-item-details:not(.toggl)', {observe: true}, funct
 
   link.classList.add('checklist-item-button');
   elem.parentNode.appendChild(link);
-}, ".window-wrapper");
+}, ".checklist-items-list, .window-wrapper");


### PR DESCRIPTION
The new `mutationClass` thingy broke Trello buttons in some cases, because there was not one reliable selector to respond to in MutationObserver (different things happen when opening a card via a link, etc).

Tweaked the observer matching to match against ALL mutations, rather than just the first mutation in the array of mutations. Then specified multiple selectors for Trello checklists.

also some lint fix

Closes #738.