### PR TITLE
The pomodoro notification should remain visible on screen

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -722,7 +722,8 @@ var TogglButton = {
       iconUrl: 'images/icon-128.png',
       title: "Toggl Button - Pomodoro Timer",
       message: "Time is up! Take a break",
-      priority: 2
+      priority: 2,
+      requireInteraction: true
     };
 
     if (!FF) {


### PR DESCRIPTION
The pomodoro notification should remain visible on screen until user activates or dismisses the notification.
It fixes issue #937.