### PR TITLE
Add integration for Sentry.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Add Toggl one-click time tracking to popular web tools.
   - [Rindle][83]
   - [Rollbar][111]
   - [Salesforce][50]
+  - [Sentry][115]
   - [SherpaDesk][86]
   - [Sifter][16]
   - [Slack][60]
@@ -134,7 +135,7 @@ List of all the changes and added features can be found at http://toggl.github.i
 
 ## Using the Button
 1.  Log in to your [Toggl][1] account from the extension popup.
-2.  Go to your [AgenoCRM][81], [Any.do][23], [Asana][5], [Assembla][46], [Axosoft][32], [Backlog.jp][96], [BamBam][43], [Basecamp][12], [Bitbucket][15], [Bitrix24][82], [Breeze][42], [Bugzilla][41], [CapsuleCRM][20], [ClickUp][112], [Cloudes.me][63], [Clubhouse][91], [Codeable][48], [Codebase][107], [Countersoft Gemini][33], [Desk.com][92], [DevDocs][68], [Doit.im][61], [DokuWiki][105], [Draftin][51], [Drupal][34], [eProject.me][64], [Esa][35], [Eventum][49], [Evernote][72], [Exana][85], [Feedly][93], [Flow][37], [FogBugz][52], [Freshdesk][65], [Gingko][54], [Github][4], [Gitlab][7], [Gogs][67], [Google Calendar][39], [Google Docs][17], [Google Inbox][55], [Google Keep][53], [Google Mail][29], [GQueue][44], [HabitRPG][31], [Help Scout][36], [Husky Marketing Planner][103], [Intercom][95], [JIRA][13], [Kanbanery][57], [KhanAcademy][102], [LiquidPlanner][69], [MantisHub][73], [MeisterTask][89], [miniCRM.pl][80], [Newsletter2Go][66], [Nozbe][104], [OnlyOffice][88], [OpenProject][78], [osTicket][106], [Overv][90], [PagerDuty][110], [Phabricator][77], [Pivotal Tracker][3], [Planbox][58], [Podio][11], [Producteev][14], [Protonmail][113], [RallyDev][108], [Redbooth][10], [Redmine][18], [Remember The Milk][71], [Rindle][83], [Rollbar][111], [Salesforce][50], [SherpaDesk][86], [Slack][60], [SmartBoard][76], [SourceLair][70], [Spidergap][109], [Sprintly][38], [Stifer][16], [Taiga][30], [TargetProcess][74], [Teamleader][94], [TeamWeek][2], [Teamwork.com][28], [TestRail][40], [TickTick][84], [Todoist][24], [Toodledo][27], [Trac][25], [Trello][8], [Unfuddle][6], [VisualStudioOnline (TFS)][75], [Waffle][47], [Wordpress][56], [Workfront][87], [Worksection][9], [Wrike][45], [Wunderlist][26], [Xero][21], [YouTrack][19], [Zendesk][22], [Zoho Books][59], [Zube][79] account and start your Toggl timer there.
+2.  Go to your [AgenoCRM][81], [Any.do][23], [Asana][5], [Assembla][46], [Axosoft][32], [Backlog.jp][96], [BamBam][43], [Basecamp][12], [Bitbucket][15], [Bitrix24][82], [Breeze][42], [Bugzilla][41], [CapsuleCRM][20], [ClickUp][112], [Cloudes.me][63], [Clubhouse][91], [Codeable][48], [Codebase][107], [Countersoft Gemini][33], [Desk.com][92], [DevDocs][68], [Doit.im][61], [DokuWiki][105], [Draftin][51], [Drupal][34], [eProject.me][64], [Esa][35], [Eventum][49], [Evernote][72], [Exana][85], [Feedly][93], [Flow][37], [FogBugz][52], [Freshdesk][65], [Gingko][54], [Github][4], [Gitlab][7], [Gogs][67], [Google Calendar][39], [Google Docs][17], [Google Inbox][55], [Google Keep][53], [Google Mail][29], [GQueue][44], [HabitRPG][31], [Help Scout][36], [Husky Marketing Planner][103], [Intercom][95], [JIRA][13], [Kanbanery][57], [KhanAcademy][102], [LiquidPlanner][69], [MantisHub][73], [MeisterTask][89], [miniCRM.pl][80], [Newsletter2Go][66], [Nozbe][104], [OnlyOffice][88], [OpenProject][78], [osTicket][106], [Overv][90], [PagerDuty][110], [Phabricator][77], [Pivotal Tracker][3], [Planbox][58], [Podio][11], [Producteev][14], [Protonmail][113], [RallyDev][108], [Redbooth][10], [Redmine][18], [Remember The Milk][71], [Rindle][83], [Rollbar][111], [Salesforce][50], [Sentry][115], [SherpaDesk][86], [Slack][60], [SmartBoard][76], [SourceLair][70], [Spidergap][109], [Sprintly][38], [Stifer][16], [Taiga][30], [TargetProcess][74], [Teamleader][94], [TeamWeek][2], [Teamwork.com][28], [TestRail][40], [TickTick][84], [Todoist][24], [Toodledo][27], [Trac][25], [Trello][8], [Unfuddle][6], [VisualStudioOnline (TFS)][75], [Waffle][47], [Wordpress][56], [Workfront][87], [Worksection][9], [Wrike][45], [Wunderlist][26], [Xero][21], [YouTrack][19], [Zendesk][22], [Zoho Books][59], [Zube][79] account and start your Toggl timer there.
 
 _See this article for reference where the start timer link is located in all the tools: [Where can I find the Button?][100]_
 
@@ -271,3 +272,4 @@ Don't know how to start? Just check out the [user requested services][98] that h
 [112]: https://clickup.com/
 [113]: https://protonmail.com/
 [114]: https://airtable.com
+[115]: https://sentry.io/

--- a/src/scripts/content/sentry.js
+++ b/src/scripts/content/sentry.js
@@ -1,0 +1,21 @@
+/*jslint indent: 2 */
+/*global $: false, document: false, togglbutton: false*/
+'use strict';
+
+togglbutton.render('.group-detail:not(.toggl)', {observe: true}, function () {
+  var link,
+    description,
+    errType = $('h3 > span > span').textContent.trim(),
+    detail = $('.message').textContent.trim(),
+    project = $('.project-name').textContent.trim();
+
+  description = errType + ': ' + detail;
+
+  link = togglbutton.createTimerLink({
+    className: 'sentry',
+    description: description,
+    projectName: project
+  });
+
+  $('.group-detail .nav-tabs').appendChild(link);
+});

--- a/src/scripts/origins.json
+++ b/src/scripts/origins.json
@@ -388,6 +388,10 @@
     "name": "Salesforce Lightning",
     "file": "salesforce.js"
   },
+  "sentry.io": {
+    "url": "*://*.sentry.io/*",
+    "name": "Sentry"
+  },
   "sifterapp.com": {
     "url": "*://*.sifterapp.com/*",
     "name": "Sifterapp"

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1315,3 +1315,8 @@ a.toggl-button.workfront.min {
 .toggl-button.protonmail:hover {
   text-decoration: underline;
 }
+
+/********* SENTRY *********/
+.toggl-button.sentry {
+  margin: 0 auto 20px 10px;
+}


### PR DESCRIPTION
This PR adds Toggl button integration for [Sentry](https://sentry.io/).

- Matches the error type & detail as description 

![sentry_image](https://user-images.githubusercontent.com/17750543/32669317-476167d0-c66a-11e7-81b2-2e212ca92804.png)