### PR TITLE
Add Dokuwiki integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Add Toggl one-click time tracking to popular web tools.
   - [Desk.com][92]
   - [DevDocs][68]
   - [Doit.im][61]
+  - [DokuWiki][105]
   - [Draftin][51]
   - [Drupal][34]
   - [eProject.me][64]
@@ -124,7 +125,7 @@ List of all the changes and added features can be found at http://toggl.github.i
 
 ## Using the Button
 1.  Log in to your [Toggl][1] account from the extension popup.
-2.  Go to your [AgenoCRM][81], [Any.do][23], [Asana][5], [Assembla][46], [Axosoft][32], [Backlog.jp][96], [BamBam][43], [Basecamp][12], [Bitbucket][15], [Bitrix24][82], [Breeze][42], [Bugzilla][41], [CapsuleCRM][20], [Cloudes.me][63], [Clubhouse][91], [Codeable][48], [Countersoft Gemini][33], [Desk.com][92], [DevDocs][68], [Doit.im][61], [Draftin][51], [Drupal][34], [eProject.me][64], [Esa][35], [Eventum][49], [Evernote][72], [Exana][85], [Feedly][93], [Flow][37], [FogBugz][52], [Freshdesk][65], [Gingko][54], [Github][4], [Gitlab][7], [Gogs][67], [Google Calendar][39], [Google Docs][17], [Google Inbox][55], [Google Keep][53], [Google Mail][29], [GQueue][44], [HabitRPG][31], [Help Scout][36], [Husky Marketing Planner][103], [Intercom][95], [JIRA][13], [Kanbanery][57], [KhanAcademy][102], [LiquidPlanner][69], [MantisHub][73], [MeisterTask][89], [miniCRM.pl][80], [Newsletter2Go][66], [Nozbe][104], [OnlyOffice][88], [OpenProject][78], [Overv][90], [Phabricator][77], [Pivotal Tracker][3], [Planbox][58], [Podio][11], [Producteev][14], [Redbooth][10], [Redmine][18], [Remember The Milk][71], [Rindle][83], [Salesforce][50], [SherpaDesk][86], [Slack][60], [SmartBoard][76], [SourceLair][70], [Sprintly][38], [Stifer][16], [Taiga][30], [TargetProcess][74], [Teamleader][94], [TeamWeek][2], [Teamwork.com][28], [TestRail][40], [TickTick][84], [Todoist][24], [Toodledo][27], [Trac][25], [Trello][8], [Unfuddle][6], [VisualStudioOnline (TFS)][75], [Waffle][47], [Wordpress][56], [Workfront][87], [Worksection][9], [Wrike][45], [Wunderlist][26], [Xero][21], [YouTrack][19], [Zendesk][22], [Zoho Books][59], [Zube][79] account and start your Toggl timer there.
+2.  Go to your [AgenoCRM][81], [Any.do][23], [Asana][5], [Assembla][46], [Axosoft][32], [Backlog.jp][96], [BamBam][43], [Basecamp][12], [Bitbucket][15], [Bitrix24][82], [Breeze][42], [Bugzilla][41], [CapsuleCRM][20], [Cloudes.me][63], [Clubhouse][91], [Codeable][48], [Countersoft Gemini][33], [Desk.com][92], [DevDocs][68], [Doit.im][61], [DokuWiki][105], [Draftin][51], [Drupal][34], [eProject.me][64], [Esa][35], [Eventum][49], [Evernote][72], [Exana][85], [Feedly][93], [Flow][37], [FogBugz][52], [Freshdesk][65], [Gingko][54], [Github][4], [Gitlab][7], [Gogs][67], [Google Calendar][39], [Google Docs][17], [Google Inbox][55], [Google Keep][53], [Google Mail][29], [GQueue][44], [HabitRPG][31], [Help Scout][36], [Husky Marketing Planner][103], [Intercom][95], [JIRA][13], [Kanbanery][57], [KhanAcademy][102], [LiquidPlanner][69], [MantisHub][73], [MeisterTask][89], [miniCRM.pl][80], [Newsletter2Go][66], [Nozbe][104], [OnlyOffice][88], [OpenProject][78], [Overv][90], [Phabricator][77], [Pivotal Tracker][3], [Planbox][58], [Podio][11], [Producteev][14], [Redbooth][10], [Redmine][18], [Remember The Milk][71], [Rindle][83], [Salesforce][50], [SherpaDesk][86], [Slack][60], [SmartBoard][76], [SourceLair][70], [Sprintly][38], [Stifer][16], [Taiga][30], [TargetProcess][74], [Teamleader][94], [TeamWeek][2], [Teamwork.com][28], [TestRail][40], [TickTick][84], [Todoist][24], [Toodledo][27], [Trac][25], [Trello][8], [Unfuddle][6], [VisualStudioOnline (TFS)][75], [Waffle][47], [Wordpress][56], [Workfront][87], [Worksection][9], [Wrike][45], [Wunderlist][26], [Xero][21], [YouTrack][19], [Zendesk][22], [Zoho Books][59], [Zube][79] account and start your Toggl timer there.
 
 _See this article for reference where the start timer link is located in all the tools: [Where can I find the Button?][100]_
 
@@ -251,3 +252,4 @@ Don't know how to start? Just check out the [user requested services][98] that h
 [102]: https://www.khanacademy.org/
 [103]: https://www.huskymarketingplanner.com/
 [104]: https://nozbe.com/
+[105]: https://www.dokuwiki.org/

--- a/src/scripts/content/dokuwiki.js
+++ b/src/scripts/content/dokuwiki.js
@@ -1,0 +1,20 @@
+/*jslint indent: 2, unparam: true*/
+/*global $: false, document: false, togglbutton: false*/
+
+'use strict';
+togglbutton.render('#dokuwiki__content', {observe: false}, function (elem) {
+  var link, description,
+    numElem = $(".pageId span"),
+    pName = numElem.textContent.split(":")[0].trim(),
+    target = $(".wrapper.group") || // DokuWiki Template
+    $(".pageId");                   // Bootstrap3 Template
+
+  description = numElem.textContent.split(" ").pop().trim();
+  link = togglbutton.createTimerLink({
+    className: 'wiki',
+    description: description,
+    projectName: pName
+  });
+
+  target.prepend(link);
+});

--- a/src/scripts/origins.json
+++ b/src/scripts/origins.json
@@ -101,6 +101,11 @@
     "name": "Doit",
     "clone": "true"
   },
+  "dokuwiki.org": {
+    "url": "*://*.dokuwiki.org/*",
+    "name": "DokuWiki",
+    "file": "dokuwiki.js"
+  },
   "draftin.com": {
     "url": "*://*.draftin.com/*",
     "name": "Draftin"


### PR DESCRIPTION
Creates toggl button anywhere on the site. 
Button is placed right bellow the header node and can be used for any activity on dokuwiki (reading, editing, comparing...)

![screenshot from 2017-07-10 17-41-56](https://user-images.githubusercontent.com/17459600/28026745-513b1ee2-6597-11e7-890d-f16f1ba49674.png)
![screenshot from 2017-07-10 17-42-03](https://user-images.githubusercontent.com/17459600/28026752-559b92dc-6597-11e7-8c3b-62fbb444e7f6.png)
