### PR TITLE
Add day/week total duration text to popup

### DIFF
--- a/src/html/popup.html
+++ b/src/html/popup.html
@@ -27,8 +27,8 @@
           <div class="resume-button" data-event="resume">Continue latest</div>
         </li>
         <li class="summary">
-          <div class="s-today">Today: <span>1h 20min</span></div>
-          <div class="s-week">This Week: <span>8h 30m</span></div>
+          <div class="s-today">Today: <span>0h 00min</span></div>
+          <div class="s-week">This Week: <span>0h 00m</span></div>
         </li>
         <li class="entries-list"></li>
       </ul>

--- a/src/html/popup.html
+++ b/src/html/popup.html
@@ -26,6 +26,10 @@
           <div class="stop-button">Stop</div>
           <div class="resume-button" data-event="resume">Continue latest</div>
         </li>
+        <li class="summary">
+          <div class="s-today">Today: <span>1h 20min</span></div>
+          <div class="s-week">This Week: <span>8h 30m</span></div>
+        </li>
         <li class="entries-list"></li>
       </ul>
 

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -1,5 +1,5 @@
 /*jslint indent: 2, unparam: true, plusplus: true, nomen: true */
-/*global debug: true, console: false, report: true, escapeHtml: true, GA: false, window: false, setTimeout: false, clearTimeout: false, setInterval: false, clearInterval: false, Db: false, XMLHttpRequest: false, Image: false, WebSocket: false, navigator: false, chrome: false, btoa: false, localStorage:false, document: false, Audio: false, Bugsnag: false */
+/*global secToHHMM: true, debug: true, console: false, report: true, escapeHtml: true, GA: false, window: false, setTimeout: false, clearTimeout: false, setInterval: false, clearInterval: false, Db: false, XMLHttpRequest: false, Image: false, WebSocket: false, navigator: false, chrome: false, btoa: false, localStorage:false, document: false, Audio: false, Bugsnag: false */
 "use strict";
 
 var openWindowsCount = 0,
@@ -1400,6 +1400,59 @@ var TogglButton = {
     if (!!popup && popup.length && !!popup[0].PopUp) {
       popup[0].PopUp.showPage();
     }
+  },
+
+  calculateSums: function () {
+    var now = new Date(),
+      today,
+      todaySum = 0,
+      weekSum = 0,
+      m = now.getMonth() + 1,
+      getWeekStart,
+      weekStart;
+
+    now.setHours(0);
+    now.setMinutes(0);
+    now.setSeconds(0);
+
+    if (m < 10) {
+      m = "0" + m;
+    }
+    today = now.getFullYear() + "-" + m + "-" + now.getDate();
+    today = "2017-08-25";
+
+    getWeekStart = function (d) {
+      var startDay = TogglButton.$user.beginning_of_week,
+        day = d.getDay(),
+        diff = d.getDate() - day + (day === 0 ? startDay - 7 : startDay);
+
+      return new Date(d.setDate(diff));
+    };
+
+    weekStart = getWeekStart(now);
+
+    TogglButton.$user.time_entries.forEach(function (entry) {
+      // Calc today total
+      if (entry.start.split("T")[0] === today) {
+        if (entry.duration < 0) {
+          todaySum += ((new Date() - new Date(entry.start)) / 1000);
+        } else {
+          todaySum += entry.duration;
+        }
+      }
+
+      // Calc week total
+      if (new Date(entry.start).getTime() > weekStart.getTime()) {
+        if (entry.duration < 0) {
+          weekSum += ((new Date() - new Date(entry.start)) / 1000);
+        } else {
+          weekSum += entry.duration;
+        }
+      }
+
+    });
+
+    return {today: secToHHMM(todaySum), week: secToHHMM(weekSum)};
   },
 
   contextMenuClick: function (info, tab) {

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -1408,6 +1408,7 @@ var TogglButton = {
       todaySum = 0,
       weekSum = 0,
       m = now.getMonth() + 1,
+      d = now.getDate(),
       getWeekStart,
       weekStart;
 
@@ -1418,8 +1419,10 @@ var TogglButton = {
     if (m < 10) {
       m = "0" + m;
     }
-    today = now.getFullYear() + "-" + m + "-" + now.getDate();
-    today = "2017-08-25";
+    if (d < 10) {
+      d = "0" + d;
+    }
+    today = now.getFullYear() + "-" + m + "-" + d;
 
     getWeekStart = function (d) {
       var startDay = TogglButton.$user.beginning_of_week,

--- a/src/scripts/lib.js
+++ b/src/scripts/lib.js
@@ -16,7 +16,8 @@ var report,
     return String(string).replace(/[&<>"'\/]/g, function (s) {
       return entityMap[s];
     });
-  };
+  },
+  secToHHMM;
 
 Bugsnag.apiKey = "7419717b29de539ab0fbe35dcd7ca19d";
 Bugsnag.appVersion = chrome.runtime.getManifest().version;
@@ -31,6 +32,13 @@ report = function (e) {
   } else {
     Bugsnag.notifyException(e);
   }
+};
+
+secToHHMM = function (sum) {
+  var hours = Math.floor(sum / 3600),
+    minutes = Math.floor((sum % 3600) / 60);
+
+  return hours + "h " + minutes + "m";
 };
 
 chrome.webRequest.onBeforeSendHeaders.addListener(

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -76,6 +76,7 @@ var PopUp = {
           PopUp.switchView(PopUp.$menuView);
         }
         PopUp.renderEntriesList();
+        PopUp.renderSummary();
       } else {
         localStorage.setItem('latestStoppedEntry', '');
         PopUp.switchView(PopUp.$loginView);
@@ -157,6 +158,13 @@ var PopUp = {
     PopUp.$editButton.setAttribute('title', 'Click to edit "' + description + '"');
 
     PopUp.setTagIcon(data.tags);
+  },
+
+  renderSummary: function () {
+    var sums = TogglButton.calculateSums();
+
+    document.querySelector(".summary .s-today > span").innerHTML = sums.today;
+    document.querySelector(".summary .s-week > span").innerHTML = sums.week;
   },
 
   renderEntriesList: function () {

--- a/src/styles/popup.css
+++ b/src/styles/popup.css
@@ -728,6 +728,29 @@ hr {
   box-shadow: 0px 0px 5px rgb(26, 153, 243);
 }
 
+/** Summary **/
+
+.summary {
+  height: 35px;
+  padding-top: 10px;
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+.summary > div {
+  color: #a3a3a3;
+  font-weight: 200;
+  width: 50%;
+}
+
+.summary .s-today {
+  float: left;
+}
+
+.summary .s-week {
+  float: right;
+}
+
 /** Time Entries list **/
 
 #menu .entries-list {


### PR DESCRIPTION
This is something that I have been using for months now. It adds today's total and weeks total duration right under the timer in the Toggl Button popup. It might just be a good addition to the extension. Any feedback is welcome.

<img width="248" alt="screen shot 2018-01-29 at 12 42 44" src="https://user-images.githubusercontent.com/842229/35506445-f2d39848-04f1-11e8-894a-3eed67f0d235.png">
