### PR TITLE
Button patches

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -852,7 +852,7 @@ var TogglButton = {
       onLoad: function (xhr) {
         TogglButton.$user = null;
         TogglButton.updateTriggers(null);
-        localStorage.setItem('userToken', null);
+        localStorage.removeItem('userToken');
         sendResponse({success: (xhr.status === 200), xhr: xhr});
         if (xhr.status === 200) {
           TogglButton.setBrowserActionBadge();

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -21,6 +21,7 @@ var TogglButton = {
   $user: null,
   $curEntry: null,
   $latestStoppedEntry: null,
+  $ApiUrl: "https://www.toggl.com/api/",
   $ApiV8Url: "https://www.toggl.com/api/v8",
   $ApiV9Url: "https://www.toggl.com/api/v9/workspaces",
   $sendResponse: null,
@@ -74,10 +75,10 @@ var TogglButton = {
 
   fetchUser: function (token) {
     TogglButton.ajax('/me?with_related_data=true', {
-      token: token || ' ',
+      token: token,
       baseUrl: TogglButton.$ApiV8Url,
       onLoad: function (xhr) {
-        var resp, apiToken, projectMap = {}, clientMap = {}, clientNameMap = {}, tagMap = {}, projectTaskList = null,
+        var resp, projectMap = {}, clientMap = {}, clientNameMap = {}, tagMap = {}, projectTaskList = null,
           entry = null;
         try {
           if (xhr.status === 200) {
@@ -130,7 +131,6 @@ var TogglButton = {
             TogglButton.$user.clientNameMap = clientNameMap;
             TogglButton.$user.tagMap = tagMap;
             TogglButton.$user.projectTaskList = projectTaskList;
-            localStorage.removeItem('userToken');
             localStorage.setItem('userToken', resp.data.api_token);
             if (TogglButton.$sendResponse !== null) {
               TogglButton.$sendResponse({success: (xhr.status === 200)});
@@ -142,11 +142,6 @@ var TogglButton = {
             TogglButton.handleQueue();
             TogglButton.setCanSeeBillable();
             GA.reportOs();
-          } else if (!token) {
-            apiToken = localStorage.getItem('userToken');
-            if (apiToken) {
-              TogglButton.fetchUser(apiToken);
-            }
           } else {
             TogglButton.setBrowserActionBadge();
           }
@@ -524,7 +519,6 @@ var TogglButton = {
   loadOrigins: function () {
     TogglButton.ajax('scripts/origins.json', {
       method: 'GET',
-      token: ' ',
       baseUrl: '/',
       mime: true,
       onLoad: function (xhr) {
@@ -542,23 +536,26 @@ var TogglButton = {
     var xhr = new XMLHttpRequest(),
       method = opts.method || 'GET',
       baseUrl = opts.baseUrl || TogglButton.$ApiV8Url,
-      token = opts.token || (TogglButton.$user && TogglButton.$user.api_token),
-      credentials = opts.credentials || null;
+      resolvedUrl = baseUrl + url,
+      token = opts.token || (TogglButton.$user && TogglButton.$user.api_token) || localStorage.getItem('userToken'),
+      credentials = opts.credentials || null
 
-    xhr.open(method, baseUrl + url, true);
+    xhr.open(method, resolvedUrl, true);
     xhr.setRequestHeader("IsTogglButton", "true");
+
+    if (resolvedUrl.match(TogglButton.$ApiUrl)) {
+      if (token) {
+        xhr.setRequestHeader('Authorization', 'Basic ' + btoa(token + ':api_token'));
+      } else if (credentials) {
+        xhr.setRequestHeader('Authorization', 'Basic ' + btoa(credentials.username + ':' + credentials.password));
+      }
+    }
 
     if (opts.onError) {
       xhr.addEventListener('error', function () { opts.onError(xhr); });
     }
     if (opts.onLoad) {
       xhr.addEventListener('load', function () { opts.onLoad(xhr); });
-    }
-    if (token && token !== ' ') {
-      xhr.setRequestHeader('Authorization', 'Basic ' + btoa(token + ':api_token'));
-    }
-    if (credentials) {
-      xhr.setRequestHeader('Authorization', 'Basic ' + btoa(credentials.username + ':' + credentials.password));
     }
     if (opts.mime) {
       xhr.overrideMimeType("application/json");


### PR DESCRIPTION
- ensures we interact with `https?` tabs only; closes #804
- fixes token removal; auth headers set only for API requests; closes #806 