### PR TITLE
Add support for Meistertask 2.0

### DIFF
--- a/src/scripts/content/meistertask.js
+++ b/src/scripts/content/meistertask.js
@@ -40,3 +40,45 @@ togglbutton.render('.js-box-wrapper:not(.toggl)', { observe: true }, function(
 
   togglButtonElement.parentNode.insertBefore(link, togglButtonElement);
 });
+
+// MeisterTask 2.0 (2018)
+// since they removed all descriptive classes selectors looks awful
+togglbutton.render('.kr-view.react-dialog-box > .kr-view:not(.toggl)', { observe: true }, function (elem) {
+  var link, description, project, tagFunc, togglButtonElement;
+
+  description = $('div.react-modals-enable-events > div > div > div:nth-child(1) > div > div > div > div:nth-child(2) > div:nth-child(1) > div:nth-child(1) > div > div', elem).textContent;
+  project = $('div.react-modals-enable-events > div > div > div:nth-child(1) > div > div > div > div:nth-child(2) > div:nth-child(2) > div:nth-child(4) > div:nth-child(1) > a', elem).textContent;
+
+  tagFunc = function () {
+    var index,
+      tags = [],
+      tagList = $('div.react-modals-enable-events > div > div > div:nth-child(1) > div > div > div > div:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div > div:nth-child(2)', elem),
+      tagItems;
+
+    if (!tagList) {
+      return [];
+    }
+
+    tagItems = tagList.children;
+
+    for (index in tagItems) {
+      if (tagItems.hasOwnProperty(index)) {
+        tags.push(tagItems[index].textContent);
+      }
+    }
+
+    return tags;
+  }
+
+  link = togglbutton.createTimerLink({
+    className: 'meistertask',
+    description: description,
+    projectName: project,
+    tags: tagFunc,
+    buttonType: 'minimal'
+  });
+
+  togglButtonElement = $('div.react-modals-enable-events > div > div > div:nth-child(1) > div > div > div > div:nth-child(1) > div > div:nth-child(2)', elem);
+
+  togglButtonElement.parentNode.insertBefore(link, togglButtonElement);
+});


### PR DESCRIPTION
Add support for Meistertask 2.0.

Quick note: new layout has very, very strange selectors. Well, all they use only few classes for everything (like `.kr-text`, `.kr-view`, and so). That's why selectors look so bad 🤕 
If someone has better solution, feel free to review this.
 
close #1106, close #1102, close #1093