### PR TITLE
Adjust to new Toodledo layout

### DIFF
--- a/src/scripts/content/toodledo.js
+++ b/src/scripts/content/toodledo.js
@@ -3,13 +3,13 @@
 
 'use strict';
 
-togglbutton.render('.row:not(.toggl)', {observe: true}, function (elem) {
+togglbutton.render('.row:not(.toggl), .taskRow:not(.toggl)', {observe: true}, function (elem) {
   var link,
     newElem,
     landmarkElem,
-    taskElem = $('.task', elem),
-    goalElem = $('.col1024', elem),
-    folderElem = $('.col1', elem),
+    newLayout = $('.tc_title', elem),
+    taskElem = newLayout ? newLayout : $('.task', elem),
+    folderElem = $('.col1', elem) || $('.taskCell:not(.tc_title)', elem),
     folderName = folderElem && folderElem.firstChild.textContent;
 
   folderName = (!folderName || folderName === "No Folder") ? "" : " - " + folderName;
@@ -17,14 +17,15 @@ togglbutton.render('.row:not(.toggl)', {observe: true}, function (elem) {
   link = togglbutton.createTimerLink({
     className: 'toodledo',
     buttonType: 'minimal',
-    description: taskElem.textContent + folderName,
-    projectName: goalElem && goalElem.textContent
+    description: taskElem.textContent + folderName
   });
 
   newElem = document.createElement('div');
   newElem.appendChild(link);
-  newElem.setAttribute('style', 'float:left;width:30px;height:20px;');
+  newElem.setAttribute('style', (newLayout ? 'display:inline-block;' : 'float:left;') +
+    'width:30px;height:20px;');
+  if (!newLayout) link.setAttribute('style', 'top:1px;');
 
-  landmarkElem = $('.subm', elem) || $('.subp', elem) || $('.ax', elem);
+  landmarkElem = $('.subm', elem) || $('.subp', elem) || $('.ax', elem) || $('.cellAction', elem);
   elem.insertBefore(newElem, landmarkElem.nextSibling);
 });

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -732,7 +732,7 @@ only screen and (min-resolution: 192dpi) {
 
 /********* TOODLEDO *********/
 .toggl-button.toodledo {
-  margin-top: -3px;
+  top: 3px;
   position: relative;
   margin-left: 5px;
 }


### PR DESCRIPTION
This updates Toodledo integration to the new layout

* Currently works on both old and new
* Adjusted button vertical alignment on both
* I couldn't find "goal" text to match up against projects. Removed it.
   * Folder name currently maps to just a suffix to the task description (as it used to), but since we don't have something to try and match with the project name, we could use the **folder** name for project names on Toggl, instead of being part of the description.
  * ^ left as this to match current/previous behavior

Closes #786