### PR TITLE
Fix gitlab issue page button

### DIFF
--- a/src/scripts/content/gitlab.js
+++ b/src/scripts/content/gitlab.js
@@ -7,7 +7,7 @@ togglbutton.render('.issue-details .detail-page-description:not(.toggl)', {obser
   var link, description,
     numElem = $(".identifier"),
     titleElem = $(".title", elem),
-    projectElem = $("h1 .project-item-select-holder");
+    projectElem = $(".title .project-item-select-holder");
 
   description = titleElem.textContent.trim();
 
@@ -28,7 +28,7 @@ togglbutton.render('.merge-request-details .detail-page-description:not(.toggl)'
   var link, description,
     numElem = $(".identifier"),
     titleElem = $(".title", elem),
-    projectElem = $("h1 .project-item-select-holder");
+    projectElem = $(".title .project-item-select-holder");
 
   description = titleElem.textContent.trim();
   if (numElem !== null) {


### PR DESCRIPTION
Hi!
I fixed https://github.com/toggl/toggl-button/issues/866 in this PR.

It can show button both (old or new) navigation now.

New navigation
![default](https://user-images.githubusercontent.com/13980441/30197759-c7fffb06-94a4-11e7-996d-c9ede2b70777.png)

Old navigation
![2](https://user-images.githubusercontent.com/13980441/30197838-56587aea-94a5-11e7-817a-e4ddd2d83902.png)

Thank you.