### PR TITLE
Change duration input type to text

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -47,7 +47,7 @@ var TogglButton = {
       '<a class="toggl-button {service} active" href="javascript:void(0)">Stop timer</a>' +
       '<a id="toggl-button-hide">&times;</a>' +
       '<div class="toggl-button-row" id="toggl-button-duration-row">' +
-        '<input name="toggl-button-duration" tabindex="100" type="time" step="1" id="toggl-button-duration" class="toggl-button-input" value="" placeholder="00:00" autocomplete="off">' +
+        '<input name="toggl-button-duration" tabindex="100" type="text" pattern="[\\d]{2}:[\\d]{2}:[\\d]{2}" title="Please write the duration in the \'hh:mm:ss\' format." id="toggl-button-duration" class="toggl-button-input" value="" placeholder="00:00" autocomplete="off">' +
       '</div>' +
       '<div class="toggl-button-row">' +
         '<input name="toggl-button-description" tabindex="101" type="text" id="toggl-button-description" class="toggl-button-input" value="" placeholder="(no description)" autocomplete="off">' +

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -413,6 +413,9 @@ var PopUp = {
   },
 
   submitForm: function (that) {
+    if (!this.isformValid()) {
+      return
+    }
     var selected = PopUp.$projectAutocomplete.getSelected(),
       billable = !!document.querySelector(".tb-billable.tb-checked:not(.no-billable)"),
       request = {
@@ -435,6 +438,10 @@ var PopUp = {
     PopUp.sendMessage(request);
     PopUp.updateMenuTimer(request);
     PopUp.switchView(PopUp.$menuView);
+  },
+
+  isformValid: function() {
+    return !!document.querySelector('#toggl-button-edit-form form:valid')
   },
 
   addEditEvents: function () {

--- a/src/styles/popup.css
+++ b/src/styles/popup.css
@@ -632,6 +632,15 @@ hr {
   left: -8px;
 }
 
+#toggl-button-edit-form form:invalid #toggl-button-update {
+  background-color: #cccccc;
+  cursor: default;
+}
+
+#toggl-button-edit-form input:invalid {
+  color: #ff3333;
+}
+
 #toggl-button-edit-form #toggl-button-hide{
   float: right;
   background: transparent;


### PR DESCRIPTION
Prevents incorrectly displaying duration on 12h locale.
Also uses `pattern` to validate input.

Can't test it because no MacOS, but I'd be impressed if it still displays "AM" with `type="text"`.
Anyway, please test... And validate the validator regex :)

Closes #879