### PR TITLE
Fix Jira integration on new SPA layouts

### DIFF
--- a/src/scripts/content/atlassian.js
+++ b/src/scripts/content/atlassian.js
@@ -30,87 +30,34 @@ togglbutton.render(
   }
 );
 
-// Jira 2018-06 new sprint modal
-// Classes are random keep changing so we need to rely on other attributes
+// Jira 2018-X Sprint Modal
+// We select dialog content in order to wait for the SPA to render.
+// N.B. this can bring its own issues (see comment about infinite re-renders).
+// The h1 element gets replaced and no longer has .toggl class, so we have to be careful.
 togglbutton.render(
-  'div[role="dialog"] h1 + button[aria-label="Edit Summary"]',
+  'div[role="dialog"] h1:not(.toggl)',
   { observe: true },
   function(needle) {
     var root = needle.closest('div[role="dialog"]'),
       id = $('div:last-child > a[spacing="none"][href^="/browse/"]:last-child', root),
       description = $('h1:first-child', root),
-      project = $('a[spacing="none"][href*="/projects/"]'),
-      container = createTag('div', 'jira-ghx-toggl-button'),
+      project = $('[data-test-id="navigation-apps.project-switcher-v2"] button > div:nth-child(2) > div'),
       link;
 
     if (project === null) {
-      project = $('div[data-test-id="navigation-apps.project-switcher-v2"] button > div:nth-child(1) > div:first-child');
+      project = $('a[href^="/browse/"][target=_self]');
     }
 
     if (id !== null && description !== null) {
       link = togglbutton.createTimerLink({
-        className: 'jira2017',
+        className: 'jira2018',
         description: id.textContent + ' ' + description.textContent,
         projectName: project && project.textContent
       });
 
-      container.appendChild(link);
-      id.parentNode.appendChild(container);
-    }
-  }
-);
-
-// Jira 2018-08 sprint modal
-// Using the h1 as selector to make sure that it will only try to render the button
-// after Jira has fully rendered the modal content
-togglbutton.render(
-  'div[role="dialog"].sc-krDsej h1:not(.toggl)',
-  { observe: true },
-  function(needle) {
-    var root = needle.closest('div[role="dialog"]'),
-      id = $('a:first-child', root),
-      description = $('h1:first-child', root),
-      project = $('.sc-cremA'),
-      container = createTag('div', 'jira-ghx-toggl-button'),
-      link;
-
-    if (id !== null && description !== null && project !== null) {
-      link = togglbutton.createTimerLink({
-        className: 'jira2018-modal',
-        description: id.textContent + ' ' + description.textContent,
-        projectName: project && project.textContent,
-        buttonType: 'minimal'
-      });
-
-      container.appendChild(link);
-      $('.sc-iBmynh', root).appendChild(container);
-    }
-  }
-);
-
-// Jira 2018 sprint modal
-// Using the h1 as selector to make sure that it will only try to render the button
-// after Jira has fully rendered the modal content
-togglbutton.render(
-  'div[role="dialog"] .ffQQbf:not(.toggl)',
-  { observe: true },
-  function(needle) {
-    var root = needle.closest('div[role="dialog"]'),
-      id = $('a:first-child', root),
-      description = $('h1:first-child', root),
-      project = $('.bgdPDV'),
-      container = createTag('div', 'jira-ghx-toggl-button'),
-      link;
-
-    if (id !== null && description !== null && project !== null) {
-      link = togglbutton.createTimerLink({
-        className: 'jira2017',
-        description: id.textContent + ' ' + description.textContent,
-        projectName: project && project.textContent
-      });
-
-      container.appendChild(link);
-      id.parentNode.appendChild(container);
+      // Link is not placed in exactly the same element as a regular issue page,
+      // else we encounter infinite re-renders when the SPA updates the DOM.
+      id.parentNode.appendChild(link);
     }
   }
 );
@@ -157,7 +104,7 @@ togglbutton.render(
       // the project name from that. Historically project has not always been picked up reliably in Jira.
       projectElement = $('[data-test-id="navigation-apps.project-switcher-v2"] button > div:nth-child(2) > div');
       // Attempt to find the project name in page subtitle in case the sidebar is hidden
-      if (!projectElement) $('a[href^="/browse/"][target=_self]')
+      if (!projectElement) projectElement = $('a[href^="/browse/"][target=_self]')
 
       if (projectElement) {
         project = projectElement.textContent.trim();

--- a/src/scripts/content/atlassian.js
+++ b/src/scripts/content/atlassian.js
@@ -198,6 +198,9 @@ togglbutton.render(
       description = numElem.textContent + description;
     }
 
+    if (projectElem === null) {
+      projectElem = $('[data-test-id="navigation-apps.project-switcher-v2"] button > div:nth-child(2) > div');
+    }
     // JIRA server support
     if (projectElem === null) {
       projectElem = $('#project-name-val');

--- a/src/scripts/content/atlassian.js
+++ b/src/scripts/content/atlassian.js
@@ -76,7 +76,7 @@ togglbutton.render(
 
     if (id !== null && description !== null && project !== null) {
       link = togglbutton.createTimerLink({
-        className: 'jira2018',
+        className: 'jira2018-modal',
         description: id.textContent + ' ' + description.textContent,
         projectName: project && project.textContent,
         buttonType: 'minimal'
@@ -112,6 +112,67 @@ togglbutton.render(
       container.appendChild(link);
       id.parentNode.appendChild(container);
     }
+  }
+);
+
+// Jira 2018-11 issue page. Uses functions for timer values due to SPA on issue-lists.
+togglbutton.render(
+  '#jira-frontend:not(.toggl)',
+  { observe: true },
+  function (elem) {
+    var link,
+      issueNumberElement,
+      container,
+      titleElement,
+      projectElement;
+
+    // The main "issue link" at the top of the issue.
+    // Extra target and role selectors are to avoid picking up wrong links on issue-list-pages.
+    issueNumberElement = $('a[href^="/browse/"][target=_blank]:not([role=list-item])', elem);
+    container = issueNumberElement.parentElement.parentElement.parentElement;
+
+    function getDescription () {
+      var description = '';
+
+      // Title/summary of the issue - we use the hidden "edit" button that's there for a11y
+      // in order to avoid picking up actual page title in the case of issue-list-pages.
+      titleElement = $('h1 ~ button[aria-label]', elem).previousSibling;
+
+      if (issueNumberElement) {
+        description += issueNumberElement.textContent.trim();
+      }
+
+      if (titleElement) {
+        if (description) description += ' ';
+        description += titleElement.textContent.trim();
+      }
+
+      return description
+    }
+
+    function getProject () {
+      var project = '';
+
+      // Best effort to find the "Project switcher" found in the sidebar of most pages, and extract
+      // the project name from that. Historically project has not always been picked up reliably in Jira.
+      projectElement = $('[data-test-id="navigation-apps.project-switcher-v2"] button > div:nth-child(2) > div');
+      // Attempt to find the project name in page subtitle in case the sidebar is hidden
+      if (!projectElement) $('a[href^="/browse/"][target=_self]')
+
+      if (projectElement) {
+        project = projectElement.textContent.trim();
+      }
+
+      return project
+    }
+
+    link = togglbutton.createTimerLink({
+      className: 'jira2018',
+      description: getDescription,
+      projectName: getProject
+    });
+
+    container.appendChild(link);
   }
 );
 

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -447,6 +447,14 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
 }
 
 .toggl-button.jira2018 {
+  margin-left: 8px;
+  margin-top: 0;
+  position: relative; /* margin interferes with Jira layout, using relative pos instead */
+  top: 2px;
+  cursor: pointer;
+}
+
+.toggl-button.jira2018-modal {
   margin-top: .5em;
   margin-left: 0;
   cursor: pointer;


### PR DESCRIPTION
Fixes the Jira integration on the new issue page, and shares a small improvement for project name to the older page as well. You can test this by clicking a link on an individual issue in the "Toggl Button Project", so that a new tab opens with the issue filling the whole page.

Fix Jira integration on the "list of issues" page(s). You can test this by going to the "All issues" page. The selected issue will have a button inside of it in the right pane.

Fix Jira "sprint modal" integration not picking up the project name. You can test this on the "Toggl Button Scrum Project" project, viewing the current sprint, and clicking ona ny issue.

Remove some old dead versions of the sprint modal integration.

There was a contributor PR open for this in September (#1121, I'll update the user later), I've taken this from scratch to avoid using generated/obfuscated class names and use some hopefully more reliable selectors. The button is still placed to the right of the "issue link" as normal, and I tried to avoid interfering with a new button that shows in that area when hovering the mouse.

See commits for details. Diff is awkward, try looking at individual commits if need be.

Closes #1117. 