### PR TITLE
Fix popdown height calc

### DIFF
--- a/src/scripts/autocomplete.js
+++ b/src/scripts/autocomplete.js
@@ -58,6 +58,7 @@ AutoComplete.prototype.addEvents = function () {
 
   that.filterClear.addEventListener('click', function (e) {
     that.closeDropdown();
+    e.preventDefault();
   });
 };
 
@@ -98,8 +99,9 @@ AutoComplete.prototype.updateHeight = function () {
     listStyle = "max-height:auto;",
     calc;
 
-  if (elRect.bottom + 25 >= bodyRect.bottom) {
-    calc = ((elRect.bottom - elRect.top) - (elRect.bottom - bodyRect.bottom + 10));
+   if (elRect.bottom + 25 >= bodyRect.bottom) {
+    calc = window.scrollY + bodyRect.bottom - elRect.top - 10;
+    if (calc < 55) calc = 55;
     style = "max-height: " + calc + "px;";
     listStyle = "max-height: " + (calc - 25) + "px;";
   }

--- a/src/styles/autocomplete.css
+++ b/src/styles/autocomplete.css
@@ -118,7 +118,6 @@
 #toggl-button-tag-filter {
   max-height: 0;
   position: absolute;
-  top: -1000px;
 }
 
 .toggl-button-row.open #toggl-button-project-filter,


### PR DESCRIPTION
This fixes the `max-height` calculation, taking into account scroll position.

Also prevents scrolling to top when focusing inputs; and `preventDefault`s the clear button, to also prevent scrolling to top.

Partially fixes #767