### PR TITLE
Add Planfix Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Add Toggl one-click time tracking to popular web tools.
 - [Phacility](http://phacility.com/)
 - [Pivotal](https://www.pivotaltracker.com/)
 - [Planbox](http://www.planbox.com/)
+- [Planfix](https://planfix.ru/)
 - [Podio](https://podio.com/)
 - [ProcessWire](http://processwire.com/)
 - [Producteev](https://www.producteev.com/)

--- a/src/scripts/content/planfix.js
+++ b/src/scripts/content/planfix.js
@@ -1,0 +1,38 @@
+/*jslint indent: 2 */
+/*global $: false, document: false, togglbutton: false*/
+'use strict';
+
+togglbutton.render('.taskCard-header-data-blocks .b-green-block-taskAfterLabel:not(.toggl)', {observe: true}, function (elem) {
+  var div, link, description, tags, projectId,
+    numElem = $('.b-task-general-id a'),
+    titleElem = $('.b-task-param-editable a'),
+    projectElem = $('.task-project-text a'),
+    existingTag = $('.b-toggl-btn.toggl.planfix');
+
+  if (existingTag) {
+    if (existingTag.parentNode.firstChild.classList.contains('toggl')) {
+      return;
+    }
+    existingTag.parentNode.removeChild(existingTag);
+  }
+
+  description = titleElem.textContent;
+  if (numElem !== null) {
+    description = description.trim();
+    tags = [ numElem.textContent.replace('#', '') ];
+  }
+
+  div = document.createElement("div");
+  div.classList.add("b-toggl-btn", "toggl", "planfix");
+
+  link = togglbutton.createTimerLink({
+    className: 'planfix',
+    description: description,
+    buttonType: 'minimal',
+    projectName: projectElem && projectElem.textContent,
+    tags: tags
+  });
+
+  div.appendChild(link);
+  elem.prepend(div);
+});

--- a/src/scripts/origins.json
+++ b/src/scripts/origins.json
@@ -314,6 +314,10 @@
     "url": "*://*.planbox.com/*",
     "name": "Planbox"
   },
+  "planfix.ru": {
+    "url": "*://*.planfix.ru/*",
+    "name": "Planfix"
+  },
   "podio.com": {
     "url": "*://*.podio.com/*",
     "name": "Podio"

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1132,6 +1132,16 @@ only screen and (min-resolution: 192dpi) {
   margin-left: -5px;
 }
 
+/********* PLANFIX *********/
+.b-toggl-btn.planfix {
+  display: flex;
+  align-items: center;
+}
+.toggl-button.planfix {
+  height: 20px;
+  margin-right: 5px;
+}
+
 /********* EPROJECT *********/
 .toggl-timer {
   margin-left: 5px !important;


### PR DESCRIPTION
Adds Planfix Integration, https://planfix.ru/ (https://planfix.com). Tested on the latest versions of Google Chrome and Planfix. Inspired by #964 and Github integration.

Button appears in task header, task id added as tag.

![image](https://user-images.githubusercontent.com/3027126/35770632-b900c99e-0940-11e8-8448-1f1fd79477f1.png)
