### PR TITLE
Fixes Visual Studio Integration

### DIFF
--- a/src/scripts/content/visualstudio.js
+++ b/src/scripts/content/visualstudio.js
@@ -6,9 +6,9 @@
 togglbutton.render('.witform-layout-content-container:not(.toggl)', {observe: true}, function () {
   var link,
     description = $('.work-item-form-id span').innerText + ' ' + $('.work-item-form-title input').value,
-    project = $('.menu-item.l1-navigation-text.drop-visible .text').textContent.trim(),
+    project = $('.tfs-selector span').innerText,
     container = $('.work-item-form-header-controls-container'),
-    vs_activeClassContent = $('.hub-list .menu-item.currently-selected').textContent.trim();
+    vs_activeClassContent = $('.commandbar.header-bottom > .commandbar-item > .displayed').innerText;
 
   link = togglbutton.createTimerLink({
     className: 'visual-studio-online',
@@ -16,7 +16,7 @@ togglbutton.render('.witform-layout-content-container:not(.toggl)', {observe: tr
     projectName: project
   });
 
-  if (vs_activeClassContent === "Work Items*" || vs_activeClassContent === "Backlogs") {
+  if (vs_activeClassContent === "Work Items" || vs_activeClassContent === "Backlogs") {
     container.appendChild(link);
   }
 });


### PR DESCRIPTION
I've updated some of the selectors for the new VSTS markup to fix #1019 

The only thing I'm not sure of is what element was initially used for the project value.
In this PR, it's the value in the project selector, which is CRM in the screenshot.
<img width="447" alt="screen shot 2018-06-05 at 17 05 57" src="https://user-images.githubusercontent.com/3738747/40984945-4c9f0baa-68e3-11e8-8cc6-117595c8646e.png">

Here you can see that the button is on the page again:
<img width="1226" alt="screen shot 2018-06-05 at 17 11 48" src="https://user-images.githubusercontent.com/3738747/40985076-9957a920-68e3-11e8-974f-2651dc4df829.png">

