### PR TITLE
Fix. Backlog

### DIFF
--- a/src/scripts/content/backlog.js
+++ b/src/scripts/content/backlog.js
@@ -7,7 +7,7 @@ togglbutton.render('#issueArea:not(.toggl)', {observe: true}, function (elem) {
   var link, container = createTag('span', ''),
     descFunc,
     ticketNumElem = $('.ticket__key .ticket__key-number', elem),
-    titleElem = $('h3#summary span', elem),
+    titleElem = $('h3#summary span.title-group__title-text', elem),
     projectElem = $('.project-header h1 .header-icon-set__name'),
     descriptionElem = $('#summary span');
 


### PR DESCRIPTION
Possibility that 'titleElem.textContent' will fail to fetch.
Because, 'h3#summary' has meny 'span'.