### PR TITLE
Add multiple issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,36 @@
+---
+name: Bug
+about: Report a problem with an integration or a general feature.
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+* **OS version**: 
+* **Browser version**: 
+* **Extension version**: 
+
+#### Relevant integration (if any):
+
+<!-- Please also include the domain you use the integration on (e.g. https://app.asana.com) -->
+
+### 🐛 Describe the bug
+
+<!-- A clear and concise description of what the bug is, and where it's occurring. -->
+
+### Expected behaviour
+
+<!-- Describe what you expected to happen -->
+
+### Steps to reproduce
+
+<!-- Describe how to reproduce the bug if you can -->
+
+Steps to reproduce the behaviour:
+1. Go to ...
+2. ...
+
+### Other details or context
+
+<!-- Provide any other information, such as steps you tried to work around the problem yourself. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest a new feature. For example, a new setting or menu option.
+title: Add ...
+labels: enhancement
+assignees: ''
+
+---
+
+<!-- If you're asking for an integration with another service (e.g. Trello), please use the "Integration request" issue template instead! -->
+
+### Describe the new feature
+
+<!-- A clear and concise description of what the new feature is. E.g. "I would like a setting to remind me to track time every X minutes." -->
+
+### How does this help you?
+
+<!-- Provide additional context - what problem is this solving, how does it improve your productivity? -->
+
+### If we couldn't add this feature, is there a compromise you can think of?
+
+<!-- Think of a less-perfect solution. It's OK if the answer is no. -->

--- a/.github/ISSUE_TEMPLATE/integration-changes-and-updates.md
+++ b/.github/ISSUE_TEMPLATE/integration-changes-and-updates.md
@@ -1,0 +1,22 @@
+---
+name: Integration changes and updates
+about: Suggest a change or improvement to an existing integration.
+title: Add support for ...
+labels: enhancement
+assignees: ''
+
+---
+
+<!-- If an integration has broken, please report it as a bug instead. -->
+
+### Describe the changes you'd like
+
+<!-- A clear description of the changes you want to see. Keep in mind that it should be useful to the wider user base. -->
+
+### Relevant links or screenshots
+
+<!-- For example, please tell us how to find the relevant screen within the service if it's a new feature -->
+
+#### Additional context
+
+<!-- Add any other context or helpful information here. Maybe share how this improves your productivity with the integration? -->

--- a/.github/ISSUE_TEMPLATE/integration-request.md
+++ b/.github/ISSUE_TEMPLATE/integration-request.md
@@ -1,0 +1,22 @@
+---
+name: Integration request
+about: Suggest a new service you want to see Toggl Button integrated with.
+title: Add integration with SERVICENAME
+labels: integration-request
+assignees: ''
+
+---
+
+<!-- If you're suggesting changes to an existing integration, please use the "Integration changes" issue template instead! -->
+
+**Link to service:** https://example.com
+
+**Is there a free account option?**: Yes/No
+
+### Describe the solution you'd like
+
+<!-- A clear description of where you'd like to see Toggl Button appear inside the service. Feel free to include a screenshot. Keep in mind that it should be useful to the wider user base. -->
+
+#### Additional context
+
+<!-- Add any other context or helpful information here. Maybe share how this fits into your workflow? -->


### PR DESCRIPTION
Add our first multiple issue templates.

I have tried to use a format and language that is easy to follow, and not assuming much technical knowledge or software lingo. New integrations and existing integrations are split to help prioritising and getting the right info for each issue. 

* Integration request - for asking us to add a brand new integration.
* Integration changes and updates - to ask for an integration to support a new feature, or to improve existing functionality
* Feature request - for asking us to add a new feature to the extension.
* Bug - for reporting any bug. I did not find value in splitting up integration bugs and general bugs, I wrote two different ones then thought they're just gonna be used for the wrong things, in addition to the 2 different integration templates.

