### PR TITLE
Fix wrong durations for entries that were manually edited

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -885,6 +885,10 @@ window.TogglButton = {
       entry.start = timeEntry.start;
     }
 
+    if (timeEntry.duration) {
+        entry.duration = timeEntry.duration;
+    }
+
     TogglButton.ajax(
       `/time_entries/${TogglButton.$curEntry.id}`,
       {

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -451,8 +451,7 @@ window.PopUp = {
   getStart: function() {
     var arr = document.querySelector('#toggl-button-duration').value.split(':'),
       duration,
-      now,
-      start;
+      now;
 
     if (!PopUp.isNumber(arr.join(''))) {
       return false;
@@ -461,8 +460,7 @@ window.PopUp = {
     duration = 1000 * (arr[2] || 0) + 60000 * arr[1] + 3600000 * arr[0];
 
     now = new Date();
-    start = new Date(now.getTime() - duration);
-    return start.toISOString();
+    return new Date(now.getTime() - duration);
   },
 
   isNumber: function(n) {
@@ -502,7 +500,8 @@ window.PopUp = {
       start = PopUp.getStart();
 
     if (start) {
-      request.start = start;
+      request.start = start.toISOString();
+      request.duration = -1 * Math.floor(start.getTime() / 1000);
     }
 
     PopUp.sendMessage(request);


### PR DESCRIPTION
Toggl-Button does not update the duration when updating the start date. This results in entries that have a different duration than what was displayed in toggl-button and in toggl.com as well.

This commit updates duration as well whenever the start time changes to fix this.

Fixes #1171 and #1130