### PR TITLE
Fix Sync Issue with Entry being Deleted

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -315,6 +315,11 @@ var TogglButton = {
         entry = null;
       }
       TogglButton.updateTriggers(entry);
+    } else if (data.action === "delete") {
+      if (TogglButton.$curEntry !== null && TogglButton.$curEntry.id === entry.id) {
+        TogglButton.$latestStoppedEntry = entry;
+        TogglButton.updateTriggers(null);
+      }
     }
   },
 


### PR DESCRIPTION
The extention should now update the icon when the currently running
timer is deleted. It will also set that deleted entry that was running
in the latest stopped entry for the resume shortcut.

This should fix #993