### PR TITLE
Updates Slack integration

### DIFF
--- a/src/scripts/content/slack.js
+++ b/src/scripts/content/slack.js
@@ -1,12 +1,12 @@
 /*jslint indent: 2 */
 /*global $: false, document: false, togglbutton: false, createTag:false*/
-'use strict';
 
 togglbutton.render('#channel_name:not(.toggl)', {observe: true}, function () {
+  'use strict';
   var link,
     placeholder = $('.channel_title_info'),
-    description = $("#channel_name").textContent.trim().substr(1),
-    project = $('#team_name').textContent;
+    project = $('#team_name').textContent,
+    description = $("#channel_name").textContent.trim().replace(/^#/, '');
 
   link = togglbutton.createTimerLink({
     className: 'slack',
@@ -16,4 +16,26 @@ togglbutton.render('#channel_name:not(.toggl)', {observe: true}, function () {
   });
 
   placeholder.parentNode.insertBefore(link, placeholder);
+});
+
+togglbutton.render('.c-message--hover:not(.toggl)', {observe: true}, function (elem) {
+  'use strict';
+  var link,
+    placeholder = $('.c-message_actions__button--last-child'),
+    description = $('.c-message__body', elem).textContent,
+    project = $('#team_name').textContent,
+    button = document.createElement('button');
+
+  link = togglbutton.createTimerLink({
+    className: 'slack-message',
+    projectName: project,
+    description: description,
+    buttonType: 'minimal'
+  });
+
+  button.className = "c-button-unstyled c-message_actions__button";
+  button.setAttribute("type", "button");
+  button.appendChild(link);
+
+  placeholder.parentNode.insertBefore(button, placeholder);
 });

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1090,6 +1090,14 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
   background-position-x: 8px !important;
 }
 
+.toggl-button.slack-message {
+  background-color: #fff !important;
+  background-size: 16px !important;
+  padding-left:1px;
+  width: 16px;
+  height: 16px;
+}
+
 /********* ZOHO BOOKS *********/
 .toggl-button.zoho_books {
   margin-top: 5px;


### PR DESCRIPTION
This update fixes the issue with the first letter being removed from a private channel. However, it also changes the current behaviour of the Toggl button in Slack. I think it's an improvement, but that may just be my opinion. Changes included here are:

- Project is now taken from the channel name ***not team name as before***
- Hyphens (`-`) and underscores (`_`) are converted to spaces
- Project name is converted to Title Case
- Task description is left undefined for the channel title button
- Adds a Toggl button to the hover message actions list
- Task description for this button is taken from the message body
- Fixes #1002 
- Fixes #601

![image](https://user-images.githubusercontent.com/1894530/41719153-79efbce8-755f-11e8-9e5f-61d6a20f2ac8.png)
