### PR TITLE
Fix backlog integration

### DIFF
--- a/src/scripts/content/backlog.js
+++ b/src/scripts/content/backlog.js
@@ -5,13 +5,9 @@ togglbutton.render('#issueArea:not(.toggl)', { observe: true }, function(elem) {
     container = createTag('span', ''),
     descFunc,
     ticketNumElem = $('.ticket__key .ticket__key-number', elem),
-    titleElem = $('h3#summary span.title-group__title-text', elem),
-    projectElem = $('.project-header h1 .header-icon-set__name'),
-    descriptionElem = $('#summary span');
-
-  if (!descriptionElem) {
-    return;
-  }
+    titleElem = $('#summary .title-group__title-text', elem),
+    projectElem = $('.project-header .header-icon-set__name'),
+    containerElem = $('#summary *:first-child');
 
   descFunc = function() {
     return ticketNumElem.textContent + ' ' + titleElem.textContent;
@@ -25,5 +21,5 @@ togglbutton.render('#issueArea:not(.toggl)', { observe: true }, function(elem) {
   });
 
   container.appendChild(link);
-  descriptionElem.parentNode.appendChild(container, descriptionElem);
+  containerElem.parentNode.appendChild(container, containerElem);
 });


### PR DESCRIPTION
Fix a selector, and removed some element type specificity from other selectors to reduce risk.

I removed the `if !descriptionElem return` as we want errors to be captured in bugsnag.

Fixes #1181.

When testing, you may have to add a custom domain in the extension settings for `myaccount.backlog.com`.