### PR TITLE
Fix notification actions triggering without user input

### DIFF
--- a/src/scripts/lib/db.js
+++ b/src/scripts/lib/db.js
@@ -44,20 +44,20 @@ export default class Db {
         this.updateSetting(
           'nannyCheckEnabled',
           request.state,
-          this.togglButton.triggerNotification
+          this.togglButton.setNannyTimer
         );
       } else if (request.type === 'toggle-nanny-from-to') {
         this.updateSetting(
           'nannyFromTo',
           request.state,
-          this.togglButton.triggerNotification,
+          this.togglButton.setNannyTimer,
           this.get('nannyCheckEnabled')
         );
       } else if (request.type === 'toggle-nanny-interval') {
         this.updateSetting(
           'nannyInterval',
           Math.max(request.state, 1000),
-          this.togglButton.triggerNotification,
+          this.togglButton.setNannyTimer,
           this.get('nannyCheckEnabled')
         );
       } else if (request.type === 'toggle-idle') {


### PR DESCRIPTION
Fix multiple issues arising from notifications triggering their action when closed, rather than only when the user interacts with the notification. The main offender was the timer starting automatically whenever the notification is shown.

See commit for details. Fixes #778, #1116, #1170.

### Recommendations for testing

I mainly tested the "reminder to track time". I set this to 1 minute, and started+stopped the timer to trigger the reminder behind the scenes.

When the notification shows, if you either don't do anything or choose "close" (not on macOS+Firefox), the timer **should not start**. 

It's the same for all notifications, though. Needs testing on both Chrome and Firefox, and we should test Windows Firefox.

