### PR TITLE
Add Spidergap360 integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Add Toggl one-click time tracking to popular web tools.
   - [Slack][60]
   - [SmartBoard][76]
   - [SourceLair][70]
+  - [Spidergap][108]
   - [Sprintly][38]
   - [Taiga][30]
   - [TargetProcess][74]
@@ -127,7 +128,7 @@ List of all the changes and added features can be found at http://toggl.github.i
 
 ## Using the Button
 1.  Log in to your [Toggl][1] account from the extension popup.
-2.  Go to your [AgenoCRM][81], [Any.do][23], [Asana][5], [Assembla][46], [Axosoft][32], [Backlog.jp][96], [BamBam][43], [Basecamp][12], [Bitbucket][15], [Bitrix24][82], [Breeze][42], [Bugzilla][41], [CapsuleCRM][20], [Cloudes.me][63], [Clubhouse][91], [Codeable][48], [Codebase][107], [Countersoft Gemini][33], [Desk.com][92], [DevDocs][68], [Doit.im][61], [DokuWiki][105], [Draftin][51], [Drupal][34], [eProject.me][64], [Esa][35], [Eventum][49], [Evernote][72], [Exana][85], [Feedly][93], [Flow][37], [FogBugz][52], [Freshdesk][65], [Gingko][54], [Github][4], [Gitlab][7], [Gogs][67], [Google Calendar][39], [Google Docs][17], [Google Inbox][55], [Google Keep][53], [Google Mail][29], [GQueue][44], [HabitRPG][31], [Help Scout][36], [Husky Marketing Planner][103], [Intercom][95], [JIRA][13], [Kanbanery][57], [KhanAcademy][102], [LiquidPlanner][69], [MantisHub][73], [MeisterTask][89], [miniCRM.pl][80], [Newsletter2Go][66], [Nozbe][104], [OnlyOffice][88], [OpenProject][78], [osTicket][106], [Overv][90], [Phabricator][77], [Pivotal Tracker][3], [Planbox][58], [Podio][11], [Producteev][14], [Redbooth][10], [Redmine][18], [Remember The Milk][71], [Rindle][83], [Salesforce][50], [SherpaDesk][86], [Slack][60], [SmartBoard][76], [SourceLair][70], [Sprintly][38], [Stifer][16], [Taiga][30], [TargetProcess][74], [Teamleader][94], [TeamWeek][2], [Teamwork.com][28], [TestRail][40], [TickTick][84], [Todoist][24], [Toodledo][27], [Trac][25], [Trello][8], [Unfuddle][6], [VisualStudioOnline (TFS)][75], [Waffle][47], [Wordpress][56], [Workfront][87], [Worksection][9], [Wrike][45], [Wunderlist][26], [Xero][21], [YouTrack][19], [Zendesk][22], [Zoho Books][59], [Zube][79] account and start your Toggl timer there.
+2.  Go to your [AgenoCRM][81], [Any.do][23], [Asana][5], [Assembla][46], [Axosoft][32], [Backlog.jp][96], [BamBam][43], [Basecamp][12], [Bitbucket][15], [Bitrix24][82], [Breeze][42], [Bugzilla][41], [CapsuleCRM][20], [Cloudes.me][63], [Clubhouse][91], [Codeable][48], [Codebase][107], [Countersoft Gemini][33], [Desk.com][92], [DevDocs][68], [Doit.im][61], [DokuWiki][105], [Draftin][51], [Drupal][34], [eProject.me][64], [Esa][35], [Eventum][49], [Evernote][72], [Exana][85], [Feedly][93], [Flow][37], [FogBugz][52], [Freshdesk][65], [Gingko][54], [Github][4], [Gitlab][7], [Gogs][67], [Google Calendar][39], [Google Docs][17], [Google Inbox][55], [Google Keep][53], [Google Mail][29], [GQueue][44], [HabitRPG][31], [Help Scout][36], [Husky Marketing Planner][103], [Intercom][95], [JIRA][13], [Kanbanery][57], [KhanAcademy][102], [LiquidPlanner][69], [MantisHub][73], [MeisterTask][89], [miniCRM.pl][80], [Newsletter2Go][66], [Nozbe][104], [OnlyOffice][88], [OpenProject][78], [osTicket][106], [Overv][90], [Phabricator][77], [Pivotal Tracker][3], [Planbox][58], [Podio][11], [Producteev][14], [Redbooth][10], [Redmine][18], [Remember The Milk][71], [Rindle][83], [Salesforce][50], [SherpaDesk][86], [Slack][60], [SmartBoard][76], [SourceLair][70], [Spidergap][108], [Sprintly][38], [Stifer][16], [Taiga][30], [TargetProcess][74], [Teamleader][94], [TeamWeek][2], [Teamwork.com][28], [TestRail][40], [TickTick][84], [Todoist][24], [Toodledo][27], [Trac][25], [Trello][8], [Unfuddle][6], [VisualStudioOnline (TFS)][75], [Waffle][47], [Wordpress][56], [Workfront][87], [Worksection][9], [Wrike][45], [Wunderlist][26], [Xero][21], [YouTrack][19], [Zendesk][22], [Zoho Books][59], [Zube][79] account and start your Toggl timer there.
 
 _See this article for reference where the start timer link is located in all the tools: [Where can I find the Button?][100]_
 
@@ -257,3 +258,4 @@ Don't know how to start? Just check out the [user requested services][98] that h
 [105]: https://www.dokuwiki.org/
 [106]: http://osticket.com/
 [107]: https://www.codebasehq.com/
+[108]: https://www.spidergap.com/

--- a/src/scripts/content/spidergap.js
+++ b/src/scripts/content/spidergap.js
@@ -1,0 +1,17 @@
+/*jslint indent: 2 */
+/*global $: false, document: false, togglbutton: false*/
+'use strict';
+
+togglbutton.render('.section-header:not(.toggl)', {observe: true}, function () {
+  var link,
+    description = $('.section-header h1').textContent.trim(),
+    project = $('#navbar-project-link').textContent.trim();
+
+  link = togglbutton.createTimerLink({
+    className: 'spidergap',
+    description: description,
+    projectName: project
+  });
+
+  $('.nav-tabs').appendChild(link);
+});

--- a/src/scripts/origins.json
+++ b/src/scripts/origins.json
@@ -380,6 +380,10 @@
     "url": "*://www.sourcelair.com/*",
     "name": "Sourcelair"
   },
+  "spidergap.com": {
+    "url": "*://*.spidergap.com/*",
+    "name": "Spidergap"
+  },
   "sprint.ly": {
     "url": "*://sprint.ly/*",
     "name": "Sprintly"

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1277,3 +1277,8 @@ a.toggl-button.workfront.min {
 .sidebar__module .toggl-button {
   margin-bottom: 5px;
 }
+
+/********* SPIDERGAP *********/
+.nav-tabs .toggl-button {
+  margin: 5px 0 0 60px;
+}


### PR DESCRIPTION
This PR adds Toggl button integration for [Spidergap360](https://www.spidergap.com), a popular 360-degree employee feedback tool.

- Matches the title of the page as description & Spidergap project name as Timer project

A screenshot of Design page - 


![design_page](https://user-images.githubusercontent.com/17750543/29638205-4af901a8-8878-11e7-9c9a-e5d3d9061d9e.png)

On Settings page - 

![settings_page](https://user-images.githubusercontent.com/17750543/29638261-82ef14ee-8878-11e7-94b4-25308f4b6494.png)


Passed `make lint` & submitted in one commit as suggested.

You can sign up [here](https://www.spidergap.com/signup) for Spidergap account.