### PR TITLE
Update bitrix24.js

### DIFF
--- a/src/scripts/content/bitrix24.js
+++ b/src/scripts/content/bitrix24.js
@@ -3,10 +3,10 @@
 
 'use strict';
 
-togglbutton.render('#task-view-buttons.start:not(.toggl)', {observe: true}, function (elem) {
+togglbutton.render('.task-view-buttonset:not(.toggl)', {observe: true}, function (elem) {
 
   var link, descFunc,
-    description = $('.task-detail-header-title'),
+    description = $('#pagetitle'),
     project = $('.task-group-field-label').textContent;
 
   descFunc = function () {


### PR DESCRIPTION
Bitrix24 must have changed since the last commit. Currently, the toggl button no longer displays. I updated the selectors to work with the new layout.