### PR TITLE
Fix github button disappearing

### DIFF
--- a/src/scripts/content/github.js
+++ b/src/scripts/content/github.js
@@ -36,4 +36,4 @@ togglbutton.render('#partial-discussion-sidebar', {observe: true}, function (ele
 
   div.appendChild(link);
   elem.prepend(div);
-}, '#js-repo-pjax-container, .discussion-sidebar-item:not(.toggl)');
+});


### PR DESCRIPTION
GitHub is now mutating the whole html, apparently. So we can no
longer check for single elements changing.

Closes #787