### PR TITLE
Add Kantree integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Add Toggl one-click time tracking to popular web tools.
 - [Jira](https://www.atlassian.com/software/jira)
 - [Kanbanery](https://www.kanbanery.com/)
 - [Kanboard](https://kanboard.org/)
+- [Kantree](https://kantree.io/)
 - [KhanAcademy](https://www.khanacademy.org/)
 - [LiquidPlanner](https://www.liquidplanner.com/)
 - [ManageEngine](https://www.manageengine.com/)

--- a/src/scripts/content/kantree.js
+++ b/src/scripts/content/kantree.js
@@ -1,0 +1,82 @@
+'use strict';
+
+/* Features: */
+/* - Add timer to the card */
+/* - Add timer to the sub-tasks list */
+/* - Get toggl project name from kantree card */
+/* - Get toggl tags from kantree card */
+/* - Handle card view mode changes */
+console.log('Toggl Button loaded for kantree.');
+
+/* Card button */
+togglbutton.render('.card-view:not(.toggl)', {observe: true}, function (elem) {
+      var link, container = createTag('div', 'kt-card-toggl-btn btn btn-board-menu'),
+    cardRef = $('.card-view-header a.ref', elem),
+    cardId = cardRef && cardRef.textContent,
+    cardTitle = $('.card-view-header h2', elem) && $('.card-view-header h2', elem).textContent,
+    taskTitle =  cardId + ' ' + cardTitle,
+    projectTitle = $('.board-info .title a').getAttribute("title"),
+    descriptionElem = $('.card-view-attributes-form', elem);
+
+  if (!descriptionElem || !taskTitle) {
+    return;
+  }
+
+  var tagsFunc = function () {
+    var index,
+      tags = [],
+      tagItems = document.querySelectorAll('.attribute-type-group-type .group', elem);
+
+    if (!tagItems) {
+      return [];
+    }
+
+    for (index in tagItems) {
+      if (tagItems.hasOwnProperty(index)) {
+        tags.push(tagItems[index].textContent.trim());
+      }
+    }
+
+    return tags;
+  };
+
+  link = togglbutton.createTimerLink({
+    className: 'kantree',
+    description: taskTitle,
+    projectName: projectTitle,
+    calculateTotal: true,
+    tags: tagsFunc
+  });
+
+  container.appendChild(link);
+  descriptionElem.parentNode.insertBefore(container, descriptionElem);
+}, "#card-modal-host, .card-modal");
+
+/* Checklist buttons */
+togglbutton.render('.card-tile-content:not(.toggl)', {observe: true}, function (elem) {
+  var link,
+    projectTitle = $('.board-info .title a').getAttribute("title"),
+    subTaskRef = $('.ref', elem),
+    cardRef = $('.card-view-header a.ref').textContent,
+    taskDesc = $('.title', elem).textContent,
+    taskId = subTaskRef && $('.ref', elem).textContent;
+
+  link = togglbutton.createTimerLink({
+    className: 'kantree',
+    buttonType: 'minimal',
+    projectName: projectTitle,
+    description: taskId + ' ' + taskDesc + ' (parent ' + cardRef + ')'
+  });
+
+  link.classList.add('kt-checklist-item-toggl-btn');
+
+  if (!taskId) {
+    // run toggl after sub-task creation.
+    setTimeout(function () {
+      subTaskRef.parentNode.prepend(link);
+    }, 2000);
+  }
+  else {
+    subTaskRef.parentNode.prepend(link);
+  }
+}, ".card-view-children .children .card-tile, #card-modal-host, .card-modal");

--- a/src/scripts/origins.js
+++ b/src/scripts/origins.js
@@ -249,6 +249,10 @@ export default {
     url: '',
     name: 'Kanboard'
   },
+  'kantree.io': {
+    url: '*://*.kantree.io/*',
+    name: 'Kantree'
+  },
   'liquidplanner.com': {
     url: '*://app.liquidplanner.com/*',
     name: 'Liquidplanner'

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1479,3 +1479,17 @@ label > .toggl-button.outlook {
   position: relative;
   top: 1px;
 }
+
++/********* KANTREE **********/
+.kt-card-toggl-btn {
+  min-height: 34px;
+}
+
+.kt-checklist-item-toggl-btn {
+    background-color: #f5f5f5;
+    border: 0;
+    float: right;
+    font-size: 0;
+    display: inline-block;
+    margin: 0 10px;
+}


### PR DESCRIPTION
Adds a kantree.io integration with loading the project name and the task number as description:
 "#[task id] [task title]".

Works both either on single card or sub-tasks list.

Additional features:
- Gets toggl project name from kantree card
- Gets toggl tags from kantree card
- Works in both viewmodes (eg. modal window or sidebar panel)
- Adds toggl button even on newly created sub-task

<img width="167" alt="19 write product description kantree 2018-09-05 16-04-17" src="https://user-images.githubusercontent.com/791060/45095382-9fa40400-b126-11e8-9662-ecd958c337ab.png">
<img width="454" alt="19 write product description kantree 2018-09-05 16-06-04" src="https://user-images.githubusercontent.com/791060/45095398-a6cb1200-b126-11e8-891a-f216e3b5256d.png">
