### PR TITLE
Fix Freshdesk Mint button duplicating

### DIFF
--- a/src/scripts/content/freshdesk.js
+++ b/src/scripts/content/freshdesk.js
@@ -22,17 +22,19 @@ togglbutton.render('#Pagearea:not(.toggl)', { observe: true }, function(elem) {
 });
 
 // Freshdesk mint (late 2018)
-togglbutton.render('.page-actions__right:not(.toggl)', { observe: true }, elem => {
+togglbutton.render('.page-actions__left:not(.toggl)', { observe: true }, elem => {
   const descriptionElem = $('.description-subject');
 
   // if there's no description element it's overview page, don't show
   if (!descriptionElem) { return }
 
-  const description = descriptionElem ? descriptionElem.textContent.trim() : '';
+  const descriptionSelector = () => {
+    return $('.description-subject').textContent.trim()
+  }
 
   const link = togglbutton.createTimerLink({
     className: 'freshdesk__mint',
-    description,
+    description: descriptionSelector,
     buttonType: 'minimal',
     tags: () => {
       const tagList = $('.list-items');
@@ -45,5 +47,5 @@ togglbutton.render('.page-actions__right:not(.toggl)', { observe: true }, elem =
     }
   })
 
-  elem.parentNode.prepend(link);
+  elem.appendChild(link);
 });

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1120,9 +1120,12 @@ li > .toggl-button.phabricator {
   margin-top: 3px;
 }
 .toggl-button.freshdesk__mint {
-  margin-top: 14px;
-  margin-left: 5px;
+  margin: 0;
+  position: relative;
+  top: 6px;
+  left: 5px;
 }
+
 /********* CLOUDES.ME *********/
 .boxedDotted .toggl-button.cloudes {
   margin-left: 7px;


### PR DESCRIPTION
Fixes #1228 

The button was placed in an element that was not necessarily removed when navigating between views. 

Move the button to a deeper element that is removed/cleaned up when navigating. The element in question is the "left side" of the toolbar, which updates pretty much all the time and is a much more "correct" solution.

This PR also contains a free improvement to fetch the description every time button is clicked (fixes issue when using task navigation on the right side of the page).