### PR TITLE
Fixed sentry.io button

### DIFF
--- a/src/scripts/content/sentry.js
+++ b/src/scripts/content/sentry.js
@@ -7,7 +7,7 @@ togglbutton.render('.group-detail:not(.toggl)', {observe: true}, function () {
     description,
     errType = $('h3 > span > span').textContent.trim(),
     detail = $('.message').textContent.trim(),
-    project = $('.project-name').textContent.trim();
+    project = $('.project-select').textContent.trim();
 
   description = errType + ': ' + detail;
 


### PR DESCRIPTION
The button stopped working for sentry.io. The project name class is no longer in the DOM. I've fixed this by changing it to the value of the project select class element.