### PR TITLE
Fix origin checking (app.asana.com)

### DIFF
--- a/src/scripts/db.js
+++ b/src/scripts/db.js
@@ -44,7 +44,7 @@ var Db = {
     if (!TogglOrigins[origin]) {
       // Handle cases where subdomain is used (like web.any.do (or sub1.sub2.any.do), we remove web from the beginning)
       origin = origin.split(".");
-      while (origin.length > 0 && TogglOrigins[origin.join('.')] === null) { origin.shift(); }
+      while (origin.length > 0 && !TogglOrigins[origin.join('.')]) { origin.shift(); }
       origin = origin.join(".");
       if (!TogglOrigins[origin]) {
         return null;


### PR DESCRIPTION
In the case of subdomains and the like, we do some logic to try and
match a content script even if an immediate match isn't available.

The code was changed recently and the test ended up testing strictly vs null
whereas undefined is really what we're after here.

!x seems to be the case that stops jslint from shouting, whereas it
shouts at 'x == null' and '!(x != null)' and the like with current
settings.

Closes issue #781