### PR TITLE
Fix blank screen in extension options

### DIFF
--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -645,7 +645,7 @@ document.addEventListener('DOMContentLoaded', function(e) {
     }
 
     // Change active tab.
-    const activeTab = Number.parseInt(db.get('settings-active-tab'), 10);
+    const activeTab = Number.parseInt(db.get('settings-active-tab'), 10) || 0;
     changeActiveTab(activeTab);
     document.querySelector('body').style.display = 'block';
 
@@ -778,7 +778,6 @@ document.addEventListener('DOMContentLoaded', function(e) {
 
     document.querySelectorAll('.tab-links .tab-link').forEach(tab =>
       tab.addEventListener('click', function(e) {
-        const target = e.target;
         const index = [...e.target.parentElement.children].indexOf(e.target);
 
         Settings.saveSetting(index, 'update-settings-active-tab');


### PR DESCRIPTION
## :star2: What does this PR do?

* Fallback to `0` if activeTab value is parsed as `NaN` when `db.get('settings-active-tab')` returns null.

## :bug: Recommendations for testing

* Click on extension options
* See the option tabs

![image](https://user-images.githubusercontent.com/1716853/47001551-5e047100-d148-11e8-83d7-0b7a5f57d263.png)


## :memo: Links to relevant issues/docs

Closes #1151

## :speech_balloon: Summarise how you feel about this PR with a gif

![Your Amazing Giphy](https://media1.tenor.com/images/70c8e14a04cc70d830acc4ea51289da2/tenor.gif?itemid=12673556)