### PR TITLE
Added duration field to extension popup edit view

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -46,17 +46,20 @@ var TogglButton = {
       '<form autocomplete="off">' +
       '<a class="toggl-button {service} active" href="#">Stop timer</a>' +
       '<a id="toggl-button-hide">&times;</a>' +
-      '<div class="toggl-button-row">' +
-        '<input name="toggl-button-description" tabindex="100" type="text" id="toggl-button-description" class="toggl-button-input" value="" placeholder="(no description)" autocomplete="off">' +
+      '<div class="toggl-button-row" id="toggl-button-duration-row">' +
+        '<input name="toggl-button-duration" tabindex="100" type="time" id="toggl-button-duration" class="toggl-button-input" value="" placeholder="00:00" autocomplete="off">' +
       '</div>' +
       '<div class="toggl-button-row">' +
-        '<input name="toggl-button-project-filter" tabindex="101" type="text" id="toggl-button-project-filter" class="toggl-button-input" value="" placeholder="Filter Projects" autocomplete="off">' +
+        '<input name="toggl-button-description" tabindex="101" type="text" id="toggl-button-description" class="toggl-button-input" value="" placeholder="(no description)" autocomplete="off">' +
+      '</div>' +
+      '<div class="toggl-button-row">' +
+        '<input name="toggl-button-project-filter" tabindex="102" type="text" id="toggl-button-project-filter" class="toggl-button-input" value="" placeholder="Filter Projects" autocomplete="off">' +
         '<a href="#clear" class="filter-clear">&times;</a>' +
         '<div id="toggl-button-project-placeholder" class="toggl-button-input" disabled><span class="tb-project-bullet"></span><div class="toggl-button-text">Add project</div><span>▼</span></div>' +
         '<div id="project-autocomplete">{projects}</div>' +
       '</div>' +
       '<div class="toggl-button-row">' +
-        '<input name="toggl-button-tag-filter" tabindex="102" type="text" id="toggl-button-tag-filter" class="toggl-button-input" value="" placeholder="Filter Tags" autocomplete="off">' +
+        '<input name="toggl-button-tag-filter" tabindex="103" type="text" id="toggl-button-tag-filter" class="toggl-button-input" value="" placeholder="Filter Tags" autocomplete="off">' +
         '<a href="#add" class="add-new-tag">+ Add</a>' +
         '<a href="#clear" class="filter-clear">&times;</a>' +
         '<div id="toggl-button-tag-placeholder" class="toggl-button-input" disabled><div class="toggl-button-text">Add tags</div><span>▼</span></div>' +
@@ -68,7 +71,7 @@ var TogglButton = {
         '<div class="toggl-button-billable-label">Billable</div>' +
         '<div class="toggl-button-billable-flag"><span></span></div>' +
       '</div>' +
-      '<div id="toggl-button-update" tabindex="104">DONE</div>' +
+      '<div id="toggl-button-update" tabindex="105">DONE</div>' +
       '<input type="submit" class="hidden">' +
       '</from>' +
     '</div>',
@@ -769,6 +772,10 @@ var TogglButton = {
     if (entry.pid) {
       project = TogglButton.findProjectByPid(parseInt(entry.pid, 10));
       entry.wid = (project && project.wid);
+    }
+
+    if (timeEntry.start) {
+      entry.start = timeEntry.start;
     }
 
     TogglButton.ajax('/' + entry.wid + '/time_entries/' + TogglButton.$curEntry.id, {

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -47,7 +47,7 @@ var TogglButton = {
       '<a class="toggl-button {service} active" href="#">Stop timer</a>' +
       '<a id="toggl-button-hide">&times;</a>' +
       '<div class="toggl-button-row" id="toggl-button-duration-row">' +
-        '<input name="toggl-button-duration" tabindex="100" type="time" id="toggl-button-duration" class="toggl-button-input" value="" placeholder="00:00" autocomplete="off">' +
+        '<input name="toggl-button-duration" tabindex="100" type="time" step="1" id="toggl-button-duration" class="toggl-button-input" value="" placeholder="00:00" autocomplete="off">' +
       '</div>' +
       '<div class="toggl-button-row">' +
         '<input name="toggl-button-description" tabindex="101" type="text" id="toggl-button-description" class="toggl-button-input" value="" placeholder="(no description)" autocomplete="off">' +

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -28,6 +28,7 @@ var PopUp = {
   mousedownTrigger: null,
   projectBlurTrigger: null,
   editFormAdded: false,
+  durationChanged: false,
   $billable: null,
   $header: document.querySelector(".header"),
   $menuView: document.querySelector("#menu"),
@@ -124,9 +125,18 @@ var PopUp = {
     }
 
     var duration = PopUp.msToTime(new Date() - new Date(TogglButton.$curEntry.start)),
-      description = TogglButton.$curEntry.description || "(no description)";
+      description = TogglButton.$curEntry.description || "(no description)",
+      durationField = document.querySelector("#toggl-button-duration");
 
     PopUp.$togglButton.textContent = duration;
+
+    // Update edit form duration field
+    if (durationField !== document.activeElement && PopUp.durationChanged === false) {
+      durationField.value = duration;
+    } else {
+      PopUp.durationChanged = true;
+    }
+
     if (startTimer) {
       PopUp.$timer = setInterval(function () { PopUp.showCurrentDuration(); }, 1000);
       description += PopUp.$projectAutocomplete.setProjectBullet(TogglButton.$curEntry.pid, TogglButton.$curEntry.tid, PopUp.$projectBullet);
@@ -317,9 +327,11 @@ var PopUp = {
     var pid = (!!TogglButton.$curEntry.pid) ? TogglButton.$curEntry.pid : 0,
       tid = (!!TogglButton.$curEntry.tid) ? TogglButton.$curEntry.tid : 0,
       wid = TogglButton.$curEntry.wid,
-      togglButtonDescription = document.querySelector("#toggl-button-description");
+      togglButtonDescription = document.querySelector("#toggl-button-description"),
+      togglButtonDuration = document.querySelector("#toggl-button-duration");
 
     togglButtonDescription.value = (!!TogglButton.$curEntry.description) ? TogglButton.$curEntry.description : "";
+    togglButtonDuration.value = PopUp.msToTime(new Date() - new Date(TogglButton.$curEntry.start));
 
     PopUp.$projectAutocomplete.setup(pid, tid);
     PopUp.$tagAutocomplete.setup(TogglButton.$curEntry.tags, wid);
@@ -331,6 +343,8 @@ var PopUp = {
     togglButtonDescription.focus();
     togglButtonDescription.setSelectionRange(0, 0);
     togglButtonDescription.scrollLeft = 0;
+
+    PopUp.durationChanged = false;
   },
 
   updateBillable: function (pid, no_overwrite) {
@@ -363,6 +377,28 @@ var PopUp = {
     }
   },
 
+  // Duration changed let's calculate new start
+  getStart: function () {
+    var arr = document.querySelector("#toggl-button-duration").value.split(":"),
+      duration,
+      now,
+      start;
+
+    if (!PopUp.isNumber(arr.join(""))) {
+      return false;
+    }
+
+    duration = 1000 * (arr[2] || 0) + 60000 * arr[1] + 3600000 * arr[0];
+
+    now = new Date();
+    start = new Date(now.getTime() - duration);
+    return start.toISOString();
+  },
+
+  isNumber: function (n) {
+    return !isNaN(parseFloat(n)) && isFinite(n);
+  },
+
   toggleBillable: function (visible) {
     var tabIndex = visible ? "103" : "-1";
     PopUp.$billable.setAttribute("tabindex", tabIndex);
@@ -387,7 +423,12 @@ var PopUp = {
         respond: true,
         billable: billable,
         service: "dropdown"
-      };
+      },
+      start = PopUp.getStart();
+
+    if (start) {
+      request.start = start;
+    }
 
     PopUp.sendMessage(request);
     PopUp.updateMenuTimer(request);

--- a/src/styles/popup.css
+++ b/src/styles/popup.css
@@ -453,7 +453,7 @@ hr {
   display: none;
   padding: 0;
   width: 240px;
-  height: 269px;
+  height: 315px;
 }
 
 #toggl-button-edit-form {
@@ -462,7 +462,7 @@ hr {
   max-width: 240px;
   padding: 10px !important;
   box-sizing: border-box;
-  height: 269px;
+  height: 315px;
 }
 
 #toggl-button-edit-form .toggl-button{
@@ -509,6 +509,7 @@ hr {
 #toggl-button-edit-form #toggl-button-project-placeholder,
 #toggl-button-edit-form #toggl-button-tag-placeholder,
 #toggl-button-edit-form #toggl-button-description,
+#toggl-button-edit-form #toggl-button-duration,
 #toggl-button-edit-form #toggl-button-project,
 #toggl-button-edit-form #toggl-button-project-filter,
 #toggl-button-edit-form #toggl-button-tag-filter {
@@ -521,6 +522,18 @@ hr {
   border-radius: 0;
   background-color: #ffffff;
   font-size: 14px;
+}
+
+#toggl-button-edit-form #toggl-button-duration-row {
+  outline: none;
+}
+
+#toggl-button-edit-form #toggl-button-duration {
+  font-size: 22px;
+  text-align: center;
+  width: 100%;
+  font-weight: 200;
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 
 #toggl-button-edit-form #toggl-button-project-placeholder,
@@ -639,6 +652,10 @@ hr {
 /** FIREFOX **/
 .ff #toggl-button-update:focus{
   box-shadow: 1px 1px 5px #83bffc;
+}
+
+.ff #toggl-button-edit-form #toggl-button-duration {
+  padding: 0;
 }
 
 /** FIREFOX END **/

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -145,6 +145,10 @@ only screen and (min-resolution: 192dpi) {
   font-size: 14px;
 }
 
+#toggl-button-edit-form #toggl-button-duration {
+  display: none;
+}
+
 #toggl-button-edit-form #toggl-button-description img {
   display: none !important;
 }


### PR DESCRIPTION
The thing I've missed the most. Being able to edit the duration to reflect the correct time I started working. Actually I just miss working on Toggl Button.

This PR adds duration edit field into the Extension icon popup Edit view.

Tested both in Chrome and FF and it seemed to be ok.

**Chrome**
![screen shot 2017-08-12 at 23 52 35](https://user-images.githubusercontent.com/842229/29244132-5c5343a4-7fb9-11e7-8558-94100532ce8f.png)

**Firefox**
![screen shot 2017-08-12 at 23 44 04](https://user-images.githubusercontent.com/842229/29244117-f843a020-7fb8-11e7-91f4-6d657b612910.png)


Some comments about the code.

- The duration field updates every second until user focuses the field. `PopUp.durationChanged` flag is used to determine if field should be updated or not.

- Firefox needed to validate the input in the time field as it allows to type in non numeric characters. That's why `isNumeric` function was added to PopUp.

- `(arr[2] || 0)` is used because in cases like `03:00:00` the value for some reason is `"03:00"` and this breaks the calculation as `arr[2]` is undefined.

- The duration edit is only visible in the popup and not in the edit form shown on the page

Happy Reviewing!