### PR TITLE
Fix trello script breaking when projectElem is null

### DIFF
--- a/src/scripts/content/trello.js
+++ b/src/scripts/content/trello.js
@@ -10,7 +10,7 @@ togglbutton.render('.window-header:not(.toggl)', {observe: true}, function (elem
     titleElem = $('.window-title h2', elem),
     //trackedContainer = createTag('div', 'toggl-tracked'),
     //trackedElem = $('.other-actions'),
-    projectElem = $('.board-header > a'),
+    projectElem = $('.board-header > a') || $('board-header-btn-name'),
     descriptionElem = $('.js-move-card');
 
   if (!descriptionElem) {
@@ -24,7 +24,7 @@ togglbutton.render('.window-header:not(.toggl)', {observe: true}, function (elem
   link = togglbutton.createTimerLink({
     className: 'trello',
     description: descFunc,
-    projectName: projectElem.textContent,
+    projectName: projectElem && projectElem.textContent,
     calculateTotal: true
   });
 


### PR DESCRIPTION
Related issue: #1053

Desk cases: case/729276, case/717583, case/717865

#1053 seems to be a common issue between trello and jira users and is probably related to the backend of the extension db/background scripts.

This PR doesn't address that issue specifically but is a fix for the most common error on [bugsnag](https://app.bugsnag.com/toggl-dot-com/toggl-button/errors?filters[event.since][0][type]=eq&filters[event.since][0][value]=7d&filters[error.status][0][type]=eq&filters[error.status][0][value]=open&filters[search][0][type]=eq&filters[search][0][value]=trello&sort=events)