### PR TITLE
Added support for the new Google Calendar Modern UI

### DIFF
--- a/src/scripts/content/google-calendar.js
+++ b/src/scripts/content/google-calendar.js
@@ -58,3 +58,28 @@ var observer = new MutationObserver(function (mutations) {
 });
 
 observer.observe($('body'), { childList: true, subtree: true });
+
+//Google Calendar Modern
+
+function insertButtonModern(bubblecontent, description) {
+  var link = togglbutton.createTimerLink({
+    className: 'google-calendar-modern',
+    description: description
+  });
+  bubblecontent.appendChild(link);
+}
+
+// Popup view Google Calendar Modern
+togglbutton.render('div[data-chips-dialog="true"]', {observe: true}, function (elem) {
+  if ($('.toggl-button', elem)) {
+    return;
+  }
+  var title = $('span[role="heading"]', elem), target = elem, description;
+  if (title) {
+    description = title.textContent;
+    target = title.parentElement.previousSibling;
+  }
+  if (description) {
+    insertButtonModern(target, description);
+  }
+});

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -871,7 +871,12 @@ only screen and (min-resolution: 192dpi) {
 .toggl-button.google-calendar {
   margin-left: 30px;
   margin-bottom: 10px;
-  margin-top: -2px;;
+  margin-top: -2px;
+}
+
+.toggl-button.google-calendar-modern {
+  margin-top: auto;
+  margin-bottom: auto;
 }
 
 .bubblecontent .toggl-button.google-calendar {


### PR DESCRIPTION
This PR adds support for the new Google Calendar Modern UI and resolves #919.
The Toggl Button is placed in the popup after clicking on an event, next to the delete, menu and close buttons.
![image](https://user-images.githubusercontent.com/843806/32407972-d17b098c-c190-11e7-93dc-c12a47ccb7cd.png)
