### PR TITLE
Add setting to control automatic tagging

### DIFF
--- a/src/html/settings.html
+++ b/src/html/settings.html
@@ -72,6 +72,11 @@
               <div class="description">This will remember the last project used on each service/url separately. Overrides default project.</div>
             </li>
             <li>
+              <input type="checkbox" id="enable-auto-tagging">
+              <label for="enable-auto-tagging">Enable automatic tagging</label>
+              <div class="description">If a service supports tags or labels, this setting will automatically add them to the timer and create them in Toggl. Not available in all services.</div>
+            </li>
+            <li>
               <input type="checkbox" id="show_right_click_button">
               <label for="show_right_click_button">Show "Start timer" item in right click menu</label>
               <div class="description">Makes it super easy to start timer with any copied text as description. If something is copied to clipboard you can start timer with that text. If clipboard is empty, page title is used as the description.</div>

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -436,6 +436,7 @@ window.TogglButton = {
       defaultProject = db.getDefaultProject(),
       rememberProjectPer = db.get('rememberProjectPer'),
       entry;
+    const enableAutoTagging = db.get('enableAutoTagging');
     TogglButton.$curService = (timeEntry || {}).service;
     TogglButton.$curURL = (timeEntry || {}).url;
 
@@ -463,7 +464,7 @@ window.TogglButton = {
       pid: timeEntry.pid || timeEntry.projectId || null,
       tid: timeEntry.tid || null,
       wid: timeEntry.wid || TogglButton.$user.default_wid,
-      tags: timeEntry.tags || null,
+      tags: enableAutoTagging ? (timeEntry.tags || null) : null,
       billable: timeEntry.billable || false,
       created_with: timeEntry.createdWith || TogglButton.$fullVersion
     };

--- a/src/scripts/lib/db.js
+++ b/src/scripts/lib/db.js
@@ -24,7 +24,8 @@ export default class Db {
     dayEndTime: '17:00',
     defaultProject: 0,
     projects: '',
-    rememberProjectPer: 'false'
+    rememberProjectPer: 'false',
+    enableAutoTagging: false
   };
 
   // core settings: key, default value
@@ -109,6 +110,10 @@ export default class Db {
         request.type === 'update-send-error-reports'
       ) {
         this.updateSetting('sendErrorReports', request.state)
+      } else if (
+        request.type === 'update-enable-auto-tagging'
+      ) {
+        this.updateSetting('enableAutoTagging', request.state)
       }
     } catch (e) {
       bugsnagClient.notify(e);

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -42,6 +42,7 @@ var Settings = {
   $pomodoroVolumeLabel: null,
   $sendUsageStatistics: null,
   $sendErrorReports: null,
+  $enableAutoTagging: null,
   showPage: function() {
     var volume = parseInt(db.get('pomodoroSoundVolume') * 100, 10),
       rememberProjectPer = db.get('rememberProjectPer');
@@ -59,6 +60,10 @@ var Settings = {
         Settings.$showRightClickButton,
         db.get('showRightClickButton')
       );
+      Settings.toggleState(
+        Settings.$enableAutoTagging,
+        db.get('enableAutoTagging')
+      )
       Settings.toggleState(
         Settings.$startAutomatically,
         db.get('startAutomatically')
@@ -598,6 +603,7 @@ document.addEventListener('DOMContentLoaded', function(e) {
       '#send-usage-statistics'
     );
     Settings.$sendErrorReports = document.querySelector('#send-error-reports');
+    Settings.$enableAutoTagging = document.querySelector('#enable-auto-tagging');
 
     // Show permissions page with notice
     if (
@@ -662,6 +668,13 @@ document.addEventListener('DOMContentLoaded', function(e) {
       );
       TogglButton.toggleRightClickButton(
         localStorage.getItem('showRightClickButton') !== 'true'
+      );
+    });
+    Settings.$enableAutoTagging.addEventListener('click', function (e) {
+      Settings.toggleSetting(
+        e.target,
+        localStorage.getItem('enableAutoTagging') !== 'true',
+        'update-enable-auto-tagging'
       );
     });
     Settings.$startAutomatically.addEventListener('click', function(e) {


### PR DESCRIPTION
This setting controls whether service integrations will automatically add any tags/labels detected to the time entry (and therefore creating them in Toggl, too). It defaults to **disabled**.

The main reasoning stems from feedback in #1217, where users have their own tags in the integration - unrelated to the way the team tracks time -  and now the Toggl workspace is being polluted with dozens of new tags since automatic tagging was added to that integration.

This affects behaviour of **very few** other existing integrations (`<= 4` at best), so any unrest when this setting is released should be minimal.

Closes #1217.