### PR TITLE
Todoist: Use name of containing subproject as Toggl project

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -329,15 +329,21 @@ TogglButton = {
     }
   },
 
-  findProjectByName: function (name) {
+  findProjectByName: function (nameOrNames) {
     var key,
-      result;
+      name,
+      names = [].concat(nameOrNames),
+      result,
+      i;
 
-    for (key in TogglButton.$user.projectMap) {
-      if (TogglButton.$user.projectMap.hasOwnProperty(key) && TogglButton.$user.projectMap[key].name === name) {
-        result = TogglButton.$user.projectMap[key];
-        if (result.wid === TogglButton.$user.default_wid) {
-          return result;
+    for (i=0; i < names.length; i++) {
+      name = names[i];
+      for (key in TogglButton.$user.projectMap) {
+        if (TogglButton.$user.projectMap.hasOwnProperty(key) && TogglButton.$user.projectMap[key].name === name) {
+          result = TogglButton.$user.projectMap[key];
+          if (result.wid === TogglButton.$user.default_wid) {
+            return result;
+          }
         }
       }
     }

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -336,7 +336,7 @@ TogglButton = {
       result,
       i;
 
-    for (i=0; i < names.length; i++) {
+    for (i = 0; i < names.length; i++) {
       name = names[i];
       for (key in TogglButton.$user.projectMap) {
         if (TogglButton.$user.projectMap.hasOwnProperty(key) && TogglButton.$user.projectMap[key].name === name) {

--- a/src/scripts/content/todoist.js
+++ b/src/scripts/content/todoist.js
@@ -41,15 +41,23 @@ function getProjectNameHierarchy(sidebarEle) {
   return [projectName].concat(getProjectNameHierarchy(parentProjectEle));
 }
 
+function projectWasJustCreated(projectId) {
+  return projectId.startsWith('_');
+}
+
 function getSidebarEle(elem) {
   var editorInstance, projectId, sidebarRoot, sidebarColorEle, sidebarEle;
   editorInstance = elem.closest('.project_editor_instance');
   if (editorInstance) {
     projectId = editorInstance.getAttribute('data-project-id');
     sidebarRoot = $('#project_list');
-    sidebarColorEle = $('#project_color_' + projectId, sidebarRoot);
-    if (sidebarColorEle) {
-      sidebarEle = sidebarColorEle.closest('.menu_clickable');
+    if (projectWasJustCreated(projectId)) {
+      sidebarEle = $('.current', sidebarRoot);
+    } else {
+      sidebarColorEle = $('#project_color_' + projectId, sidebarRoot);
+      if (sidebarColorEle) {
+        sidebarEle = sidebarColorEle.closest('.menu_clickable');
+      }
     }
   }
   return sidebarEle;

--- a/src/scripts/content/todoist.js
+++ b/src/scripts/content/todoist.js
@@ -4,9 +4,9 @@
 'use strict';
 
 togglbutton.render('.task_item .content:not(.toggl)', {observe: true}, function (elem) {
-  var link, descFunc, container = $('.text', elem), description,
+  var link, descFunc, container = $('.text', elem),
     getSidebarEle, getProjectNameHierarchy, isTopLevelProject, levelPattern, getParentEle,
-    getProjectNameFromLabel, sidebarEle, projectNames;
+    getProjectNameFromLabel, getProjectNames;
 
   descFunc = function () {
     var clone = container.cloneNode(true),
@@ -36,12 +36,15 @@ togglbutton.render('.task_item .content:not(.toggl)', {observe: true}, function 
   };
 
   getSidebarEle = function (elem) {
-    var editorInstance, projectId, sidebarRoot, sidebarEle;
+    var editorInstance, projectId, sidebarRoot, sidebarColorEle, sidebarEle;
     editorInstance = elem.closest('.project_editor_instance');
     if (editorInstance) {
       projectId = editorInstance.getAttribute('data-project-id');
       sidebarRoot = $('#project_list');
-      sidebarEle = $('#project_color_' + projectId, sidebarRoot).closest('.menu_clickable');
+      sidebarColorEle = $('#project_color_' + projectId, sidebarRoot);
+      if (sidebarColorEle) {
+        sidebarEle = sidebarColorEle.closest('.menu_clickable');
+      }
     }
     return sidebarEle;
   };
@@ -85,18 +88,20 @@ togglbutton.render('.task_item .content:not(.toggl)', {observe: true}, function 
     return projectLabel;
   };
 
-  description = descFunc();
-  sidebarEle = getSidebarEle(elem);
-  if (sidebarEle) {
-    projectNames = getProjectNameHierarchy(sidebarEle);
-  } else {
-    projectNames = [getProjectNameFromLabel(elem)];
-  }
+  getProjectNames = function() {
+    var sidebarEle = getSidebarEle(elem);
+    if (sidebarEle) {
+      projectNames = getProjectNameHierarchy(sidebarEle);
+    } else {
+      projectNames = [getProjectNameFromLabel(elem)];
+    }
+    return projectNames;
+  };
 
   link = togglbutton.createTimerLink({
     className: 'todoist',
-    description: description,
-    projectName: projectNames
+    description: descFunc(),
+    projectName: getProjectNames()
   });
 
   container.insertBefore(link, container.lastChild);

--- a/src/scripts/content/todoist.js
+++ b/src/scripts/content/todoist.js
@@ -49,25 +49,24 @@ togglbutton.render('.task_item .content:not(.toggl)', {observe: true}, function 
     return sidebarEle;
   };
 
-  getProjectNameHierarchy = function(sidebarEle) {
+  getProjectNameHierarchy = function (sidebarEle) {
     var parentProjectEle, projectName;
     projectName = $('.name', sidebarEle).firstChild.textContent.trim();
     if (isTopLevelProject(sidebarEle)) {
       return [projectName];
-    } else {
-      parentProjectEle = getParentEle(sidebarEle);
-      return [projectName].concat(getProjectNameHierarchy(parentProjectEle));
     }
+    parentProjectEle = getParentEle(sidebarEle);
+    return [projectName].concat(getProjectNameHierarchy(parentProjectEle));
   };
 
   isTopLevelProject = function (sidebarEle) {
     return sidebarEle.classList.contains('indent_1');
   };
 
-  levelPattern = /(?:^|\s)indent_(.*?)(?:\s|$)/;
-  getParentEle = function(sidebarEle) {
+  levelPattern = /(?:^|\s)indent_([0-9]*?)(?:\s|$)/;
+  getParentEle = function (sidebarEle) {
     var curLevel, parentClass, parentCandidate;
-    curLevel = sidebarEle.className.match(levelPattern)[1],
+    curLevel = sidebarEle.className.match(levelPattern)[1];
     parentClass = 'indent_' + (curLevel - 1);
 
     parentCandidate = sidebarEle;
@@ -77,18 +76,18 @@ togglbutton.render('.task_item .content:not(.toggl)', {observe: true}, function 
         break;
       }
     }
-   return parentCandidate;
+    return parentCandidate;
   };
 
   getProjectNameFromLabel = function (elem) {
-    var projectLabel='', projectLabelEle = $('.pname', elem.parentNode.parentNode);
+    var projectLabel = '', projectLabelEle = $('.pname', elem.parentNode.parentNode);
     if (projectLabelEle) {
       projectLabel = projectLabelEle.textContent.trim();
     }
     return projectLabel;
   };
 
-  getProjectNames = function() {
+  getProjectNames = function () {
     var projectNames, viewingInbox, sidebarEle;
     viewingInbox = $('#filter_inbox.current, #filter_team_inbox.current');
     if (viewingInbox) {

--- a/src/scripts/content/todoist.js
+++ b/src/scripts/content/todoist.js
@@ -3,10 +3,76 @@
 
 'use strict';
 
+function getProjectNameFromLabel(elem) {
+  var projectLabel = '', projectLabelEle = $('.pname', elem.parentNode.parentNode);
+  if (projectLabelEle) {
+    projectLabel = projectLabelEle.textContent.trim();
+  }
+  return projectLabel;
+}
+
+var levelPattern = /(?:^|\s)indent_([0-9]*?)(?:\s|$)/;
+function getParentEle(sidebarEle) {
+  var curLevel, parentClass, parentCandidate;
+  curLevel = sidebarEle.className.match(levelPattern)[1];
+  parentClass = 'indent_' + (curLevel - 1);
+
+  parentCandidate = sidebarEle;
+  while (parentCandidate.previousElementSibling) {
+    parentCandidate = parentCandidate.previousElementSibling;
+    if (parentCandidate.classList.contains(parentClass)) {
+      break;
+    }
+  }
+  return parentCandidate;
+}
+
+function isTopLevelProject(sidebarEle) {
+  return sidebarEle.classList.contains('indent_1');
+}
+
+function getProjectNameHierarchy(sidebarEle) {
+  var parentProjectEle, projectName;
+  projectName = $('.name', sidebarEle).firstChild.textContent.trim();
+  if (isTopLevelProject(sidebarEle)) {
+    return [projectName];
+  }
+  parentProjectEle = getParentEle(sidebarEle);
+  return [projectName].concat(getProjectNameHierarchy(parentProjectEle));
+}
+
+function getSidebarEle(elem) {
+  var editorInstance, projectId, sidebarRoot, sidebarColorEle, sidebarEle;
+  editorInstance = elem.closest('.project_editor_instance');
+  if (editorInstance) {
+    projectId = editorInstance.getAttribute('data-project-id');
+    sidebarRoot = $('#project_list');
+    sidebarColorEle = $('#project_color_' + projectId, sidebarRoot);
+    if (sidebarColorEle) {
+      sidebarEle = sidebarColorEle.closest('.menu_clickable');
+    }
+  }
+  return sidebarEle;
+}
+
+function getProjectNames(elem) {
+  var projectNames, viewingInbox, sidebarEle;
+  viewingInbox = $('#filter_inbox.current, #filter_team_inbox.current');
+  if (viewingInbox) {
+    projectNames = ['Inbox'];
+  } else {
+    sidebarEle = getSidebarEle(elem);
+    if (sidebarEle) {
+      projectNames = getProjectNameHierarchy(sidebarEle);
+    } else {
+      projectNames = [getProjectNameFromLabel(elem)];
+    }
+  }
+  return projectNames;
+}
+
 togglbutton.render('.task_item .content:not(.toggl)', {observe: true}, function (elem) {
-  var link, descFunc, container = $('.text', elem),
-    getSidebarEle, getProjectNameHierarchy, isTopLevelProject, levelPattern, getParentEle,
-    getProjectNameFromLabel, getProjectNames;
+  var link, descFunc, container = $('.text', elem);
 
   descFunc = function () {
     var clone = container.cloneNode(true),
@@ -35,78 +101,10 @@ togglbutton.render('.task_item .content:not(.toggl)', {observe: true}, function 
     return clone.textContent.trim();
   };
 
-  getSidebarEle = function (elem) {
-    var editorInstance, projectId, sidebarRoot, sidebarColorEle, sidebarEle;
-    editorInstance = elem.closest('.project_editor_instance');
-    if (editorInstance) {
-      projectId = editorInstance.getAttribute('data-project-id');
-      sidebarRoot = $('#project_list');
-      sidebarColorEle = $('#project_color_' + projectId, sidebarRoot);
-      if (sidebarColorEle) {
-        sidebarEle = sidebarColorEle.closest('.menu_clickable');
-      }
-    }
-    return sidebarEle;
-  };
-
-  getProjectNameHierarchy = function (sidebarEle) {
-    var parentProjectEle, projectName;
-    projectName = $('.name', sidebarEle).firstChild.textContent.trim();
-    if (isTopLevelProject(sidebarEle)) {
-      return [projectName];
-    }
-    parentProjectEle = getParentEle(sidebarEle);
-    return [projectName].concat(getProjectNameHierarchy(parentProjectEle));
-  };
-
-  isTopLevelProject = function (sidebarEle) {
-    return sidebarEle.classList.contains('indent_1');
-  };
-
-  levelPattern = /(?:^|\s)indent_([0-9]*?)(?:\s|$)/;
-  getParentEle = function (sidebarEle) {
-    var curLevel, parentClass, parentCandidate;
-    curLevel = sidebarEle.className.match(levelPattern)[1];
-    parentClass = 'indent_' + (curLevel - 1);
-
-    parentCandidate = sidebarEle;
-    while (parentCandidate.previousElementSibling) {
-      parentCandidate = parentCandidate.previousElementSibling;
-      if (parentCandidate.classList.contains(parentClass)) {
-        break;
-      }
-    }
-    return parentCandidate;
-  };
-
-  getProjectNameFromLabel = function (elem) {
-    var projectLabel = '', projectLabelEle = $('.pname', elem.parentNode.parentNode);
-    if (projectLabelEle) {
-      projectLabel = projectLabelEle.textContent.trim();
-    }
-    return projectLabel;
-  };
-
-  getProjectNames = function () {
-    var projectNames, viewingInbox, sidebarEle;
-    viewingInbox = $('#filter_inbox.current, #filter_team_inbox.current');
-    if (viewingInbox) {
-      projectNames = ['Inbox'];
-    } else {
-      sidebarEle = getSidebarEle(elem);
-      if (sidebarEle) {
-        projectNames = getProjectNameHierarchy(sidebarEle);
-      } else {
-        projectNames = [getProjectNameFromLabel(elem)];
-      }
-    }
-    return projectNames;
-  };
-
   link = togglbutton.createTimerLink({
     className: 'todoist',
     description: descFunc(),
-    projectName: getProjectNames()
+    projectName: getProjectNames(elem)
   });
 
   container.insertBefore(link, container.lastChild);

--- a/src/scripts/content/todoist.js
+++ b/src/scripts/content/todoist.js
@@ -89,11 +89,17 @@ togglbutton.render('.task_item .content:not(.toggl)', {observe: true}, function 
   };
 
   getProjectNames = function() {
-    var sidebarEle = getSidebarEle(elem);
-    if (sidebarEle) {
-      projectNames = getProjectNameHierarchy(sidebarEle);
+    var projectNames, viewingInbox, sidebarEle;
+    viewingInbox = $('#filter_inbox.current, #filter_team_inbox.current');
+    if (viewingInbox) {
+      projectNames = ['Inbox'];
     } else {
-      projectNames = [getProjectNameFromLabel(elem)];
+      sidebarEle = getSidebarEle(elem);
+      if (sidebarEle) {
+        projectNames = getProjectNameHierarchy(sidebarEle);
+      } else {
+        projectNames = [getProjectNameFromLabel(elem)];
+      }
     }
     return projectNames;
   };

--- a/src/scripts/content/todoist.js
+++ b/src/scripts/content/todoist.js
@@ -12,12 +12,12 @@ function getProjectNameFromLabel(elem) {
 }
 
 var levelPattern = /(?:^|\s)indent_([0-9]*?)(?:\s|$)/;
-function getParentEle(sidebarEle) {
+function getParentEle(sidebarCurrentEle) {
   var curLevel, parentClass, parentCandidate;
-  curLevel = sidebarEle.className.match(levelPattern)[1];
+  curLevel = sidebarCurrentEle.className.match(levelPattern)[1];
   parentClass = 'indent_' + (curLevel - 1);
 
-  parentCandidate = sidebarEle;
+  parentCandidate = sidebarCurrentEle;
   while (parentCandidate.previousElementSibling) {
     parentCandidate = parentCandidate.previousElementSibling;
     if (parentCandidate.classList.contains(parentClass)) {
@@ -27,17 +27,17 @@ function getParentEle(sidebarEle) {
   return parentCandidate;
 }
 
-function isTopLevelProject(sidebarEle) {
-  return sidebarEle.classList.contains('indent_1');
+function isTopLevelProject(sidebarCurrentEle) {
+  return sidebarCurrentEle.classList.contains('indent_1');
 }
 
-function getProjectNameHierarchy(sidebarEle) {
+function getProjectNameHierarchy(sidebarCurrentEle) {
   var parentProjectEle, projectName;
-  projectName = $('.name', sidebarEle).firstChild.textContent.trim();
-  if (isTopLevelProject(sidebarEle)) {
+  projectName = $('.name', sidebarCurrentEle).firstChild.textContent.trim();
+  if (isTopLevelProject(sidebarCurrentEle)) {
     return [projectName];
   }
-  parentProjectEle = getParentEle(sidebarEle);
+  parentProjectEle = getParentEle(sidebarCurrentEle);
   return [projectName].concat(getProjectNameHierarchy(parentProjectEle));
 }
 
@@ -45,33 +45,33 @@ function projectWasJustCreated(projectId) {
   return projectId.startsWith('_');
 }
 
-function getSidebarEle(elem) {
-  var editorInstance, projectId, sidebarRoot, sidebarColorEle, sidebarEle;
+function getSidebarCurrentEle(elem) {
+  var editorInstance, projectId, sidebarRoot, sidebarColorEle, sidebarCurrentEle;
   editorInstance = elem.closest('.project_editor_instance');
   if (editorInstance) {
     projectId = editorInstance.getAttribute('data-project-id');
     sidebarRoot = $('#project_list');
     if (projectWasJustCreated(projectId)) {
-      sidebarEle = $('.current', sidebarRoot);
+      sidebarCurrentEle = $('.current', sidebarRoot);
     } else {
       sidebarColorEle = $('#project_color_' + projectId, sidebarRoot);
       if (sidebarColorEle) {
-        sidebarEle = sidebarColorEle.closest('.menu_clickable');
+        sidebarCurrentEle = sidebarColorEle.closest('.menu_clickable');
       }
     }
   }
-  return sidebarEle;
+  return sidebarCurrentEle;
 }
 
 function getProjectNames(elem) {
-  var projectNames, viewingInbox, sidebarEle;
+  var projectNames, viewingInbox, sidebarCurrentEle;
   viewingInbox = $('#filter_inbox.current, #filter_team_inbox.current');
   if (viewingInbox) {
     projectNames = ['Inbox'];
   } else {
-    sidebarEle = getSidebarEle(elem);
-    if (sidebarEle) {
-      projectNames = getProjectNameHierarchy(sidebarEle);
+    sidebarCurrentEle = getSidebarCurrentEle(elem);
+    if (sidebarCurrentEle) {
+      projectNames = getProjectNameHierarchy(sidebarCurrentEle);
     } else {
       projectNames = [getProjectNameFromLabel(elem)];
     }


### PR DESCRIPTION
Todoist displays entries of a subproject below the main project's entries. Currently toggl-button just uses the main project's name as the Toggl project. This commit adds the ability to use the subproject name.

Any depth of project nesting is handled. We determine the name of the project, its parent, grandparent, and so on up the project hierarchy. Then we pass an array of these project names to the createTimerLink function so that each may be tried successively until one of them matches a Toggl project. (The matching doesn't happen until we click the Start Timer and it sends a message to the extension's background code, which I've enhanced slightly to accept a list of project names to look for.)

We determine the parent of a Todoist project by inspecting the indentation of their entries in the sidebar menu.