### PR TITLE
Fix error popup on clicking "Recent entries"

### DIFF
--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -283,6 +283,7 @@ var PopUp = {
 
     elem = document.createElement("p");
     elem.textContent = "Recent entries";
+    elem.addEventListener('click', e => e.stopPropagation());
     html.appendChild(elem);
 
     html.appendChild(ul);


### PR DESCRIPTION
Make 'Recent entries' non clickable

**Note:** Use of arrow function as discussed with @langri-sha we are now using ES features supported by Firefox ESR