### PR TITLE
Add HEFLO integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Add Toggl one-click time tracking to popular web tools.
   - [Google Mail][29]
   - [GQueue][44]
   - [HabitRPG][31]
+  - [HEFLO][116]
   - [Help Scout][36]
   - [Husky Marketing Planner][103]
   - [Intercom][95]
@@ -135,7 +136,7 @@ List of all the changes and added features can be found at http://toggl.github.i
 
 ## Using the Button
 1.  Log in to your [Toggl][1] account from the extension popup.
-2.  Go to your [AgenoCRM][81], [Any.do][23], [Asana][5], [Assembla][46], [Axosoft][32], [Backlog.jp][96], [BamBam][43], [Basecamp][12], [Bitbucket][15], [Bitrix24][82], [Breeze][42], [Bugzilla][41], [CapsuleCRM][20], [ClickUp][112], [Cloudes.me][63], [Clubhouse][91], [Codeable][48], [Codebase][107], [Countersoft Gemini][33], [Desk.com][92], [DevDocs][68], [Doit.im][61], [DokuWiki][105], [Draftin][51], [Drupal][34], [eProject.me][64], [Esa][35], [Eventum][49], [Evernote][72], [Exana][85], [Feedly][93], [Flow][37], [FogBugz][52], [Freshdesk][65], [Gingko][54], [Github][4], [Gitlab][7], [Gogs][67], [Google Calendar][39], [Google Docs][17], [Google Inbox][55], [Google Keep][53], [Google Mail][29], [GQueue][44], [HabitRPG][31], [Help Scout][36], [Husky Marketing Planner][103], [Intercom][95], [JIRA][13], [Kanbanery][57], [KhanAcademy][102], [LiquidPlanner][69], [MantisHub][73], [MeisterTask][89], [miniCRM.pl][80], [Newsletter2Go][66], [Nozbe][104], [OnlyOffice][88], [Onshape][115], [OpenProject][78], [osTicket][106], [Overv][90], [PagerDuty][110], [Phabricator][77], [Pivotal Tracker][3], [Planbox][58], [Podio][11], [Producteev][14], [Protonmail][113], [RallyDev][108], [Redbooth][10], [Redmine][18], [Remember The Milk][71], [Rindle][83], [Rollbar][111], [Salesforce][50], [SherpaDesk][86], [Slack][60], [SmartBoard][76], [SourceLair][70], [Spidergap][109], [Sprintly][38], [Stifer][16], [Taiga][30], [TargetProcess][74], [Teamleader][94], [TeamWeek][2], [Teamwork.com][28], [TestRail][40], [TickTick][84], [Todoist][24], [Toodledo][27], [Trac][25], [Trello][8], [Unfuddle][6], [VisualStudioOnline (TFS)][75], [Waffle][47], [Wordpress][56], [Workfront][87], [Worksection][9], [Wrike][45], [Wunderlist][26], [Xero][21], [YouTrack][19], [Zendesk][22], [Zoho Books][59], [Zube][79] account and start your Toggl timer there.
+2.  Go to your [AgenoCRM][81], [Any.do][23], [Asana][5], [Assembla][46], [Axosoft][32], [Backlog.jp][96], [BamBam][43], [Basecamp][12], [Bitbucket][15], [Bitrix24][82], [Breeze][42], [Bugzilla][41], [CapsuleCRM][20], [ClickUp][112], [Cloudes.me][63], [Clubhouse][91], [Codeable][48], [Codebase][107], [Countersoft Gemini][33], [Desk.com][92], [DevDocs][68], [Doit.im][61], [DokuWiki][105], [Draftin][51], [Drupal][34], [eProject.me][64], [Esa][35], [Eventum][49], [Evernote][72], [Exana][85], [Feedly][93], [Flow][37], [FogBugz][52], [Freshdesk][65], [Gingko][54], [Github][4], [Gitlab][7], [Gogs][67], [Google Calendar][39], [Google Docs][17], [Google Inbox][55], [Google Keep][53], [Google Mail][29], [GQueue][44], [HabitRPG][31], [HEFLO][116], [Help Scout][36], [Husky Marketing Planner][103], [Intercom][95], [JIRA][13], [Kanbanery][57], [KhanAcademy][102], [LiquidPlanner][69], [MantisHub][73], [MeisterTask][89], [miniCRM.pl][80], [Newsletter2Go][66], [Nozbe][104], [OnlyOffice][88], [Onshape][115], [OpenProject][78], [osTicket][106], [Overv][90], [PagerDuty][110], [Phabricator][77], [Pivotal Tracker][3], [Planbox][58], [Podio][11], [Producteev][14], [Protonmail][113], [RallyDev][108], [Redbooth][10], [Redmine][18], [Remember The Milk][71], [Rindle][83], [Rollbar][111], [Salesforce][50], [SherpaDesk][86], [Slack][60], [SmartBoard][76], [SourceLair][70], [Spidergap][109], [Sprintly][38], [Stifer][16], [Taiga][30], [TargetProcess][74], [Teamleader][94], [TeamWeek][2], [Teamwork.com][28], [TestRail][40], [TickTick][84], [Todoist][24], [Toodledo][27], [Trac][25], [Trello][8], [Unfuddle][6], [VisualStudioOnline (TFS)][75], [Waffle][47], [Wordpress][56], [Workfront][87], [Worksection][9], [Wrike][45], [Wunderlist][26], [Xero][21], [YouTrack][19], [Zendesk][22], [Zoho Books][59], [Zube][79] account and start your Toggl timer there.
 
 _See this article for reference where the start timer link is located in all the tools: [Where can I find the Button?][100]_
 
@@ -273,4 +274,5 @@ Don't know how to start? Just check out the [user requested services][98] that h
 [113]: https://protonmail.com/
 [114]: https://airtable.com
 [115]: https://onshape.com/
+[116]: https://app.heflo.com/
 >>>>>>> 6dfeb4f9cf1936c0e0b3c4e70131aeea560a704f

--- a/src/scripts/content/heflo.js
+++ b/src/scripts/content/heflo.js
@@ -1,0 +1,49 @@
+/*jslint indent: 2 */
+/*global $: false, document: false, togglbutton: false, window: false*/
+'use strict';
+
+/*workitems / tasks view */
+togglbutton.render('.edit-container:not(.toggl)', {observe: true}, function (elem) {
+  var link,
+    titleEl = $('.header-title-container', elem),
+    number = $('.token-number', titleEl).textContent,
+    subject = $('.vk-editableText span', titleEl).textContent,
+    descriptionFunc = function () {
+      var task = $('.first-panel .vk-accordion-title', elem),
+        taskText = task ? " - " + task.textContent : "",
+        description = number + subject + taskText;
+
+      return description;
+    },
+    project = $('#miAppsPopover').textContent;
+
+  link = togglbutton.createTimerLink({
+    className: 'heflo',
+    description: descriptionFunc,
+    projectName: project
+  });
+
+  $('.header-btn-container', elem).appendChild(link);
+});
+
+/*process editor view */
+togglbutton.render('.vk-mainDiagram:not(.toggl)', {observe: true}, function () {
+  var link,
+    liTag = document.createElement("li"),
+    descriptionFunc = function () {
+      return window.document.title;
+    },
+    project = $('#miAppsPopover').textContent,
+    lastEl = $('.navbar-nav');
+
+  liTag.className = "navbar-right toggl-container";
+
+  link = togglbutton.createTimerLink({
+    className: 'heflo',
+    description: descriptionFunc,
+    projectName: project
+  });
+
+  liTag.appendChild(link);
+  lastEl.insertBefore(liTag, lastEl.querySelector(".navbar-save-button").nextSibling);
+});

--- a/src/scripts/origins.json
+++ b/src/scripts/origins.json
@@ -210,6 +210,10 @@
     "url": "*://habitica.com/*",
     "name": "Habitica"
   },
+  "heflo.com": {
+    "url": "*://app.heflo.com/*",
+    "name": "HEFLO"
+  },
   "helpscout.net": {
     "url": "*://secure.helpscout.net/*",
     "name": "Helpscout"

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1320,3 +1320,35 @@ a.toggl-button.workfront.min {
 .toggl-button.protonmail:hover {
   text-decoration: underline;
 }
+
+/********* HEFLO *********/
+@media (max-width: 767px) {
+  .toggl-button.heflo {
+    float: left;
+    position: absolute;
+  }
+}
+.toggl-button.heflo {
+  order: -1;
+  position: relative;
+  right: auto;
+  margin-top: 5px;
+  margin-left: 10px;
+  color: white;
+}
+
+li .toggl-button.heflo {
+  position: relative;
+  line-height: 20px !important;
+  margin: 0;
+  padding-left: 23px !important;
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
+  margin: 20px 0;
+}
+
+.toggl-container {
+  padding-left: 5px;
+  height: 60px;
+}
+


### PR DESCRIPTION
This PR adds Toggl button integration for HEFLO.

- Matches the workitem subject and current task label as description

- Matches process name and version as description on process designer

- Matches the user current application name as project

<img width="740" alt="screen shot 2017-11-15 at 03 00 02" src="https://user-images.githubusercontent.com/13373451/32820104-d563403e-c9b3-11e7-8125-8339d5830989.png">
<img width="1440" alt="screen shot 2017-11-15 at 02 53 56" src="https://user-images.githubusercontent.com/13373451/32820112-daa88cde-c9b3-11e7-9feb-c528d1f15449.png">
