### PR TITLE
Added Checkvist support

### DIFF
--- a/src/scripts/content/checkvist.js
+++ b/src/scripts/content/checkvist.js
@@ -1,0 +1,24 @@
+/*jslint indent: 2 */
+/*global $: false, document: false, togglbutton: false*/
+'use strict';
+
+var toggleEnabledForCheckvistList = (function () {
+  var togglTag = $('.tag_toggl');
+  return togglTag !== null;
+}());
+
+togglbutton.render('li.nonDivider:not(.toggl)', {observe: true}, function (elem) {
+  if (!toggleEnabledForCheckvistList) {
+    return;
+  }
+
+  var description = $('.node_text', elem).textContent,
+    projectName = $('#header_span').textContent,
+    link = togglbutton.createTimerLink({
+      className: 'checkvist',
+      description: description,
+      projectName: projectName
+    });
+
+  $(".coreDiv", elem).appendChild(link);
+});

--- a/src/scripts/origins.json
+++ b/src/scripts/origins.json
@@ -64,6 +64,10 @@
     "url": "*://*.capsulecrm.com/*",
     "name": "CapsuleCRM"
   },
+  "checkvist.com": {
+	  "url": "*://*.checkvist.com/*", 
+	  "name": "Checkvist"
+  },
   "cloudes.me": {
     "url": "*://*.cloudes.me/*",
     "name": "Cloudes.me"


### PR DESCRIPTION
This adds a toggl button to tasks on [Checkvist](https://www.checkvist.com) lists.

The lists can get horribly messy with every task having a toggl button, and this may be inappropriate in many cases -- who wants to time the 'carrots' item on their shopping list?  So I'm adding the button  only if one or more tasks in a given  list is tagged with "#toggl".

Buttons are appended to the end of the task text. This doesn't look great, but I found that justifying them (eg. to the RHS) made it hard to associate buttons with tasks, so I chose function over form. Jony Ive I'm not.

Screenshot of simple test list with toggl buttons enabled:

![toggl_checkvist](https://cloud.githubusercontent.com/assets/630851/22452141/59a31a14-e7c8-11e6-8f9b-fc474e3d7df2.png)

