### PR TITLE
Handles v8 API response with not default wid

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -138,6 +138,10 @@ var TogglButton = {
             TogglButton.$user.clientNameMap = clientNameMap;
             TogglButton.$user.tagMap = tagMap;
             TogglButton.$user.projectTaskList = projectTaskList;
+            if (!TogglButton.$user.default_wid) {
+              const defaultWS = TogglButton.$user.workspaces[0];
+              TogglButton.$user.default_wid = defaultWS.id;
+            }
             localStorage.setItem('userToken', resp.data.api_token);
             if (TogglButton.$sendResponse !== null) {
               TogglButton.$sendResponse({success: (xhr.status === 200)});


### PR DESCRIPTION
## :star2: What does this PR do?

* Assign a `default_wid` to `TogglButton.$user`
* Prevent type error at https://github.com/toggl/toggl-button/blob/39e7cd52b1a3676dcb0b8a95e35cbbf963472d6a/src/scripts/autocomplete.js#L452


## :bug: Recommendations for testing
See `/keybase/team/toggl.frontend/toggl-button/1053/info.md` on keybase for instructions.

```shell
# on mac
open /keybase/team/toggl.frontend/toggl-button/1053/info.md
```
on windows open `k:\team\toggl.frontend\toggl-button\1053\info.md`

## :memo: Links to relevant issues/docs

For some users particularly ones who created account via an invite thus
are part of a workspace that they don't own the api wasn't returning the
`default_wid` field in the response in the `v8/me` endpoint. 

Related #671 

Closes #1053