### PR TITLE
Break up Feedly rave

### DIFF
--- a/src/scripts/content/feedly.js
+++ b/src/scripts/content/feedly.js
@@ -12,6 +12,6 @@ togglbutton.render('.entryHeader:not(.toggl)', {observe: true}, function (elem) 
     description: description
   });
 
-  $('.entryHeader > .metadata').appendChild(textnode);
-  $('.entryHeader > .metadata').appendChild(link);
+  elem.querySelector('.entryHeader > .metadata').appendChild(textnode);
+  elem.querySelector('.entryHeader > .metadata').appendChild(link);
 });


### PR DESCRIPTION
All buttons were added to the first card in Full view mode. This scopes
the selector to the current card. It fixes things for me.

closes #790