### PR TITLE
Add telemetry controls

### DIFF
--- a/src/html/settings.html
+++ b/src/html/settings.html
@@ -9,6 +9,7 @@
       <li class="tab-link">General</li>
       <li class="tab-link">Pomodoro Timer</li>
       <li class="tab-link">Permissions</li>
+      <li class="tab-link">Telemetry</li>
     </ul>
   </header>
   <body>
@@ -185,6 +186,20 @@
             </div>
             <div id="custom-perm-container"></div>
           </div>
+        </div>
+        <div class="tab tab-4">
+          <ul class="list">
+            <li>
+              <input type="checkbox" id="send-usage-statistics">
+              <label for="send-usage-statistics">Send usage statistics</label>
+              <div class="description">Help us understand how Toggl Button is used by sending usage statistics.</div>
+            </li>
+            <li>
+              <input type="checkbox" id="send-error-reports">
+              <label for="send-error-reports">Send error reports</label>
+              <div class="description">Submit error reports to help us fix issues with Toggl Button.</div>
+            </li>
+          </ul>
         </div>
       </div>
     </div>

--- a/src/scripts/lib/bugsnag.js
+++ b/src/scripts/lib/bugsnag.js
@@ -7,7 +7,12 @@ const client = bugsnag({
   notifyReleaseStages: ['production', 'development'],
   autoBreadcrumbs: false,
   autoCaptureSessions: false,
-  collectUserIp: false
+  collectUserIp: false,
+  beforeSend: function (report) {
+    if (localStorage.getItem('sendErrorReports') !== 'true') {
+      report.ignore()
+    }
+  }
 });
 
 client.beforeNotify = function(error, metaData) {

--- a/src/scripts/lib/db.js
+++ b/src/scripts/lib/db.js
@@ -32,7 +32,8 @@ export default class Db {
     'dont-show-permissions': false,
     'show-permissions-info': 0,
     'selected-settings-tab': 1,
-    sendErrorReports: true
+    sendErrorReports: true,
+    sendUsageStatistics: true
   };
 
   newMessage = (request, sender, sendResponse) => {

--- a/src/scripts/lib/db.js
+++ b/src/scripts/lib/db.js
@@ -31,6 +31,7 @@ export default class Db {
   core = {
     'dont-show-permissions': false,
     'show-permissions-info': 0,
+    'settings-active-tab': 0,
     'selected-settings-tab': 1,
     sendErrorReports: true,
     sendUsageStatistics: true

--- a/src/scripts/lib/db.js
+++ b/src/scripts/lib/db.js
@@ -31,7 +31,8 @@ export default class Db {
   core = {
     'dont-show-permissions': false,
     'show-permissions-info': 0,
-    'settings-active-tab': 0
+    'selected-settings-tab': 1,
+    sendErrorReports: true
   };
 
   newMessage = (request, sender, sendResponse) => {

--- a/src/scripts/lib/db.js
+++ b/src/scripts/lib/db.js
@@ -101,6 +101,14 @@ export default class Db {
         request.type === 'update-selected-settings-tab'
       ) {
         this.updateSetting(request.type.substr(7), request.state);
+      } else if (
+        request.type === 'update-send-usage-statistics'
+      ) {
+        this.updateSetting('sendUsageStatistics', request.state)
+      } else if (
+        request.type === 'update-send-error-reports'
+      ) {
+        this.updateSetting('sendErrorReports', request.state)
       }
     } catch (e) {
       bugsnagClient.notify(e);

--- a/src/scripts/lib/ga.js
+++ b/src/scripts/lib/ga.js
@@ -20,6 +20,8 @@ export default class Ga {
   }
 
   report(event, service) {
+    if (!db.get('sendUsageStatistics')) return;
+
     var request = new XMLHttpRequest(),
       message =
         'v=1&tid=' +

--- a/src/scripts/lib/ga.js
+++ b/src/scripts/lib/ga.js
@@ -61,7 +61,10 @@ export default class Ga {
       'settings/show-right-click-button-' + this.db.get('showRightClickButton')
     );
     this.report('popup', 'settings/popup-' + this.db.get('showPostPopup'));
-    this.report('reminder', 'settings/reminder-' + this.db.get('nannyCheckEnabled'));
+    this.report(
+      'reminder',
+      'settings/reminder-' + this.db.get('nannyCheckEnabled')
+    );
     this.report(
       'reminder-minutes',
       'settings/reminder-minutes-' + this.db.get('nannyInterval')

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -43,6 +43,8 @@ var Settings = {
   $defaultProjectContainer: null,
   $pomodoroVolume: null,
   $pomodoroVolumeLabel: null,
+  $sendUsageStatistics: null,
+  $sendErrorReports: null,
   showPage: function() {
     var volume = parseInt(db.get('pomodoroSoundVolume') * 100, 10),
       rememberProjectPer = db.get('rememberProjectPer');
@@ -85,6 +87,14 @@ var Settings = {
       Settings.toggleState(
         Settings.$pomodoroStopTimeTracking,
         db.get('pomodoroStopTimeTrackingWhenTimerEnds')
+      );
+      Settings.toggleState(
+        Settings.$sendUsageStatistics,
+        db.get('sendUsageStatistics')
+      );
+      Settings.toggleState(
+        Settings.$sendErrorReports,
+        db.get('sendErrorReports')
       );
       Array.apply(null, Settings.$rememberProjectPer.options).forEach(function(
         option
@@ -627,6 +637,10 @@ document.addEventListener('DOMContentLoaded', function(e) {
     Settings.$rememberProjectPer = document.querySelector(
       '#remember-project-per'
     );
+    Settings.$sendUsageStatistics = document.querySelector(
+      '#send-usage-statistics'
+    );
+    Settings.$sendErrorReports = document.querySelector('#send-error-reports');
 
     // Show permissions page with notice
     if (
@@ -897,6 +911,22 @@ document.addEventListener('DOMContentLoaded', function(e) {
         ).style.display =
           'none';
       });
+
+    Settings.$sendUsageStatistics.addEventListener('click', function(e) {
+      Settings.toggleSetting(
+        e.target,
+        localStorage.getItem('sendUsageStatistics') !== 'true',
+        'update-send-usage-statistics'
+      );
+    });
+
+    Settings.$sendErrorReports.addEventListener('click', function(e) {
+      Settings.toggleSetting(
+        e.target,
+        localStorage.getItem('sendErrorReports') !== 'true',
+        'update-send-error-reports'
+      );
+    });
 
     Settings.loadSitesIntoList();
   } catch (err) {


### PR DESCRIPTION
Please review after #1145.

Adds a new settings tab for controlling the submission of usage statistics and error reports.

Please make sure to:
- ensure the by default we're sending data
- toggling the control as disabled sticks (open/close settings page)
- updating the controls at runtime instantly enables/disables the submission of data