### PR TITLE
Restore Todoist nested project logic

### DIFF
--- a/src/scripts/content/todoist.js
+++ b/src/scripts/content/todoist.js
@@ -1,32 +1,15 @@
 'use strict';
-
-function getProjectName(item) {
-  var projectItems = item.parentNode.getElementsByClassName('project_item__name');
-  
-  if (projectItems.length > 0) {
-    return projectItems[0].textContent;
-  }
-
-  return item.closest('.list_editor').querySelector('a.project_link span').textContent;
-}
-
-function getTags(item) {
-  var tags = item.querySelectorAll('.labels_holder a:not(.label_sep)')
-  
-  return Array.from(tags).map(function(tag) {
-    return tag.textContent;
-  });
-}
+/* global togglbutton, $ */
 
 togglbutton.render(
   '.task_item .content:not(.toggl)',
   { observe: true },
-  function(elem) {
+  function (elem) {
     var link,
       descFunc,
       container = $('.text', elem);
 
-    descFunc = function() {
+    descFunc = function () {
       var clone = container.cloneNode(true),
         i = 0,
         child = null;
@@ -60,10 +43,114 @@ togglbutton.render(
     link = togglbutton.createTimerLink({
       className: 'todoist',
       description: descFunc(),
-      projectName: getProjectName(elem),
+      projectName: getProjectNames(elem),
       tags: getTags(elem)
     });
 
     container.insertBefore(link, container.lastChild);
   }
 );
+
+
+function getTags(container) {
+  var tags = container.querySelectorAll('.labels_holder a:not(.label_sep)')
+
+  return Array.from(tags).map(function (tag) {
+    return tag.textContent;
+  });
+}
+
+
+/*
+Projects may have a hierarchy in Todoist.
+
+The selector functions for project name take this into account.
+All project names found in the hierarchy will be passed to Toggl button,
+which will figure out what the lowest level existing project is.
+
+E.g.
+- Project hierarchy is MyProject > MySubProject > MyFeatureProject
+- Selector will find all three project names and pass to Toggl Button
+- Toggl Button will first check if MyFeatureProject exists, and if it doesn't, try to use the next parent etc.
+*/
+
+function getProjectNameFromLabel(elem) {
+  var projectLabel = '',
+    projectLabelEle = $('.project_item__name', elem.parentNode.parentNode);
+  if (projectLabelEle) {
+    projectLabel = projectLabelEle.textContent.trim();
+  }
+  return projectLabel;
+}
+
+var levelPattern = /(?:^|\s)indent_([0-9]*?)(?:\s|$)/;
+function getParentEle(sidebarCurrentEle) {
+  var curLevel, parentClass, parentCandidate;
+  curLevel = sidebarCurrentEle.className.match(levelPattern)[1];
+  parentClass = 'indent_' + (curLevel - 1);
+
+  parentCandidate = sidebarCurrentEle;
+  while (parentCandidate.previousElementSibling) {
+    parentCandidate = parentCandidate.previousElementSibling;
+    if (parentCandidate.classList.contains(parentClass)) {
+      break;
+    }
+  }
+  return parentCandidate;
+}
+
+function isTopLevelProject(sidebarCurrentEle) {
+  return sidebarCurrentEle.classList.contains('indent_1');
+}
+
+function getProjectNameHierarchy(sidebarCurrentEle) {
+  var parentProjectEle, projectName;
+  projectName = $('.name', sidebarCurrentEle).firstChild.textContent.trim();
+  if (isTopLevelProject(sidebarCurrentEle)) {
+    return [projectName];
+  }
+  parentProjectEle = getParentEle(sidebarCurrentEle);
+  return [projectName].concat(getProjectNameHierarchy(parentProjectEle));
+}
+
+function projectWasJustCreated(projectId) {
+  return projectId.startsWith('_');
+}
+
+function getSidebarCurrentEle(elem) {
+  var editorInstance,
+    projectId,
+    sidebarRoot,
+    sidebarColorEle,
+    sidebarCurrentEle;
+  editorInstance = elem.closest('.project_editor_instance');
+  if (editorInstance) {
+    projectId = editorInstance.getAttribute('data-project-id');
+    sidebarRoot = $('#project_list');
+    if (projectWasJustCreated(projectId)) {
+      sidebarCurrentEle = $('.current', sidebarRoot);
+    } else {
+      sidebarColorEle = $('#project_color_' + projectId, sidebarRoot);
+      if (sidebarColorEle) {
+        sidebarCurrentEle = sidebarColorEle.closest('.menu_clickable');
+      }
+    }
+  }
+  return sidebarCurrentEle;
+}
+
+function getProjectNames(elem) {
+  var projectNames, viewingInbox, sidebarCurrentEle;
+  viewingInbox = $('#filter_inbox.current, #filter_team_inbox.current');
+  if (viewingInbox) {
+    projectNames = ['Inbox'];
+  } else {
+    sidebarCurrentEle = getSidebarCurrentEle(elem);
+    if (sidebarCurrentEle) {
+      projectNames = getProjectNameHierarchy(sidebarCurrentEle);
+    } else {
+      projectNames = [getProjectNameFromLabel(elem)];
+    }
+  }
+  return projectNames;
+}

--- a/src/scripts/content/todoist.js
+++ b/src/scripts/content/todoist.js
@@ -45,7 +45,7 @@ togglbutton.render(
       return [...tags].map(tag => {
         return tag.textContent;
       });
-    }
+    };
 
     const link = togglbutton.createTimerLink({
       className: 'todoist',
@@ -141,13 +141,15 @@ function getSidebarCurrentEle(elem) {
 }
 
 function getProjectNames(elem) {
-  // return a function for timer link to use, in order for projects to be retrieved
+  // Return a function for timer link to use, in order for projects to be retrieved
   // at the moment the button is clicked (rather than only on load)
   return () => {
     let projectNames;
     let sidebarCurrentEle;
 
-    const isViewingInbox = $('#filter_inbox.current, #filter_team_inbox.current');
+    const isViewingInbox = $(
+      '#filter_inbox.current, #filter_team_inbox.current'
+    );
 
     if (isViewingInbox) {
       projectNames = ['Inbox'];
@@ -160,5 +162,5 @@ function getProjectNames(elem) {
       }
     }
     return projectNames;
-  }
+  };
 }


### PR DESCRIPTION
Some useful project logic was mistakenly removed in #1197 . This re-introduces it. 

The logic being re-introduced looks for the closest project in the Todoist project hierarchy that matches something in the user's Toggl workspace. This was existing behaviour that shouldn't be removed.

Resolves #1223, partially reverts #1197. 

Second commit refactors the module according to eslint/prettier, and tweaks the integration to provide functions to the timer link instead of raw values (so that it can retrieve values at runtime after any changes, not only on load).

#### Testing points

* Lowest level project in Todoist project hierarchy, which matches an existing project in your Toggl workspace, is added to the time entry.
* Tags are added to the timer if the Todoist task has any tags or not.
* If you open a task and then change the description or the tags, the latest values will be reflected in the popup after you click the timer button.
* Extension doesn't error out if there isn't a project etc.