### PR TITLE
Adds Airtable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Add Toggl one-click time tracking to popular web tools.
 
 ## Compatible services
   - [AgenoCRM][81]
+  - [Airtable][112]
   - [Any.do][23]
   - [Asana][5]
   - [Assembla][46]
@@ -265,3 +266,4 @@ Don't know how to start? Just check out the [user requested services][98] that h
 [109]: https://www.spidergap.com/
 [110]: https://www.pagerduty.com/
 [111]: https://rollbar.com/
+[112]: https://airtable.com

--- a/src/scripts/content/airtable.js
+++ b/src/scripts/content/airtable.js
@@ -1,0 +1,22 @@
+/*jslint indent: 2 */
+/*global $: false, document: false, togglbutton: false*/
+
+'use strict';
+
+togglbutton.render('.detailViewWithActivityFeedBase .dialog > .header > .flex-auto:not(.toggl)', {observe: true}, function (elem) {
+
+  var link, descFunc,
+    container = $('.justify-center > .relative', elem),
+    description = $('.truncate.flex-auto.line-height-3', elem);
+
+  descFunc = function () {
+    return !!description ? description.innerText : "";
+  };
+
+  link = togglbutton.createTimerLink({
+    className: 'airtable',
+    description: descFunc
+  });
+
+  container.appendChild(link);
+});

--- a/src/scripts/origins.json
+++ b/src/scripts/origins.json
@@ -4,6 +4,10 @@
     "name": "AgenoCRM",
     "file": "minicrm.js"
   },
+  "airtable.com": {
+    "url": "*://airtable.com/*",
+    "name": "Airtable"
+  },
   "any.do": {
     "url": "*://web.any.do/*",
     "name": "Anydo"

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1296,3 +1296,8 @@ a.toggl-button.workfront.min {
   margin-left: 30px;
   vertical-align: middle;
 }
+
+/********* AIRTABLE ********/
+.toggl-button.airtable {
+  margin-left: 30px;
+}


### PR DESCRIPTION
This PR adds support for airtable.com. As it is almost impossible to guess tags or projects from an airtable dataset the integration only uses the datasets identifier as the description.

![toggl-button_airtable](https://user-images.githubusercontent.com/359399/31563592-0882a80a-b060-11e7-84a4-55c785677335.png)
