### PR TITLE
Add new Jira dialog support

### DIFF
--- a/src/scripts/content/atlassian.js
+++ b/src/scripts/content/atlassian.js
@@ -55,6 +55,30 @@ togglbutton.render('div[role="dialog"].sc-ckVGcZ h1:not(.toggl)', {observe: true
   }
 });
 
+// Jira 2018-08 sprint modal
+// Using the h1 as selector to make sure that it will only try to render the button
+// after Jira has fully rendered the modal content
+togglbutton.render('div[role="dialog"].sc-krDsej h1:not(.toggl)', { observe: true }, function (needle) {
+  var root = needle.closest('div[role="dialog"]'),
+    id = $('a:first-child', root),
+    description = $('h1:first-child', root),
+    project = $('.sc-cremA'),
+    container = createTag('div', 'jira-ghx-toggl-button'),
+    link;
+
+  if (id !== null && description !== null && project !== null) {
+    link = togglbutton.createTimerLink({
+      className: 'jira2018',
+      description: id.textContent + ' ' + description.textContent,
+      projectName: project && project.textContent,
+      buttonType: 'minimal'
+    });
+
+    container.appendChild(link);
+    $('.sc-iBmynh', root).appendChild(container);
+  }
+})
+
 
 // Jira 2018 sprint modal
 // Using the h1 as selector to make sure that it will only try to render the button

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -432,6 +432,12 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
   box-shadow: none;
 }
 
+.toggl-button.jira2018 {
+  margin-top: .5em;
+  margin-left: 0;
+  cursor: pointer;
+}
+
 /********* UNFUDDLE *********/
 .toggl-button.unfuddle {
   margin-left: 4px;


### PR DESCRIPTION
Add support for recent Jira update.

## Testing recommendation
- Login to Jira account, go to kanban and open some task
- Button should be available on the right:
![screen shot 2018-08-27 at 11 23 40](https://user-images.githubusercontent.com/10184544/44652248-bdb58a00-a9eb-11e8-84f0-9e10258b3388.png)
 
close #1081