### PR TITLE
Fix button in the Asana board view

### DIFF
--- a/src/scripts/autocomplete.js
+++ b/src/scripts/autocomplete.js
@@ -1,5 +1,5 @@
 /*jslint indent: 2, unparam: true, plusplus: true */
-/*global document: false */
+/*global document: false, window: false */
 "use strict";
 
 var noop = function () { return undefined; };
@@ -34,11 +34,11 @@ AutoComplete.prototype.addEvents = function () {
     setTimeout(function () {that.filter.focus(); }, 50);
   });
 
-  that.filter.addEventListener('focus', function (e) {
-    that.filter.parentNode.classList.add("open");
-    that.listItems = that.el.querySelectorAll(that.item);
-    that.updateHeight();
-  });
+  window.addEventListener('focus', function (e) {
+    if (e.target === that.filter) {
+      that.openDropdown();
+    }
+  }, true);
 
   that.filter.addEventListener('keydown', function (e) {
     if (e.code === "Tab" || e.code === "Enter") {
@@ -74,6 +74,12 @@ AutoComplete.prototype.clearFilters = function () {
   for (i = 0; i < b.length; i++) {
     b[i].classList.remove("tasklist-opened");
   }
+};
+
+AutoComplete.prototype.openDropdown = function () {
+  this.filter.parentNode.classList.add("open");
+  this.listItems = this.el.querySelectorAll(this.item);
+  this.updateHeight();
 };
 
 AutoComplete.prototype.closeDropdown = function (t) {

--- a/src/scripts/content/asana.js
+++ b/src/scripts/content/asana.js
@@ -54,7 +54,7 @@ togglbutton.render('#right_pane__contents .SingleTaskPane:not(.toggl)', {observe
 });
 
 // Board view
-togglbutton.render('.BoardCard.BoardColumn-item:not(.toggl)', {observe: true}, function (elem) {
+togglbutton.render('.BoardCard.BoardColumnCardsContainer-item:not(.toggl)', {observe: true}, function (elem) {
   if (!!$('.toggl-button', elem)) {
     return;
   }


### PR DESCRIPTION
~~Button is back to the board view, but the board task detail view is hijacking the 'focus' event in some way that prevents our listener to be triggered. This solution leaves the user with a dropdown that at least opens on click, but not by tabbing to the input itself. ¯\_(ツ)_/¯~~

~~ps: I'm open to suggestions towards a solution that goes around whatever this view is doing with the focus event, but I couldn't find one myself. Curious thing is that you can open the console, create an event `new Event('focus')`, remove all the methods `stopImmediatePropagation`, `stopPropagation`, `cancelBubble`, `preventDefault`, then dispatch it and it will work. Buuuut if I do that inside the click listener (`autocomplete.js L33`) it doesn't work.~~

closes #759