### PR TITLE
Add support for new YouTrack layout

### DIFF
--- a/src/scripts/content/youtrack.js
+++ b/src/scripts/content/youtrack.js
@@ -27,6 +27,24 @@ togglbutton.render(
   }
 );
 
+/* new view for single issues — obligatory since YouTrack 2018.3 */
+togglbutton.render(
+  '.yt-issue-body:not(.toggl)',
+  { observe: true },
+  function (elem) {
+    var link,
+      issueId = $('.js-issue-id').textContent;
+
+    link = togglbutton.createTimerLink({
+      className: 'youtrack-new',
+      description: issueId + ' ' + $('h1').textContent.trim(),
+      projectName: issueId.split('-')[0]
+    });
+
+    elem.insertBefore(link, $('.yt-issue-view__star'));
+  }
+);
+
 // Agile board
 togglbutton.render('.yt-agile-card:not(.toggl)', { observe: true }, function(
   elem

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -377,8 +377,12 @@
   right: 3px;
   float: none;
 }
-.toggl-button.youtrack {
+.toggl-button.youtrack,
+.toggl-button.youtrack-new {
   float: right;
+}
+.toggl-button.youtrack-new {
+  margin-right: 30px;
 }
 
 /********* ASANA *********/


### PR DESCRIPTION
YouTrack has recently introduced new layout for single issues. Since YouTrack 2018.3 the ability to choose between "old" and "new" layout for single issues was removed, now only the "new" layout is available.

This pull request adds support for this new layout. 

The toggl button is located on the right:
![image](https://user-images.githubusercontent.com/6832206/47262651-f4ee7600-d518-11e8-9049-33c81a459da7.png)
![image](https://user-images.githubusercontent.com/6832206/47262665-45fe6a00-d519-11e8-9020-1bda30403e34.png)
