### PR TITLE
Fix various bugsnag issues

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -1731,19 +1731,20 @@ window.TogglButton = {
         error.stack = request.stack;
         error.message = request.stack.split('\n')[0];
 
+        // Attempt to extract integration name from content filename
+        errorSource = request.stack.split('content/')[1];
+        if (!!errorSource) {
+          errorSource = errorSource.split('.js')[0];
+        } else {
+          errorSource = 'Unknown';
+        }
+
         if (process.env.DEBUG) {
           console.log(error);
           console.log(request.category + ' Script Error [' + errorSource + ']');
         } else {
           if (request.category === 'Content') {
-            errorSource = request.stack.split('content/')[1];
-            if (!!errorSource) {
-              errorSource = errorSource.split('.js')[0];
-            } else {
-              errorSource = 'Unknown';
-            }
-
-            error.name = 'Content Error';
+            error.name = `Content Error [${errorSource}]`;
             bugsnagClient.notify(error);
           } else {
             report(error);

--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -149,8 +149,18 @@ window.togglbutton = {
     for (i = 0, len = elems.length; i < len; i += 1) {
       elems[i].classList.add('toggl');
     }
-    for (i = 0, len = elems.length; i < len; i += 1) {
-      renderer(elems[i]);
+
+    // Catch content errors here as well as render() in case of async rendering (MutationObserver)
+    try {
+      for (i = 0, len = elems.length; i < len; i += 1) {
+        renderer(elems[i]);
+      }
+    } catch (e) {
+      chrome.runtime.sendMessage({
+        type: 'error',
+        stack: e.stack,
+        category: 'Content'
+      });
     }
   },
 

--- a/src/scripts/lib/bugsnag.js
+++ b/src/scripts/lib/bugsnag.js
@@ -2,7 +2,7 @@ import bugsnag from 'bugsnag-js';
 
 const client = bugsnag({
   apiKey: process.env.BUGSNAG_API_KEY,
-  appVersion: process.env.APP_VERSION,
+  appVersion: process.env.VERSION,
   releaseStage: process.env.NODE_ENV,
   notifyReleaseStages: ['production', 'development'],
   autoBreadcrumbs: false,


### PR DESCRIPTION
* Send the release version again *(At some point the environment variable must have changed, but the client was left in the dust)*

* Catch rendering errors from async rendering (`MutationObserver`). If this is a valid change, we'll probably see significantly more useful errors coming in.

I forced tested this by breaking the wunderlist extension locally, and saw that my error only showed up after the change to error catching was made (if you want to do this yourself, you have to open background page debugging).

![screen shot 2018-12-10 at 13 28 08](https://user-images.githubusercontent.com/6432028/49735594-822f8a80-fc7f-11e8-9933-2696c3aae02f.png)


* Send integration name to bugsnag. The "name" of content script errors will now be like: `Content Error [wunderlist]`. Looks like someone intended to do this originally, but never actually sent their `errorSource` variable.