### PR TITLE
Fix remaining 'Chrome' in settings

### DIFF
--- a/src/html/settings.html
+++ b/src/html/settings.html
@@ -68,7 +68,7 @@
             <li>
               <input type="checkbox" id="start_automatically">
               <label for="start_automatically">Start automatically</label>
-              <div class="description">Start time tracking of latest task when chrome starts</div>
+              <div class="description">Start time tracking of latest task when the browser starts</div>
             </li>
             <li>
               <input type="checkbox" id="stop_automatically">


### PR DESCRIPTION
Fix a remaining "Chrome" in the settings (visible inside Firefox :p )