### PR TITLE
Fix Jira integration parentElement null error

### DIFF
--- a/src/scripts/content/atlassian.js
+++ b/src/scripts/content/atlassian.js
@@ -81,7 +81,10 @@ togglbutton.render('.issue-header-content:not(.toggl)', {observe: true}, functio
     projectName: projectElem && projectElem.textContent.trim()
   });
 
-  $('.issue-link').parentElement.appendChild(link);
+  link.style.marginLeft = '8px';
+
+  var issueLinkContainer = $('.issue-link').parentElement || $('.aui-nav li').lastElementChild;
+  issueLinkContainer && issueLinkContainer.appendChild(link);
 });
 
 // Jira pre-2017


### PR DESCRIPTION
Related issue: #1053

Desk case: case/725339

#1053 seems to be a common issue between trello and jira users and is probably related to the backend of the extension db/background scripts.

This PR doesn't address that issue specifically but is a fix for the most common error on [bugsnag](https://app.bugsnag.com/toggl-dot-com/toggl-button/errors/5b2ac4200ecf63001722ae2a?filters[event.since][0][type]=eq&filters[event.since][0][value]=30d&filters[error.status][0][type]=eq&filters[error.status][0][value]=open&filters[search][0][type]=eq&filters[search][0][value]=atlassian)