### PR TITLE
added PagerDuty integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Add Toggl one-click time tracking to popular web tools.
   - [OpenProject][78]
   - [osTicket][106]
   - [Overv][90]
+  - [PagerDuty][110]
   - [Phabricator][77]
   - [Pivotal tracker][3]
   - [Planbox][58]
@@ -129,7 +130,7 @@ List of all the changes and added features can be found at http://toggl.github.i
 
 ## Using the Button
 1.  Log in to your [Toggl][1] account from the extension popup.
-2.  Go to your [AgenoCRM][81], [Any.do][23], [Asana][5], [Assembla][46], [Axosoft][32], [Backlog.jp][96], [BamBam][43], [Basecamp][12], [Bitbucket][15], [Bitrix24][82], [Breeze][42], [Bugzilla][41], [CapsuleCRM][20], [Cloudes.me][63], [Clubhouse][91], [Codeable][48], [Codebase][107], [Countersoft Gemini][33], [Desk.com][92], [DevDocs][68], [Doit.im][61], [DokuWiki][105], [Draftin][51], [Drupal][34], [eProject.me][64], [Esa][35], [Eventum][49], [Evernote][72], [Exana][85], [Feedly][93], [Flow][37], [FogBugz][52], [Freshdesk][65], [Gingko][54], [Github][4], [Gitlab][7], [Gogs][67], [Google Calendar][39], [Google Docs][17], [Google Inbox][55], [Google Keep][53], [Google Mail][29], [GQueue][44], [HabitRPG][31], [Help Scout][36], [Husky Marketing Planner][103], [Intercom][95], [JIRA][13], [Kanbanery][57], [KhanAcademy][102], [LiquidPlanner][69], [MantisHub][73], [MeisterTask][89], [miniCRM.pl][80], [Newsletter2Go][66], [Nozbe][104], [OnlyOffice][88], [OpenProject][78], [osTicket][106], [Overv][90], [Phabricator][77], [Pivotal Tracker][3], [Planbox][58], [Podio][11], [Producteev][14], [RallyDev][108], [Redbooth][10], [Redmine][18], [Remember The Milk][71], [Rindle][83], [Salesforce][50], [SherpaDesk][86], [Slack][60], [SmartBoard][76], [SourceLair][70], [Spidergap][109], [Sprintly][38], [Stifer][16], [Taiga][30], [TargetProcess][74], [Teamleader][94], [TeamWeek][2], [Teamwork.com][28], [TestRail][40], [TickTick][84], [Todoist][24], [Toodledo][27], [Trac][25], [Trello][8], [Unfuddle][6], [VisualStudioOnline (TFS)][75], [Waffle][47], [Wordpress][56], [Workfront][87], [Worksection][9], [Wrike][45], [Wunderlist][26], [Xero][21], [YouTrack][19], [Zendesk][22], [Zoho Books][59], [Zube][79] account and start your Toggl timer there.
+2.  Go to your [AgenoCRM][81], [Any.do][23], [Asana][5], [Assembla][46], [Axosoft][32], [Backlog.jp][96], [BamBam][43], [Basecamp][12], [Bitbucket][15], [Bitrix24][82], [Breeze][42], [Bugzilla][41], [CapsuleCRM][20], [Cloudes.me][63], [Clubhouse][91], [Codeable][48], [Codebase][107], [Countersoft Gemini][33], [Desk.com][92], [DevDocs][68], [Doit.im][61], [DokuWiki][105], [Draftin][51], [Drupal][34], [eProject.me][64], [Esa][35], [Eventum][49], [Evernote][72], [Exana][85], [Feedly][93], [Flow][37], [FogBugz][52], [Freshdesk][65], [Gingko][54], [Github][4], [Gitlab][7], [Gogs][67], [Google Calendar][39], [Google Docs][17], [Google Inbox][55], [Google Keep][53], [Google Mail][29], [GQueue][44], [HabitRPG][31], [Help Scout][36], [Husky Marketing Planner][103], [Intercom][95], [JIRA][13], [Kanbanery][57], [KhanAcademy][102], [LiquidPlanner][69], [MantisHub][73], [MeisterTask][89], [miniCRM.pl][80], [Newsletter2Go][66], [Nozbe][104], [OnlyOffice][88], [OpenProject][78], [osTicket][106], [Overv][90], [PagerDuty][110], [Phabricator][77], [Pivotal Tracker][3], [Planbox][58], [Podio][11], [Producteev][14], [RallyDev][108], [Redbooth][10], [Redmine][18], [Remember The Milk][71], [Rindle][83], [Salesforce][50], [SherpaDesk][86], [Slack][60], [SmartBoard][76], [SourceLair][70], [Spidergap][109], [Sprintly][38], [Stifer][16], [Taiga][30], [TargetProcess][74], [Teamleader][94], [TeamWeek][2], [Teamwork.com][28], [TestRail][40], [TickTick][84], [Todoist][24], [Toodledo][27], [Trac][25], [Trello][8], [Unfuddle][6], [VisualStudioOnline (TFS)][75], [Waffle][47], [Wordpress][56], [Workfront][87], [Worksection][9], [Wrike][45], [Wunderlist][26], [Xero][21], [YouTrack][19], [Zendesk][22], [Zoho Books][59], [Zube][79] account and start your Toggl timer there.
 
 _See this article for reference where the start timer link is located in all the tools: [Where can I find the Button?][100]_
 
@@ -261,3 +262,4 @@ Don't know how to start? Just check out the [user requested services][98] that h
 [107]: https://www.codebasehq.com/
 [108]: https://rally1.rallydev.com/
 [109]: https://www.spidergap.com/
+[110]: https://www.pagerduty.com/

--- a/src/scripts/content/pagerduty.js
+++ b/src/scripts/content/pagerduty.js
@@ -1,0 +1,20 @@
+/*jslint indent: 2 */
+/*global $: false, togglbutton: false, createTag: false*/
+
+'use strict';
+
+togglbutton.render('.pd-incident-actions:not(.toggl)', {observe: true}, function () {
+  /*jslint browser:true */
+  var link, description,
+    projectElem = $('.pd-service-name__name a');
+
+  description = document.title.replace(/\[#(\d*)\]([\w\W]*) - PagerDuty/g, 'Pagerduty $1:$2');
+
+  link = togglbutton.createTimerLink({
+    className: 'pagerduty',
+    description: description,
+    projectName: projectElem && projectElem.textContent
+  });
+
+  $('.pd-incident-actions').appendChild(link);
+});

--- a/src/scripts/origins.json
+++ b/src/scripts/origins.json
@@ -286,6 +286,10 @@
     "name": "osTicket",
     "file": "osticket.js"
   },
+  "pagerduty.com": {
+    "url": "*://*.pagerduty.com/*",
+    "name": "PagerDuty"
+  },
   "phacility.com": {
     "url": "*://*.phacility.com/*",
     "name": "Phabricator"

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1295,3 +1295,8 @@ a.toggl-button.workfront.min {
 .nav-tabs .toggl-button {
   margin: 5px 0 0 60px;
 }
+
+/********* Pagerduty *********/
+.toggl-button.pagerduty {
+  margin-left: 9px;
+}


### PR DESCRIPTION
This adds a Toggl button inside the Incidents in [PagerDuty](https://www.pagerduty.com/).

The button is added to the right side column with the rest of the actions available for an incident. I attach a screenshot showing the placement of the button.

![pagerduty](https://user-images.githubusercontent.com/183745/30450059-5727224a-9956-11e7-9ef5-22663852c794.png)
