### PR TITLE
Fix clipped options in extension settings

### DIFF
--- a/src/html/settings.html
+++ b/src/html/settings.html
@@ -151,6 +151,7 @@
                     <label for="sound-volume">Sound volume</label>
                     <input type="range" id="sound-volume">
                     <span id="volume-label">100%</span>
+                    <br>
                     <button id="sound-test">Test &#9658;</button>
                   </p>
                 </div>

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -55,11 +55,11 @@ body,
 }
 
 .list li #nag-nanny:checked ~ div {
-  height: 110px
+  height: 160px
 }
 
 .list li #pomodoro-mode:checked ~ div {
-  height: 200px;
+  height: 220px;
 }
 
 .list li #stop-at-day-end:checked ~ div{
@@ -424,7 +424,8 @@ header .active, header li:hover {
 
 #sound-test {
   position: relative;
-  right: -28px;
+  right: -112px;
+  width: 80px;
 }
 
 .pomodoro-sound {
@@ -438,7 +439,7 @@ header .active, header li:hover {
 }
 
 #enable-sound-signal:checked ~.pomodoro-sound-volume {
-  height: 36px;
+  height: 64px;
 }
 
 .ff .tab-3 .section:first-of-type {


### PR DESCRIPTION
## :star2: What does this PR do?

* Increase height for nag reminder view in first tab
* Increase height for pomodoro option in second tab
* Tweak test sound button styling and position in second tab

### General tab

* Before

<img width="802" alt="screenshot 2018-07-30 13 22 45" src="https://user-images.githubusercontent.com/1716853/43385147-9d0eca9a-93fd-11e8-9d2e-7c39f48b8445.png">

* After

<img width="801" alt="screenshot 2018-07-30 13 23 41" src="https://user-images.githubusercontent.com/1716853/43385214-c449b8a4-93fd-11e8-962a-9dfdf2581649.png">

### Pomodoro tab

* Before

<img width="802" alt="screenshot 2018-07-30 13 22 59" src="https://user-images.githubusercontent.com/1716853/43385260-e01e6f52-93fd-11e8-97b3-444476fc3416.png">

* After

<img width="799" alt="screenshot 2018-07-30 13 25 07" src="https://user-images.githubusercontent.com/1716853/43385272-e5577a86-93fd-11e8-8415-4f40e60cefc5.png">

## :bug: Recommendations for testing

* Open extension settings
* In the **"General"** tab click on **"Remind me to track"**
* The **"Minutes since stopping last Time Entry"** option should be visible
* In the **"Pomodoro Timer"** tab click on **"Enable Pomodoro Timer"**
* The **"Test"** button should be visible and not clipped

## :memo: Links to relevant issues/docs

Closes #1074