### PR TITLE
Add WorkFlowy integration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Add Toggl one-click time tracking to popular web tools.
   - [Feedly][93]
   - [Teamleader][94]
   - [Intercom][95]
+  - [WorkFlowy][96]
 
 ## Installing from the Web Store/Addons page
 
@@ -122,7 +123,7 @@ List of all the changes and added features can be found at http://toggl.github.i
 2.  Go to your [TeamWeek][2], [Pivotal Tracker][3], [Github][4], [Asana][5], [Unfuddle][6], [Gitlab][7],
 [Trello][8], [Worksection][9], [Redbooth][10], [Podio][11], [Basecamp][12], [JIRA][13], [Producteev][14],
 [Bitbucket][15], [Stifer][16], [Google Docs][17], [Redmine][18], [YouTrack][19], [CapsuleCRM][20],
-[Xero][21], [Zendesk][22], [Any.do][23], [Todoist][24], [Trac][25], [Wunderlist][26], [Toodledo][27], [Teamwork.com][28], [Google Mail][29], [Taiga][30], [HabitRPG][31], [Axosoft][32], [Countersoft Gemini][33], [Drupal][34], [Esa][35], [Help Scout][36], [Flow][37], [Sprintly][38], [Google Calendar][39], [TestRail][40], [Bugzilla][41], [Breeze][42], [BamBam][43], [GQueue][44], [Wrike][45], [Assembla][46], [Waffle][47], [Codeable][48], [Eventum][49], [Salesforce][50], [Draftin][51], [FogBugz][52], [Google Keep][53], [Gingko][54], [Google Inbox][55], [Wordpress][56], [Kanbanery][57], [Planbox][58], [Zoho Books][59], [Slack][60], [Doit.im][61], [Cloudes.me][63], [eProject.me][64], [Freshdesk][65], [Newsletter2Go][66], [Gogs][67], [DevDocs][68], [LiquidPlanner][69], [SourceLair][70], [Remember The Milk][71], [Evernote][72], [MantisHub][73], [TargetProcess][74], [VisualStudioOnline (TFS)][75], [SmartBoard][76], [Phabricator][77], [OpenProject][78], [Zube][79], [miniCRM.pl][80], [AgenoCRM][81], [Bitrix24][82], [Rindle][83], [TickTick][84], [Exana][85], [SherpaDesk][86], [Workfront][87], [OnlyOffice][88], [MeisterTask][89], [Overv][90], [Clubhouse][91], [Desk.com][92], [Feedly][93], [Teamleader][94], [Intercom][95] account and start your Toggl timer there.
+[Xero][21], [Zendesk][22], [Any.do][23], [Todoist][24], [Trac][25], [Wunderlist][26], [Toodledo][27], [Teamwork.com][28], [Google Mail][29], [Taiga][30], [HabitRPG][31], [Axosoft][32], [Countersoft Gemini][33], [Drupal][34], [Esa][35], [Help Scout][36], [Flow][37], [Sprintly][38], [Google Calendar][39], [TestRail][40], [Bugzilla][41], [Breeze][42], [BamBam][43], [GQueue][44], [Wrike][45], [Assembla][46], [Waffle][47], [Codeable][48], [Eventum][49], [Salesforce][50], [Draftin][51], [FogBugz][52], [Google Keep][53], [Gingko][54], [Google Inbox][55], [Wordpress][56], [Kanbanery][57], [Planbox][58], [Zoho Books][59], [Slack][60], [Doit.im][61], [Cloudes.me][63], [eProject.me][64], [Freshdesk][65], [Newsletter2Go][66], [Gogs][67], [DevDocs][68], [LiquidPlanner][69], [SourceLair][70], [Remember The Milk][71], [Evernote][72], [MantisHub][73], [TargetProcess][74], [VisualStudioOnline (TFS)][75], [SmartBoard][76], [Phabricator][77], [OpenProject][78], [Zube][79], [miniCRM.pl][80], [AgenoCRM][81], [Bitrix24][82], [Rindle][83], [TickTick][84], [Exana][85], [SherpaDesk][86], [Workfront][87], [OnlyOffice][88], [MeisterTask][89], [Overv][90], [Clubhouse][91], [Desk.com][92], [Feedly][93], [Teamleader][94], [Intercom][95], [WorkFlowy][96] account and start your Toggl timer there.
 
 _See this article for reference where the start timer link is located in all the tools: [Where can I find the Button?][100]_
 

--- a/src/scripts/content/workflowy.js
+++ b/src/scripts/content/workflowy.js
@@ -1,0 +1,20 @@
+/*jslint indent: 2 */
+/*global $: false, document: false, togglbutton: false*/
+'use strict';
+
+togglbutton.render(
+  '.name:not(.toggl)',
+  {observe: true},
+  function (elem) {
+    var description = $(".content", elem).textContent,
+      link = togglbutton.createTimerLink({
+        className: 'workflowy',
+        buttonType: 'minimal',
+        description: description,
+        projectName: 'workflowy'
+      });
+    link.style['margin-top'] = '5px';
+    link.style['margin-left'] = '10px';
+    $('.parentArrow', elem).appendChild(link);
+  }
+);

--- a/src/scripts/origins.json
+++ b/src/scripts/origins.json
@@ -493,5 +493,9 @@
   "teamleader.eu": {
     "url": "*://app.teamleader.eu/*",
     "name": "Teamleader"
+  },
+  "workflowy.com": {
+    "url": "*://workflowy.com/*",
+    "name": "WorkFlowy"
   }
 }


### PR DESCRIPTION
Creates minimal toggl button with workflowy node text as description beside each visible node.

Couldn't figure out how to easily distinguish the "header" workflowy nodes from the "body" ones. I think you have to filter further by class `.selected`, but I was unable to figure out how, so it looks a little ugly.

![image](https://cloud.githubusercontent.com/assets/8809520/22732184/1ce77f36-eda2-11e6-95c6-1caf3add12c0.png)
