### PR TITLE
Improve asana titles by including workspace & project name

### DIFF
--- a/src/scripts/content/asana.js
+++ b/src/scripts/content/asana.js
@@ -104,7 +104,6 @@ togglbutton.render(
       description: descFunc,
       projectName: projectFunc
     });
-
     container.appendChild(link);
   }
 );
@@ -171,10 +170,13 @@ togglbutton.render(
     }
     var link,
       container = $('.SingleTaskPaneToolbar'),
-      description = $(
-        '.SingleTaskPane-titleRow .simpleTextarea',
-        elem.parentNode
-      ).textContent,
+      description =
+        $('.TopbarPageHeaderStructure-title span').textContent.replace('My Tasks in ', '') + ': ' +
+        $(
+          '.SingleTaskPane-titleRow .simpleTextarea',
+          elem.parentNode
+        ).textContent +
+        ' [' + $('.TaskProjectPill-projectName').textContent + ']',
       projectElement = $(
         '.SingleTaskPane-projects .TaskProjectPill-projectName',
         elem.parentNode


### PR DESCRIPTION
When using the new asana layout, the auto-generated toggl entry title will now be

`$WORKSPACE: $TASK [$PROJECT]`

which was before just

`$TASK`

and did not give enough information for typical Asana workflows.