### PR TITLE
Adjust settings dialog to prevent overflow

### DIFF
--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -147,6 +147,7 @@ header {
   right: 0;
   background: #ffffff;
   z-index: 100;
+  box-shadow: inset 0px -1px 1px -1px #bbb;
 }
 
 header ul {
@@ -170,8 +171,9 @@ header .active, header li:hover {
 .container .tabs {
   position: absolute;
   bottom: 42px;
-  top: 35px;
+  top: 0;
   left: 0px;
+  padding-top: 15px;
   width: 2600px;
   overflow: hidden;
   transition:left 300ms ease-in-out;
@@ -191,7 +193,7 @@ header .active, header li:hover {
 
 .container .tab {
   float: left;
-  height: 323px;
+  height: 343px;
   overflow-x: hidden;
   overflow-y: auto;
   width: 800px;

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -21,14 +21,23 @@ input[type="number"] {
   width: 50px;
 }
 
+html,
+body,
 .container {
+  height: 400px;
+  width: 800px;
+  max-height: 400px;
+  max-width: 800px;
+}
+
+.container {
+  position: relative;
+  height: 400px;
   width: 800px;
   margin: 20px 15px 0px;
   padding: 0;
   color: #505050!important;
   float: left;
-  min-height: 380px;
-  max-height: 400px;
   overflow: hidden;
 }
 
@@ -128,7 +137,7 @@ input[type="number"] {
   visibility: hidden;
   padding: 5px;
   width: 50%;
-  margin: 0!important;
+  margin: 0 20px!important;
 }
 
 .list li:hover .description {
@@ -186,9 +195,19 @@ header .active, header li:hover {
 .container .tab {
   float: left;
   height: 323px;
+  overflow-x: hidden;
   overflow-y: auto;
-  width: 815px;
-  padding-left: 15px;
+  width: 800px;
+  padding-left: 30px;
+}
+
+.container .tab-1 {
+  width: 785px;
+  padding-left: 0;
+}
+
+.container .tab-2 {
+  padding-left: 45px;
 }
 
 /* Permissions tab */
@@ -198,8 +217,7 @@ header .active, header li:hover {
 }
 
 .container .tab-3 {
-  padding-right: 15px;
-  width: 800px;
+  width: 785px;
 }
 
 .container .tab-3 h2 {

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -104,12 +104,10 @@ body,
 
 .footer {
   padding: 10px 15px;
-  min-width: 800px;
   background-color: #f5f5f5;
   border-top: 1px solid #e5e5e5;
   font-size: 12px;
   color: #8A8888;
-  float: left;
   position: fixed;
   bottom: 0;
   left: 0;
@@ -120,7 +118,6 @@ body,
   float: right;
   margin: 0;
   padding: 0;
-  margin-right: 10px;
 }
 
 #version a {


### PR DESCRIPTION
## What does this PR do
Adjust settings dialog to prevent overflow, specially on screens with display scaling

Apparently Chrome is misbehaving when display scaling is turned on. We define our settings dialog's width and height, and Chrome makes the dialog window bigger. Sadly, the content does not scale up.

I tried some CSS to make Chrome respect the dimensions, but couldn't. At least there's no more overflow.


## How to test
* Have high resolution screen, change display scaling
![image](https://user-images.githubusercontent.com/360894/27841839-e9452492-60da-11e7-9a1c-746c9abd2770.png)
* If you also have this feature on your OS (Mac, Linux), please let me know how that looks for you
* See issue, before and after.
* Check specially if there are no uneeded scroll bars, and if the scroll bars are not clipped.

Kinda closes #845