### PR TITLE
Handle body height 0

### DIFF
--- a/src/scripts/autocomplete.js
+++ b/src/scripts/autocomplete.js
@@ -99,7 +99,7 @@ AutoComplete.prototype.updateHeight = function () {
     listStyle = "max-height:auto;",
     calc;
 
-  if (elRect.bottom + 25 >= bodyRect.bottom) {
+  if (bodyRect.bottom > 0 && elRect.bottom + 25 >= bodyRect.bottom) {
     calc = window.scrollY + bodyRect.bottom - elRect.top - 10;
     if (calc < 55) {
       calc = 55;


### PR DESCRIPTION
If body height is 0 (everything is absolute) it
messes up the height calculation for the popdowns.

This handles that case. But if eventually if we have a too low popup window on a body height 0 page, it could get cut off.

Closes #821