### PR TITLE
Re-enable permissions in Firefox

### DIFF
--- a/src/firefox-manifest.json
+++ b/src/firefox-manifest.json
@@ -41,7 +41,9 @@
     "contextMenus",
     "notifications",
     "idle",
-    "tabs",
+    "tabs"
+  ],
+  "optional_permissions": [
     "*://*/"
   ],
   "content_security_policy":

--- a/src/html/settings.html
+++ b/src/html/settings.html
@@ -178,9 +178,11 @@
           <div class="section">
             <h2>Custom Domain Url Permissions</h2>
             <input type="text" id="new-permission" placeholder="Custom domain url"/>
-            <div id="origins-container"></div>
             <p class="description">Define custom domains here. Just type in the domain name without http(s) in format "toggl.com" and select the integration from dropdown. Ports are currently not supported.</p>
-            <button id="add-permission">Add</button>
+            <div class="button-container">
+                <div id="origins-container"></div>
+                <button id="add-permission">Add</button>
+            </div>
             <div class="permissions-toolbar" data-id="custom">
             </div>
             <div id="custom-perm-container"></div>

--- a/src/html/settings.html
+++ b/src/html/settings.html
@@ -175,11 +175,9 @@
             <p class="description">Enable tools you want to use with Toggl Button. You can enable all by clicking "Enable all" button in the top.</p>
           </div>
 
-          </br>
-
           <div class="section">
             <h2>Custom Domain Url Permissions</h2>
-            <input type="text" id="new-permission" placeholder="custom domain url"/>
+            <input type="text" id="new-permission" placeholder="Custom domain url"/>
             <div id="origins-container"></div>
             <p class="description">Define custom domains here. Just type in the domain name without http(s) in format "toggl.com" and select the integration from dropdown. Ports are currently not supported.</p>
             <button id="add-permission">Add</button>

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -21,7 +21,6 @@ if (FF) {
 document.querySelector('#version').textContent = `(${process.env.VERSION})`;
 
 var Settings = {
-  eventsSet: false,
   $startAutomatically: null,
   $stopAutomatically: null,
   $showRightClickButton: null,
@@ -32,7 +31,6 @@ var Settings = {
   lastFilter: null,
   $permissionFilter: document.querySelector('#permission-filter'),
   $permissionFilterClear: document.querySelector('#filter-clear'),
-  permissionItems: [],
   $permissionsList: document.querySelector('#permissions-list'),
   $newPermission: document.querySelector('#new-permission'),
   $originsSelect: document.querySelector('#origins'),
@@ -242,11 +240,6 @@ var Settings = {
       customs,
       tmpkey;
 
-    if (FF) {
-      // Permissions settings are not available on Firefox at this time.
-      return;
-    }
-
     try {
       // Load Custom Permissions list
 
@@ -386,192 +379,193 @@ var Settings = {
     }
   },
 
+  addCustomOrigin: function (e) {
+    var text = Settings.$newPermission.value,
+      domain,
+      permission,
+      o = Settings.$originsSelect;
+
+    if (text.indexOf(':') !== -1) {
+      text = text.split(':')[0];
+    }
+    if (text.indexOf('//') !== -1) {
+      text = text.split('//')[1];
+    }
+
+    Settings.$newPermission.value = text;
+    domain = '*://' + Settings.$newPermission.value + '/';
+    permission = { origins: [domain] };
+
+    chrome.permissions.request(permission, function (result) {
+      if (result) {
+        db.setOrigin(Settings.$newPermission.value, o.value);
+        Settings.$newPermission.value = '';
+      }
+      Settings.loadSitesIntoList();
+      if (result) {
+        document.location.hash = domain;
+      }
+    });
+  },
+
+  removeCustomOrigin: function (e) {
+    var custom,
+      domain,
+      permission,
+      parent,
+      removed = false;
+
+    if (e.target.className === 'remove-custom') {
+      parent = e.target.parentNode;
+      custom = parent.querySelector('strong').textContent;
+      domain = '*://' + custom + '/';
+      permission = { origins: [domain] };
+
+      chrome.permissions.contains(permission, function (allowed) {
+        if (allowed) {
+          chrome.permissions.remove(permission, function (result) {
+            if (result) {
+              removed = true;
+              db.removeOrigin(custom);
+              parent.remove();
+            } else {
+              alert('Fail');
+            }
+          });
+        } else {
+          alert('No "' + custom + '" host permission found.');
+        }
+      });
+
+      if (!removed) {
+        db.removeOrigin(custom);
+        parent.remove();
+      }
+    }
+    return false;
+  },
+
+  toggleOrigin: function (e) {
+    var permission,
+      target = e.target;
+
+    if (e.target.tagName !== 'INPUT') {
+      target = e.target.querySelector('input');
+      target.checked = !target.checked;
+    }
+
+    permission = { origins: target.getAttribute('data-host').split(',') };
+
+    if (target.checked) {
+      chrome.permissions.request(permission, function (result) {
+        if (result) {
+          target.parentNode.classList.remove('disabled');
+        } else {
+          target.checked = false;
+        }
+      });
+    } else {
+      chrome.permissions.contains(permission, function (allowed) {
+        if (allowed) {
+          chrome.permissions.remove(permission, function (result) {
+            if (result) {
+              target.parentNode.classList.add('disabled');
+            } else {
+              target.checked = true;
+            }
+          });
+        } else {
+          alert(
+            'No "' +
+            Settings.origins[target.getAttribute('data-id')] +
+            '" host permission found.'
+          );
+        }
+      });
+    }
+  },
+
+  enableAllOrigins: function (e) {
+    chrome.permissions.request(Settings.getAllPermissions(), function (result) {
+      if (result) {
+        Settings.loadSitesIntoList();
+      }
+    });
+  },
+
+  disableAllOrigins: function (e) {
+    chrome.permissions.getAll(function (result) {
+      var origins = [],
+        i,
+        key,
+        customOrigins = db.getAllOrigins(),
+        skip = false;
+
+      try {
+        for (i = 0; i < result.origins.length; i++) {
+          for (key in customOrigins) {
+            if (customOrigins.hasOwnProperty(key) && !skip) {
+              if (result.origins[i].indexOf(key) !== -1) {
+                skip = true;
+              }
+            }
+          }
+
+          if (
+            result.origins[i].indexOf('toggl') === -1 &&
+            result.origins[i] !== '*://*/*' &&
+            !skip
+          ) {
+            origins.push(result.origins[i]);
+          }
+          skip = false;
+        }
+      } catch (e) {
+        console.error(e)
+        chrome.runtime.sendMessage({
+          type: 'error',
+          stack: e.stack,
+          category: 'Settings'
+        });
+      }
+
+      chrome.permissions.remove({ origins: origins }, function (result, b) {
+        if (result) {
+          Settings.loadSitesIntoList();
+        }
+      });
+    });
+  },
+
   enablePermissionEvents: function() {
-    if (FF) {
-      // Permissions settings are not available on Firefox at this time.
-      return;
-    }
-    if (Settings.eventsSet) {
-      return;
-    }
     Settings.$originsSelect = document.querySelector('#origins');
 
     // Add custom permission (custom domain)
-    document
-      .querySelector('#add-permission')
-      .addEventListener('click', function(e) {
-        var text = Settings.$newPermission.value,
-          domain,
-          permission,
-          o = Settings.$originsSelect;
+    var $addCustomOrigin = document.querySelector('#add-permission');
+    $addCustomOrigin.removeEventListener('click', Settings.addCustomOrigin);
+    $addCustomOrigin.addEventListener('click', Settings.addCustomOrigin);
 
-        if (text.indexOf(':') !== -1) {
-          text = text.split(':')[0];
-        }
-        if (text.indexOf('//') !== -1) {
-          text = text.split('//')[1];
-        }
-
-        Settings.$newPermission.value = text;
-        domain = '*://' + Settings.$newPermission.value + '/';
-        permission = { origins: [domain] };
-        if (!FF) {
-          chrome.permissions.request(permission, function(result) {
-            if (result) {
-              db.setOrigin(Settings.$newPermission.value, o.value);
-              Settings.$newPermission.value = '';
-            }
-            Settings.loadSitesIntoList();
-            if (result) {
-              document.location.hash = domain;
-            }
-          });
-        }
-      });
     // Remove item from custom domain list
-    document
-      .querySelector('#custom-perm-container')
-      .addEventListener('click', function(e) {
-        var custom,
-          domain,
-          permission,
-          parent,
-          removed = false;
-        if (e.target.className === 'remove-custom') {
-          parent = e.target.parentNode;
-          custom = parent.querySelector('strong').textContent;
-          domain = '*://' + custom + '/';
-          permission = { origins: [domain] };
-
-          if (!FF) {
-            chrome.permissions.contains(permission, function(allowed) {
-              if (allowed) {
-                chrome.permissions.remove(permission, function(result) {
-                  if (result) {
-                    removed = true;
-                    db.removeOrigin(custom);
-                    parent.remove();
-                  } else {
-                    alert('Fail');
-                  }
-                });
-              } else {
-                alert('No "' + custom + '" host permission found.');
-              }
-            });
-
-            if (!removed) {
-              db.removeOrigin(custom);
-              parent.remove();
-            }
-          }
-        }
-        return false;
-      });
+    var $removeCustomOrigin = document.querySelector('#custom-perm-container');
+    $removeCustomOrigin.removeEventListener('click', Settings.removeCustomOrigin);
+    $removeCustomOrigin.addEventListener('click', Settings.removeCustomOrigin);
 
     Settings.$permissionsList = document.querySelector('#permissions-list');
 
     // Enable/Disable origin permissions
-    document
-      .querySelector('#permissions-list')
-      .addEventListener('click', function(e) {
-        var permission,
-          target = e.target;
-
-        if (e.target.tagName !== 'INPUT') {
-          target = e.target.querySelector('input');
-          target.checked = !target.checked;
-        }
-
-        permission = { origins: target.getAttribute('data-host').split(',') };
-
-        if (target.checked) {
-          chrome.permissions.request(permission, function(result) {
-            if (result) {
-              target.parentNode.classList.remove('disabled');
-            } else {
-              target.checked = false;
-            }
-          });
-        } else {
-          chrome.permissions.contains(permission, function(allowed) {
-            if (allowed) {
-              chrome.permissions.remove(permission, function(result) {
-                if (result) {
-                  target.parentNode.classList.add('disabled');
-                } else {
-                  target.checked = true;
-                }
-              });
-            } else {
-              alert(
-                'No "' +
-                Settings.origins[target.getAttribute('data-id')] +
-                '" host permission found.'
-              );
-            }
-          });
-        }
-      });
+    var $originList = document.querySelector('#permissions-list');
+    $originList.removeEventListener('click', Settings.toggleOrigin);
+    $originList.addEventListener('click', Settings.toggleOrigin);
 
     // Enable all predefined origins
-    document
-      .querySelector('.enable-all')
-      .addEventListener('click', function(e) {
-        chrome.permissions.request(Settings.getAllPermissions(), function(
-          result
-        ) {
-          if (result) {
-            Settings.loadSitesIntoList();
-          }
-        });
-      });
+    var $enableAllOrigins = document.querySelector('.enable-all');
+    $enableAllOrigins.addEventListener('click', Settings.enableAllOrigins);
+    $enableAllOrigins.addEventListener('click', Settings.enableAllOrigins);
 
     // Disable all predefined origins
-    document
-      .querySelector('.disable-all')
-      .addEventListener('click', function(e) {
-        chrome.permissions.getAll(function(result) {
-          var origins = [],
-            i,
-            key,
-            customOrigins = db.getAllOrigins(),
-            skip = false;
-
-          try {
-            for (i = 0; i < result.origins.length; i++) {
-              for (key in customOrigins) {
-                if (customOrigins.hasOwnProperty(key) && !skip) {
-                  if (result.origins[i].indexOf(key) !== -1) {
-                    skip = true;
-                  }
-                }
-              }
-
-              if (
-                result.origins[i].indexOf('toggl') === -1 &&
-                result.origins[i] !== '*://*/*' &&
-                !skip
-              ) {
-                origins.push(result.origins[i]);
-              }
-              skip = false;
-            }
-          } catch (e) {
-            chrome.runtime.sendMessage({
-              type: 'error',
-              stack: e.stack,
-              category: 'Settings'
-            });
-          }
-
-          chrome.permissions.remove({ origins: origins }, function(result) {
-            if (result) {
-              Settings.loadSitesIntoList();
-            }
-          });
-        });
-      });
+    var $disableAllOrigins = document.querySelector('.disable-all');
+    $disableAllOrigins.removeEventListener('click', Settings.disableAllOrigins);
+    $disableAllOrigins.addEventListener('click', Settings.disableAllOrigins);
   }
 };
 
@@ -606,20 +600,9 @@ document.addEventListener('DOMContentLoaded', function(e) {
     );
     Settings.$sendErrorReports = document.querySelector('#send-error-reports');
 
-    // Permissions tab is unavailable in Firefox at this time. #1060 / #1172
-    if (FF) {
-      document
-        .querySelector('.tab-3')
-        .style.display = 'none'
-      document
-        .querySelector('.tab-link:nth-child(3)')
-        .style.display = 'none'
-    }
-
     // Show permissions page with notice
-    // Permissions tab is hidden in Firefox at this time, so the notice isn't shown either.
     if (
-      !db.get('dont-show-permissions') && !FF
+      !db.get('dont-show-permissions')
     ) {
       document.querySelector('.guide-container').style.display = 'flex';
       document.querySelector(
@@ -634,20 +617,11 @@ document.addEventListener('DOMContentLoaded', function(e) {
 
     // Change active tab.
     let activeTab = Number.parseInt(db.get('settings-active-tab'), 10);
-    if (FF && activeTab > 2) {
-      // Safeguard for Firefox after the Permissions tab has been hidden.
-      activeTab = 0;
-    }
     changeActiveTab(activeTab);
     document.querySelector('body').style.display = 'block';
 
     Settings.showPage();
 
-    Settings.$permissionFilter.addEventListener('focus', function(e) {
-      Settings.permissionItems = document.querySelectorAll(
-        '#permissions-list li'
-      );
-    });
     Settings.$permissionFilter.addEventListener('keyup', function(e) {
       var key,
         val = Settings.$permissionFilter.value;
@@ -664,15 +638,15 @@ document.addEventListener('DOMContentLoaded', function(e) {
         Settings.$permissionFilterClear.style.display = 'none';
       }
       Settings.lastFilter = val;
-      for (key in Settings.permissionItems) {
-        if (Settings.permissionItems.hasOwnProperty(key)) {
-          if (Settings.permissionItems[key].id.indexOf(val) !== -1) {
-            Settings.permissionItems[key].classList.add('filter');
-          } else if (!!Settings.permissionItems[key].classList) {
-            Settings.permissionItems[key].classList.remove('filter');
-          }
+
+      const permissionItems = document.querySelectorAll('#permissions-list li');
+      permissionItems.forEach((item) => {
+        if (item.id.indexOf(val) !== -1) {
+          item.classList.add('filter');
+        } else if (!!item.classList) {
+          item.classList.remove('filter');
         }
-      }
+      });
     });
 
     Settings.$permissionFilterClear.addEventListener('click', function(e) {

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -24,12 +24,9 @@ input[type='number'] {
 .container {
   position: relative;
   width: 800px;
+  max-width: 800px;
   background-color: #fff;
   color: #505050;
-}
-
-.ff .container {
-  width: 100vw;
 }
 
 .tabs {
@@ -39,6 +36,7 @@ input[type='number'] {
   width: 100vw;
   transition: order 300ms ease-in-out;
   align-items: stretch;
+  background-color: inherit;
 }
 
 .tab {
@@ -135,7 +133,6 @@ header ul {
 }
 
 header .tab-link {
-  float: left;
   box-sizing: border-box;
   background: #fdfdfd;
   border-bottom: 1px solid #eee;
@@ -159,12 +156,35 @@ header li:hover {
   clear: both;
 }
 
-#origins-container,
-#perm-container,
-#custom-perm-container {
+#origins-container {
   display: inline;
 }
 
+.permissions-toolbar {
+  width: 375px;
+}
+
+#permission-filter {
+  width: 210px;
+  padding-right: 20px;
+}
+
+.button-container {
+    display: block;
+    margin-top: 10px;
+}
+
+.section {
+  width: 400px;
+}
+
+.section:hover .description {
+  visibility: visible;
+}
+
+/*
+ * For styling permissions and custom permissions lists
+*/
 .origin-list {
   border: 1px solid #cccaca;
   list-style: none;
@@ -173,7 +193,6 @@ header li:hover {
   padding: 5px;
   overflow: auto;
   width: 375px;
-  float: left;
   font-size: 12px;
 }
 
@@ -190,15 +209,27 @@ header li:hover {
   background: #f5f5f5;
 }
 
-.permissions-toolbar {
-  width: 375px;
+.origin-list li:last-child {
+  border-bottom: none;
 }
 
+/*
+ * Custom permissions list
+*/
 #custom-permissions-list li {
   line-height: 23px;
   vertical-align: middle;
   padding-left: 5px;
 }
+
+/*
+ * Permissions list
+*/
+#permissions-list li {
+  display: flex;
+  align-items: center;
+}
+
 
 #permissions-list.filtered li {
   display: none;
@@ -217,36 +248,16 @@ header li:hover {
   outline: 2px solid blue;
 }
 
-.origin-list li:last-child {
-  border-bottom: none;
-}
-
-.section {
-  float: left;
-}
-
-.section:hover .description {
-  visibility: visible;
-}
 
 #permissions-list li div {
   height: 23px;
   line-height: 23px;
   vertical-align: middle;
-  float: left;
 }
 
 #permissions-list li input {
-  float: left;
   margin-right: 10px;
   margin-left: 5px;
-  margin-top: 5px;
-}
-
-#permission-filter {
-  width: 210px;
-  float: left;
-  padding-right: 20px;
 }
 
 #filter-clear {
@@ -261,7 +272,6 @@ header li:hover {
   font-weight: bold;
   margin-left: -21px;
   position: relative;
-  float: left;
   text-align: center;
   margin-top: 3px;
 }
@@ -276,10 +286,6 @@ header li:hover {
   display: block;
 }
 
-.button-container {
-  float: right;
-}
-
 #default-project-container {
   display: inline;
 }
@@ -291,7 +297,6 @@ header li:hover {
 
 .remove-custom {
   display: block;
-  float: left;
   text-align: center;
   text-align: left;
   text-decoration: none;


### PR DESCRIPTION
Previously permissions were broken and/or disabled since the start due to slight differences in the extension API, which seem to be cleared up now.

unfortunately the diff is quite bad. Closes #1060, closes #1169  and probably others that I'll find.

### Changes

- Show the permissions tab in Firefox again
- Change firefox manifest to no longer have wildcard permission by default
- Change firefox manifest to have a wildcard permission in *optional_permissions*, in the same vein as Chrome. This allows us to request permission on any origin at runtime (i.e. turn on/off domains and add custom domains).
- Remove redundant conditional Firefox code in the settings module, consolidating Chrome/Firefox code as they function exactly the same now.

Other:
- Extract each permissions event handlers to its own named function, and remove/add the listener on each new render rather than adding more and more duplicate listeners over time. Fixes awful issues in Firefox where clicking a button could cause progressively more listeners to be created. The root cause is buried somewhere in the way the settings page is rendered, this is a clean fix until such a time as we re-write it.
- Refactor permission filtering in a similar fashion to be a little more manageable.
- Minor html change to settings page layout and input

### Testing

This needs a bunch of testing and playing around with in Firefox, but also Chrome.

I managed to test a custom Jira domain by installing Jira server solution locally.. I wouldn't worry about testing custom domains again like that, just that you can add and remove them correctly in the settings.