### PR TITLE
Add Protonmail integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Add Toggl one-click time tracking to popular web tools.
   - [Podio][11]
   - [ProcessWire][101]
   - [Producteev][14]
+  - [Protonmail][112]
   - [RallyDev][108]
   - [Redbooth (old UI)][10]
   - [Redmine][18]
@@ -131,7 +132,7 @@ List of all the changes and added features can be found at http://toggl.github.i
 
 ## Using the Button
 1.  Log in to your [Toggl][1] account from the extension popup.
-2.  Go to your [AgenoCRM][81], [Any.do][23], [Asana][5], [Assembla][46], [Axosoft][32], [Backlog.jp][96], [BamBam][43], [Basecamp][12], [Bitbucket][15], [Bitrix24][82], [Breeze][42], [Bugzilla][41], [CapsuleCRM][20], [Cloudes.me][63], [Clubhouse][91], [Codeable][48], [Codebase][107], [Countersoft Gemini][33], [Desk.com][92], [DevDocs][68], [Doit.im][61], [DokuWiki][105], [Draftin][51], [Drupal][34], [eProject.me][64], [Esa][35], [Eventum][49], [Evernote][72], [Exana][85], [Feedly][93], [Flow][37], [FogBugz][52], [Freshdesk][65], [Gingko][54], [Github][4], [Gitlab][7], [Gogs][67], [Google Calendar][39], [Google Docs][17], [Google Inbox][55], [Google Keep][53], [Google Mail][29], [GQueue][44], [HabitRPG][31], [Help Scout][36], [Husky Marketing Planner][103], [Intercom][95], [JIRA][13], [Kanbanery][57], [KhanAcademy][102], [LiquidPlanner][69], [MantisHub][73], [MeisterTask][89], [miniCRM.pl][80], [Newsletter2Go][66], [Nozbe][104], [OnlyOffice][88], [OpenProject][78], [osTicket][106], [Overv][90], [PagerDuty][110], [Phabricator][77], [Pivotal Tracker][3], [Planbox][58], [Podio][11], [Producteev][14], [RallyDev][108], [Redbooth][10], [Redmine][18], [Remember The Milk][71], [Rindle][83], [Rollbar][111], [Salesforce][50], [SherpaDesk][86], [Slack][60], [SmartBoard][76], [SourceLair][70], [Spidergap][109], [Sprintly][38], [Stifer][16], [Taiga][30], [TargetProcess][74], [Teamleader][94], [TeamWeek][2], [Teamwork.com][28], [TestRail][40], [TickTick][84], [Todoist][24], [Toodledo][27], [Trac][25], [Trello][8], [Unfuddle][6], [VisualStudioOnline (TFS)][75], [Waffle][47], [Wordpress][56], [Workfront][87], [Worksection][9], [Wrike][45], [Wunderlist][26], [Xero][21], [YouTrack][19], [Zendesk][22], [Zoho Books][59], [Zube][79] account and start your Toggl timer there.
+2.  Go to your [AgenoCRM][81], [Any.do][23], [Asana][5], [Assembla][46], [Axosoft][32], [Backlog.jp][96], [BamBam][43], [Basecamp][12], [Bitbucket][15], [Bitrix24][82], [Breeze][42], [Bugzilla][41], [CapsuleCRM][20], [Cloudes.me][63], [Clubhouse][91], [Codeable][48], [Codebase][107], [Countersoft Gemini][33], [Desk.com][92], [DevDocs][68], [Doit.im][61], [DokuWiki][105], [Draftin][51], [Drupal][34], [eProject.me][64], [Esa][35], [Eventum][49], [Evernote][72], [Exana][85], [Feedly][93], [Flow][37], [FogBugz][52], [Freshdesk][65], [Gingko][54], [Github][4], [Gitlab][7], [Gogs][67], [Google Calendar][39], [Google Docs][17], [Google Inbox][55], [Google Keep][53], [Google Mail][29], [GQueue][44], [HabitRPG][31], [Help Scout][36], [Husky Marketing Planner][103], [Intercom][95], [JIRA][13], [Kanbanery][57], [KhanAcademy][102], [LiquidPlanner][69], [MantisHub][73], [MeisterTask][89], [miniCRM.pl][80], [Newsletter2Go][66], [Nozbe][104], [OnlyOffice][88], [OpenProject][78], [osTicket][106], [Overv][90], [PagerDuty][110], [Phabricator][77], [Pivotal Tracker][3], [Planbox][58], [Podio][11], [Producteev][14], [Protonmail][112], [RallyDev][108], [Redbooth][10], [Redmine][18], [Remember The Milk][71], [Rindle][83], [Rollbar][111], [Salesforce][50], [SherpaDesk][86], [Slack][60], [SmartBoard][76], [SourceLair][70], [Spidergap][109], [Sprintly][38], [Stifer][16], [Taiga][30], [TargetProcess][74], [Teamleader][94], [TeamWeek][2], [Teamwork.com][28], [TestRail][40], [TickTick][84], [Todoist][24], [Toodledo][27], [Trac][25], [Trello][8], [Unfuddle][6], [VisualStudioOnline (TFS)][75], [Waffle][47], [Wordpress][56], [Workfront][87], [Worksection][9], [Wrike][45], [Wunderlist][26], [Xero][21], [YouTrack][19], [Zendesk][22], [Zoho Books][59], [Zube][79] account and start your Toggl timer there.
 
 _See this article for reference where the start timer link is located in all the tools: [Where can I find the Button?][100]_
 
@@ -265,3 +266,4 @@ Don't know how to start? Just check out the [user requested services][98] that h
 [109]: https://www.spidergap.com/
 [110]: https://www.pagerduty.com/
 [111]: https://rollbar.com/
+[112]: https://protonmail.com/

--- a/src/scripts/content/protonmail.js
+++ b/src/scripts/content/protonmail.js
@@ -1,0 +1,26 @@
+/*jslint indent: 2 */
+/*global $: false, document: false, togglbutton: false*/
+"use strict";
+
+togglbutton.render('#conversationHeader:not(.toggl)', {observe: true}, function () {
+  var link, len, description,
+    spans = document.getElementsByTagName('h1')[0].getElementsByTagName('span'),
+    project = $('li.active'),
+    container = $('#conversationHeader h1');
+
+  len = spans.length;
+
+  if (len > 1) {
+    description = $('h1 span:nth-child(2)');
+  } else {
+    description = $('h1 span');
+  }
+
+  link = togglbutton.createTimerLink({
+    className: 'protonmail',
+    description: description.textContent,
+    projectName: project.textContent.trim()
+  });
+
+  container.appendChild(link);
+});

--- a/src/scripts/origins.json
+++ b/src/scripts/origins.json
@@ -314,6 +314,10 @@
     "url": "*://*.producteev.com/*",
     "name": "Producteev"
   },
+  "protonmail.com": {
+    "url": "*://*.protonmail.com/*",
+    "name": "Protonmail"
+  },
   "proworkflow.net": {
     "url": "*://*.proworkflow.net/*",
     "name": "Proworkflow"

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1296,3 +1296,15 @@ a.toggl-button.workfront.min {
   margin-left: 30px;
   vertical-align: middle;
 }
+
+/********* PROTONMAIL *********/
+.toggl-button.protonmail {
+  margin-left: 10px;
+  font-size: 13px;
+  text-decoration: none;
+  color: rgb(85, 85, 85);
+}
+
+.toggl-button.protonmail:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
This PR adds Toggl button integration for [Protonmail](https://protonmail.com).

- Matches the email subject as description & email category as project name

![protonmail_toggl](https://user-images.githubusercontent.com/17750543/31527830-a7e36dd6-aff1-11e7-9137-b5e3e3d807f6.jpg)

Passed `make lint`.