### PR TITLE
Add custom style for YouTrack agile view

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -357,6 +357,13 @@ only screen and (min-resolution: 192dpi) {
 }
 
 /********* YOUTRACK *********/
+
+.yt-agile-card__header .toggl-button.youtrack {
+  position: absolute;
+  top: 4px;
+  right: 3px;
+  float: none;
+}
 .toggl-button.youtrack {
   float: right;
 }


### PR DESCRIPTION
Using `float: right` was causing Toggl button to drop to lower line, cropping it.

Added specific rule for card in agile board, so it does not float.
![image](https://user-images.githubusercontent.com/360894/32457709-2bddd888-c311-11e7-9185-a1558f95c023.png)

Please make sure this doesn't break elsewhere in Youtrack.
