### PR TITLE
Update Phabricator integration

### DIFF
--- a/src/scripts/content/phabricator.js
+++ b/src/scripts/content/phabricator.js
@@ -3,10 +3,10 @@
 'use strict';
 
 // Workboard view
-togglbutton.render('#phabricator-standard-page-body .phui-workpanel-view .phui-object-item:not(.toggl)', {observe: true}, function (elem) {
+togglbutton.render('#phabricator-standard-page-body .phui-workpanel-view .phui-oi:not(.toggl)', {observe: true}, function (elem) {
   var link,
-    description = $('.phui-object-item-name', elem).textContent.trim(),
-    projectName = $('.phui-crumb-view[href^="/project/view"]:not(.phabricator-last-crumb), .phui-header-view > a').textContent.trim();
+    description = $('.phui-oi-name', elem).textContent.trim(),
+    projectName = $('.phui-crumb-view[href^="/project/profile"]:not(.phabricator-last-crumb), .phui-header-view > a').textContent.trim();
 
   link = togglbutton.createTimerLink({
     className: 'phabricator',
@@ -15,7 +15,7 @@ togglbutton.render('#phabricator-standard-page-body .phui-workpanel-view .phui-o
     projectName: projectName
   });
 
-  $('.phui-object-item-name', elem).appendChild(link);
+  $('.phui-oi-name', elem).appendChild(link);
 });
 
 // Task detail view

--- a/src/scripts/content/phabricator.js
+++ b/src/scripts/content/phabricator.js
@@ -21,6 +21,8 @@ togglbutton.render('#phabricator-standard-page-body .phui-workpanel-view .phui-o
 // Task detail view
 togglbutton.render('#phabricator-standard-page-body:not(.toggl)', {observe: true}, function (elem) {
   var link,
+    wrap = document.createElement('li', 'phabricator-action-view'),
+    container = $('.phabricator-action-list-view', elem),
     desc = elem.querySelector(".phui-two-column-header .phui-header-view .phui-header-header"),
     number = $('.phabricator-last-crumb .phui-crumb-name') || "",
     projectName = $('.phabricator-handle-tag-list-item > a');
@@ -37,5 +39,6 @@ togglbutton.render('#phabricator-standard-page-body:not(.toggl)', {observe: true
     projectName: projectName
   });
 
-  desc.appendChild(link);
+  wrap.appendChild(link);
+  container.prepend(wrap);
 });

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1024,7 +1024,14 @@ only screen and (min-resolution: 192dpi) {
 /********* PHABRICATOR *********/
 .toggl-button.phabricator {
   margin-left: 5px;
+}
+
+.phui-oi-name > .toggl-button.phabricator {
   position: absolute;
+}
+
+li > .toggl-button.phabricator {
+  position: relative;
 }
 
 /********* MANTISHUB *********/


### PR DESCRIPTION
The toggl button wasn't appearing in the workboard view because the css selectors have been updated. Details here: https://github.com/phacility/phabricator/commit/e077d2f#diff-8aa808d5f88c9da253dbd34ad07755dbL343.

This PR:
- Updates css selectors for Phabricator.
- Changes the location of the toggl button in tasks and revisions. Now it is placed in the actions list.
---
- `make lint` finishes successfully.
---
### Screenshots:
- Phabricator:
<img src="https://user-images.githubusercontent.com/1057973/39083572-4e88c44c-4566-11e8-8f48-1b7df6ea481d.png" width="200"/>

![screenshot 2018-04-21 at 13 18 33](https://user-images.githubusercontent.com/1057973/39083587-870509ca-4566-11e8-80d7-0e4dfe85d47e.png)
![screenshot 2018-04-21 at 13 19 06](https://user-images.githubusercontent.com/1057973/39083590-975a7472-4566-11e8-96db-150fab694137.png)
![screenshot 2018-04-21 at 13 28 00](https://user-images.githubusercontent.com/1057973/39083643-d6cb41d0-4567-11e8-886d-5248e56a5276.png)

- Phacility:
<img src="https://user-images.githubusercontent.com/1057973/39083612-2e596752-4567-11e8-87cd-b8c88b514172.png" width="200"/>

![screenshot 2018-04-21 at 13 23 56](https://user-images.githubusercontent.com/1057973/39083617-447b8dda-4567-11e8-9978-cd074cb6bcdf.png)
![screenshot 2018-04-21 at 13 24 41](https://user-images.githubusercontent.com/1057973/39083622-5ed12be0-4567-11e8-8772-5fe926af65eb.png)

