### PR TITLE
Fix Header Showing Incorrect Weekly Time Tracked

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -1428,7 +1428,7 @@ var TogglButton = {
     getWeekStart = function (d) {
       var startDay = TogglButton.$user.beginning_of_week,
         day = d.getDay(),
-        diff = d.getDate() - day + (day === 0 ? startDay - 7 : startDay);
+        diff = d.getDate() - day + (startDay > day ? startDay - 7 : startDay);
 
       return new Date(d.setDate(diff));
     };


### PR DESCRIPTION
This now selects the most recent Sunday, Monday, Tuesday, ect. instead
of the one in the current week starting on Sunday. This caused errors
and should fix #989