### PR TITLE
Hardcoded automatic 'Tasks' and 'Reviews' project assigning

### DIFF
--- a/src/scripts/content/phabricator.js
+++ b/src/scripts/content/phabricator.js
@@ -31,9 +31,24 @@ togglbutton.render('#phabricator-standard-page-body:not(.toggl)', {observe: true
 
   projectName = (!!projectName) ? projectName.textContent.trim() : "";
 
+  if (number.length > 0 && number[0].toUpperCase() === 'T') {
+      projectName = "Tasks";
+  } else if (number.length > 0 && number[0].toUpperCase() === 'D') {
+      projectName = "Reviews";
+  }
+
+  var
+    properties = elem.querySelectorAll('.phui-property-list-properties .phui-property-list-key'),
+    maniphest = "";
+  properties.forEach(function(propertyName) {
+    if (propertyName.textContent.trim() === 'Maniphest Tasks') {
+      maniphest = " (" + propertyName.nextSibling.textContent.trim() + ")";
+    }
+  });
+
   link = togglbutton.createTimerLink({
     className: 'phabricator',
-    description: number + desc.textContent,
+    description: number + desc.textContent + maniphest,
     projectName: projectName
   });
 


### PR DESCRIPTION
How to test:
- go to `chrome://extensions/`
- check `Developer mode` on the top
- click to `Load unpacked extension` and navigate to `src` directory in this repo
- provide Toggl creddentials
- on the Permission add-on tab enable `phabricator.shoptet.cz` and assign `Phabricator` integration
- go to any Task... start tracking... tracked entity is automatically added to `Tasks` projects
- go to any Review... start tracking... tracked entity is automatically added to `Review` projects, tracked entity name ends by Task name