### PR TITLE
Fixed 'Start timer' link for Basecamp 3 todo view, closes #940

### DIFF
--- a/src/scripts/content/basecamp.js
+++ b/src/scripts/content/basecamp.js
@@ -64,24 +64,14 @@ togglbutton.render('.items_wrapper .item > .content:not(.toggl)', {observe: true
 
 // Basecamp 3
 togglbutton.render('.todos li.todo:not(.toggl):not(.completed)', {observe: true}, function (elem) {
-  var link, project, parent,
-    projectItem,
-    description = $('.checkbox__content', elem);
+  var link, project,
+    description,
+    parent = $('.checkbox__content', elem);
 
-  if (!description) {
-    return;
-  }
 
-  parent = $('.todo_assignee', elem);
-
-  if (!parent) {
-    return;
-  }
-
-  description = description.childNodes[1].textContent;
-  project = $('.checkbox__content', elem).parentNode.parentNode.parentNode.parentNode.parentNode;
-  projectItem = $('.todolist__permalink', project);
-  project = projectItem ? projectItem.textContent : "";
+  description = parent.childNodes[1].textContent.trim();
+  project = $('#a-breadcrumb-menu-button');
+  project = project ? project.textContent : "";
 
   link = togglbutton.createTimerLink({
     className: 'basecamp3',

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -475,11 +475,21 @@ only screen and (min-resolution: 192dpi) {
   display: inline;
   position: absolute;
   opacity: 0;
-  margin-left: 140px;
+  margin-top: 2px;
+  margin-left: 6px;
+  white-space: nowrap;
+}
+
+.todo__unassigned-unscheduled + .toggl-button.basecamp3 {
+  margin-left: 90px;
 }
 
 .todo:not(.selected):hover .toggl-button.basecamp3 {
   opacity: 1;
+}
+
+.card-grid .toggl-button.basecamp3 {
+  opacity: 0 !important;
 }
 
 /********* TEAMWEEK *********/

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -469,6 +469,19 @@ only screen and (min-resolution: 192dpi) {
   visibility: visible !important;
 }
 
+/********* BASECAMP 3 *********/
+.todo .toggl-button.basecamp3 {
+  transition: opacity 150ms ease;
+  display: inline;
+  position: absolute;
+  opacity: 0;
+  margin-left: 140px;
+}
+
+.todo:not(.selected):hover .toggl-button.basecamp3 {
+  opacity: 1;
+}
+
 /********* TEAMWEEK *********/
 .toggl-button.teamweek-new {
   color: rgba(47,47,47,0.8);


### PR DESCRIPTION
Updates the selectors to fix start timer location on the todo page.

Closes #940 

Start timer link appears when hovering the todo list item.

This is what you should see:

![screen shot 2017-12-08 at 14 19 01](https://user-images.githubusercontent.com/842229/33765712-d5748d54-dc22-11e7-9a3e-ade356bd185b.png)
