### PR TITLE
add integration for ClickUp

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Add Toggl one-click time tracking to popular web tools.
   - [Breeze][42]
   - [Bugzilla][41]
   - [CapsuleCRM][20]
+  - [ClickUp][112]
   - [Cloudes][63]
   - [Clubhouse][91]
   - [Codeable][48]
@@ -131,7 +132,7 @@ List of all the changes and added features can be found at http://toggl.github.i
 
 ## Using the Button
 1.  Log in to your [Toggl][1] account from the extension popup.
-2.  Go to your [AgenoCRM][81], [Any.do][23], [Asana][5], [Assembla][46], [Axosoft][32], [Backlog.jp][96], [BamBam][43], [Basecamp][12], [Bitbucket][15], [Bitrix24][82], [Breeze][42], [Bugzilla][41], [CapsuleCRM][20], [Cloudes.me][63], [Clubhouse][91], [Codeable][48], [Codebase][107], [Countersoft Gemini][33], [Desk.com][92], [DevDocs][68], [Doit.im][61], [DokuWiki][105], [Draftin][51], [Drupal][34], [eProject.me][64], [Esa][35], [Eventum][49], [Evernote][72], [Exana][85], [Feedly][93], [Flow][37], [FogBugz][52], [Freshdesk][65], [Gingko][54], [Github][4], [Gitlab][7], [Gogs][67], [Google Calendar][39], [Google Docs][17], [Google Inbox][55], [Google Keep][53], [Google Mail][29], [GQueue][44], [HabitRPG][31], [Help Scout][36], [Husky Marketing Planner][103], [Intercom][95], [JIRA][13], [Kanbanery][57], [KhanAcademy][102], [LiquidPlanner][69], [MantisHub][73], [MeisterTask][89], [miniCRM.pl][80], [Newsletter2Go][66], [Nozbe][104], [OnlyOffice][88], [OpenProject][78], [osTicket][106], [Overv][90], [PagerDuty][110], [Phabricator][77], [Pivotal Tracker][3], [Planbox][58], [Podio][11], [Producteev][14], [RallyDev][108], [Redbooth][10], [Redmine][18], [Remember The Milk][71], [Rindle][83], [Rollbar][111], [Salesforce][50], [SherpaDesk][86], [Slack][60], [SmartBoard][76], [SourceLair][70], [Spidergap][109], [Sprintly][38], [Stifer][16], [Taiga][30], [TargetProcess][74], [Teamleader][94], [TeamWeek][2], [Teamwork.com][28], [TestRail][40], [TickTick][84], [Todoist][24], [Toodledo][27], [Trac][25], [Trello][8], [Unfuddle][6], [VisualStudioOnline (TFS)][75], [Waffle][47], [Wordpress][56], [Workfront][87], [Worksection][9], [Wrike][45], [Wunderlist][26], [Xero][21], [YouTrack][19], [Zendesk][22], [Zoho Books][59], [Zube][79] account and start your Toggl timer there.
+2.  Go to your [AgenoCRM][81], [Any.do][23], [Asana][5], [Assembla][46], [Axosoft][32], [Backlog.jp][96], [BamBam][43], [Basecamp][12], [Bitbucket][15], [Bitrix24][82], [Breeze][42], [Bugzilla][41], [CapsuleCRM][20], [ClickUp][112], [Cloudes.me][63], [Clubhouse][91], [Codeable][48], [Codebase][107], [Countersoft Gemini][33], [Desk.com][92], [DevDocs][68], [Doit.im][61], [DokuWiki][105], [Draftin][51], [Drupal][34], [eProject.me][64], [Esa][35], [Eventum][49], [Evernote][72], [Exana][85], [Feedly][93], [Flow][37], [FogBugz][52], [Freshdesk][65], [Gingko][54], [Github][4], [Gitlab][7], [Gogs][67], [Google Calendar][39], [Google Docs][17], [Google Inbox][55], [Google Keep][53], [Google Mail][29], [GQueue][44], [HabitRPG][31], [Help Scout][36], [Husky Marketing Planner][103], [Intercom][95], [JIRA][13], [Kanbanery][57], [KhanAcademy][102], [LiquidPlanner][69], [MantisHub][73], [MeisterTask][89], [miniCRM.pl][80], [Newsletter2Go][66], [Nozbe][104], [OnlyOffice][88], [OpenProject][78], [osTicket][106], [Overv][90], [PagerDuty][110], [Phabricator][77], [Pivotal Tracker][3], [Planbox][58], [Podio][11], [Producteev][14], [RallyDev][108], [Redbooth][10], [Redmine][18], [Remember The Milk][71], [Rindle][83], [Rollbar][111], [Salesforce][50], [SherpaDesk][86], [Slack][60], [SmartBoard][76], [SourceLair][70], [Spidergap][109], [Sprintly][38], [Stifer][16], [Taiga][30], [TargetProcess][74], [Teamleader][94], [TeamWeek][2], [Teamwork.com][28], [TestRail][40], [TickTick][84], [Todoist][24], [Toodledo][27], [Trac][25], [Trello][8], [Unfuddle][6], [VisualStudioOnline (TFS)][75], [Waffle][47], [Wordpress][56], [Workfront][87], [Worksection][9], [Wrike][45], [Wunderlist][26], [Xero][21], [YouTrack][19], [Zendesk][22], [Zoho Books][59], [Zube][79] account and start your Toggl timer there.
 
 _See this article for reference where the start timer link is located in all the tools: [Where can I find the Button?][100]_
 
@@ -265,3 +266,4 @@ Don't know how to start? Just check out the [user requested services][98] that h
 [109]: https://www.spidergap.com/
 [110]: https://www.pagerduty.com/
 [111]: https://rollbar.com/
+[112]: https://clickup.com/

--- a/src/scripts/content/clickup.js
+++ b/src/scripts/content/clickup.js
@@ -1,0 +1,19 @@
+/*jslint indent: 2, unparam: true*/
+/*global $: false, document: false, togglbutton: false, createTag: false*/
+'use strict';
+
+togglbutton.render('#timeTrackingItem:not(.toggl)', {observe: true}, function (elem) {
+
+  var link,
+    description = $('.task-name', elem).textContent,
+    project = $('.space-name', elem).textContent;
+
+  link = togglbutton.createTimerLink({
+    className: 'clickup',
+    description: description,
+    projectName: project,
+    buttonType: 'minimal'
+  });
+
+  $('.toggl-container').appendChild(link);
+});

--- a/src/scripts/origins.json
+++ b/src/scripts/origins.json
@@ -68,6 +68,10 @@
     "url": "*://*.capsulecrm.com/*",
     "name": "CapsuleCRM"
   },
+  "clickup.com": {
+    "url": "*://*.clickup.com/*",
+    "name": "ClickUp"
+  },
   "cloudes.me": {
     "url": "*://*.cloudes.me/*",
     "name": "Cloudes.me"


### PR DESCRIPTION
It wasn't made totally clear to me if you need to see a live version of the Toggl button in our app, if it is then just let me know and I can get you credentials to a staging site right away.

We are implementing Toggl in our task view.  The two screenshots show Toggl started and Toggl stopped.  Please let me know if you need anything else from me.  Would like to get this integration going ASAP.  Customers have been asking for it!

![clickup toggl started](https://user-images.githubusercontent.com/1031722/31483838-e2eb42ec-aee2-11e7-9220-bba9ab2eea57.png)

![clickup toggl stopped](https://user-images.githubusercontent.com/1031722/31483846-ea76900c-aee2-11e7-956f-991268866da4.png)
