### PR TITLE
Remember last project per service/url

### DIFF
--- a/src/html/settings.html
+++ b/src/html/settings.html
@@ -61,6 +61,15 @@
               <div class="description">The default project will be selected when timer is started with no matched project</div>
             </li>
             <li>
+              <label for="remember-project-per">Remember project per</label>
+              <select id="remember-project-per">
+                <option value="false">Use global default</option>
+                <option value="service">Service</option>
+                <option value="url">URL</option>
+              </select>
+              <div class="description">This will remember the last project used on each service/url separately. Overrides default project.</div>
+            </li>
+            <li>
               <input type="checkbox" id="show_right_click_button">
               <label for="show_right_click_button">Show "Start timer" item in right click menu</label>
               <div class="description">Makes it super easy to start timer with any copied text as description. If something is copied to clipboard you can start timer with that text. If clipboard is empty, page title is used as the description.</div>

--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -448,7 +448,8 @@ var togglbutton = {
           tags: invokeIfFunction(params.tags),
           projectName: invokeIfFunction(params.projectName),
           createdWith: togglbutton.fullVersion + "-" + togglbutton.serviceName,
-          service: togglbutton.serviceName
+          service: togglbutton.serviceName,
+          url: window.location.href
         };
       }
       togglbutton.element = e.target;

--- a/src/scripts/db.js
+++ b/src/scripts/db.js
@@ -22,8 +22,9 @@ var Db = {
     "pomodoroInterval": 25,
     "stopAtDayEnd": false,
     "dayEndTime": "17:00",
-    "defaultProject": "0",
-    "projects": ""
+    "defaultProject": 0,
+    "projects": "",
+    "rememberProjectPer": "false"
   },
 
   // core settings: key, default value
@@ -100,6 +101,40 @@ var Db = {
       return obj;
     }
     return null;
+  },
+
+
+  /**
+   * Sets the default project for a given scope
+   * @param {number} pid The project id
+   * @param {string=} scope The scope to remember that project.
+   * If null, then set global default
+   */
+  setDefaultProject: function (pid, scope) {
+    var userId = TogglButton.$user.id,
+      defaultProjects = JSON.parse(this.get(userId + "-defaultProjects")) || {};
+    if (!scope) return this.set(userId + "-defaultProject", pid);
+    defaultProjects[scope] = pid;
+    this.set(userId + "-defaultProjects", JSON.stringify(defaultProjects));
+  },
+
+
+  /**
+   * Gets the default project for a given scope
+   * @param {string=} scope If null, then get global default
+   * @returns {number} The default project for the given scope
+   */
+  getDefaultProject: function (scope) {
+    var userId = TogglButton.$user.id,
+      defaultProjects = JSON.parse(this.get(userId + "-defaultProjects")),
+      defaultProject = parseInt(this.get(userId + "-defaultProject") || '0', 10);
+    if (!scope || !defaultProjects)
+      return defaultProject;
+    return defaultProjects[scope] || defaultProject;
+  },
+
+  resetDefaultProjects: function () {
+    this.set(TogglButton.$user.id + "-defaultProjects", null);
   },
 
   get: function (setting) {
@@ -188,6 +223,9 @@ var Db = {
         Db.updateSetting("dayEndTime", request.state);
       } else if (request.type === 'change-default-project') {
         Db.updateSetting(chrome.extension.getBackgroundPage().TogglButton.$user.id + "-defaultProject", request.state);
+      } else if (request.type === 'change-remember-project-per') {
+        Db.updateSetting("rememberProjectPer", request.state);
+        Db.resetDefaultProjects();
       } else if (request.type === 'update-dont-show-permissions' || request.type === 'update-selected-settings-tab') {
         Db.updateSetting(request.type.substr(7), request.state);
       }

--- a/src/scripts/ga.js
+++ b/src/scripts/ga.js
@@ -54,8 +54,11 @@ var GA = {
     if (Db.get("stopAtDayEnd")) {
       this.report('stop-at-day-end-time', "settings/stop-at-day-end-time" + Db.get("dayEndTime"));
     }
+    this.report('remember-project-per', "settings/remember-project-per-" + Db.get("rememberProjectPer"));
 
-    this.report('default-project', "settings/default-project" + Db.get("defaultProject"));
+    if (Db.getDefaultProject()) {
+      this.report('default-project', "settings/default-project");
+    }
   },
 
   generateGUID: function () {

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -81,6 +81,10 @@ var Settings = {
       Settings.toggleState(Settings.$pomodoroMode, Db.get("pomodoroModeEnabled"));
       Settings.toggleState(Settings.$pomodoroSound, Db.get("pomodoroSoundEnabled"));
       Settings.toggleState(Settings.$pomodoroStopTimeTracking, Db.get("pomodoroStopTimeTrackingWhenTimerEnds"));
+      var rememberProjectPer = Db.get("rememberProjectPer");
+      Array.apply(null, Settings.$rememberProjectPer.options).forEach(function(option) {
+        if (option.value === rememberProjectPer) option.setAttribute("selected", "selected");
+      });
 
       document.querySelector("#pomodoro-interval").value = Db.get("pomodoroInterval");
 
@@ -100,7 +104,7 @@ var Settings = {
   fillDefaultProject: function () {
     var key, project, clientName, projects, clients, defProject, html, dom;
     if (Db.get("projects") !== '' && !!TogglButton.$user) {
-      defProject = Db.get(TogglButton.$user.id + "-defaultProject");
+      defProject = Db.getDefaultProject();
       projects = JSON.parse(Db.get("projects"));
       clients = JSON.parse(Db.get("clients"));
 
@@ -541,6 +545,7 @@ document.addEventListener('DOMContentLoaded', function (e) {
     Settings.$stopAtDayEnd = document.querySelector("#stop-at-day-end");
     Settings.$tabs = document.querySelector(".tabs");
     Settings.$defaultProjectContainer = document.querySelector("#default-project-container");
+    Settings.$rememberProjectPer = document.querySelector("#remember-project-per");
 
     // Show permissions page with notice
     if (!!parseInt(Db.get("show-permissions-info"), 10) && !Db.get("dont-show-permissions")) {
@@ -627,6 +632,13 @@ document.addEventListener('DOMContentLoaded', function (e) {
 
     Settings.$stopAtDayEnd.addEventListener('click', function (e) {
       Settings.toggleSetting(e.target, (localStorage.getItem("stopAtDayEnd") !== "true"), "toggle-stop-at-day-end");
+    });
+
+
+    Settings.$rememberProjectPer.addEventListener('change', function (e) {
+      var rememberPer = Settings.$rememberProjectPer.options[Settings.$rememberProjectPer.selectedIndex].value;
+      if (rememberPer === "false") rememberPer = false;
+      Settings.saveSetting(rememberPer, "change-remember-project-per");
     });
 
     document.querySelector(".tab-links").addEventListener('click', function (e) {


### PR DESCRIPTION
## What does this PR do?
This adds a new option to the settings page:
Remember last project per service/url

## How to test it
Try the option out. It should:
* Remember the last project used for said service (eg. github) or url
* If it's the same as default project from settings, use that one
* When changing the option, should wipe the mapping


Closes #210 