### PR TITLE
Fix for nested projects (GitLab 10.x)

### DIFF
--- a/src/scripts/content/gitlab.js
+++ b/src/scripts/content/gitlab.js
@@ -7,7 +7,7 @@ togglbutton.render('.issue-details .detail-page-description:not(.toggl)', {obser
   var link, description,
     numElem = $(".breadcrumbs-list li:last-child .breadcrumbs-sub-title"),
     titleElem = $(".title", elem),
-    projectElem = $(".breadcrumbs-list li:nth-child(2) .breadcrumb-item-text");
+    projectElem = $(".breadcrumbs-list li:nth-last-child(3) .breadcrumb-item-text")
   description = titleElem.textContent.trim();
 
   if (numElem !== null) {
@@ -27,7 +27,7 @@ togglbutton.render('.merge-request-details .detail-page-description:not(.toggl)'
   var link, description,
     numElem = $(".breadcrumbs-list li:last-child .breadcrumbs-sub-title"),
     titleElem = $(".title", elem),
-    projectElem = $(".breadcrumbs-list li:nth-child(2) .breadcrumb-item-text");
+    projectElem = $(".breadcrumbs-list li:nth-last-child(3) .breadcrumb-item-text")
 
   description = titleElem.textContent.trim();
   if (numElem !== null) {

--- a/src/scripts/content/gitlab.js
+++ b/src/scripts/content/gitlab.js
@@ -7,7 +7,8 @@ togglbutton.render('.issue-details .detail-page-description:not(.toggl)', {obser
   var link, description,
     numElem = $(".breadcrumbs-list li:last-child .breadcrumbs-sub-title"),
     titleElem = $(".title", elem),
-    projectElem = $(".breadcrumbs-list li:nth-last-child(3) .breadcrumb-item-text")
+    projectElem = $(".breadcrumbs-list li:nth-last-child(3) .breadcrumb-item-text");
+
   description = titleElem.textContent.trim();
 
   if (numElem !== null) {
@@ -27,9 +28,10 @@ togglbutton.render('.merge-request-details .detail-page-description:not(.toggl)'
   var link, description,
     numElem = $(".breadcrumbs-list li:last-child .breadcrumbs-sub-title"),
     titleElem = $(".title", elem),
-    projectElem = $(".breadcrumbs-list li:nth-last-child(3) .breadcrumb-item-text")
+    projectElem = $(".breadcrumbs-list li:nth-last-child(3) .breadcrumb-item-text");
 
   description = titleElem.textContent.trim();
+
   if (numElem !== null) {
     description = "MR" + numElem.textContent.trim().replace("!", "") + "::" + description;
   }


### PR DESCRIPTION
When you have a project that is nested under a sub-group, the way that the project is selected via the breadcrumbs breaks.

In this PR, we select the correct item in the breadcrumb list by selecting from the end, rather than the start of the breadcrumb list. That way, we always select the project as it's always the third last item when looking at an issue. (Project -> "Issues" or "Merge Request" -> Issue or Merge Request #).