### PR TITLE
Fix asana task button

### DIFF
--- a/src/scripts/content/asana.js
+++ b/src/scripts/content/asana.js
@@ -171,10 +171,12 @@ togglbutton.render(
     }
     var link,
       container = $('.SingleTaskPaneToolbar'),
-      description = $(
-        '.SingleTaskPane-titleRow .simpleTextarea',
-        elem.parentNode
-      ).textContent,
+      description = function() {
+        return $(
+          '.SingleTaskPane-titleRow .simpleTextarea',
+          elem.parentNode
+        ).textContent;
+      },
       projectElement = $(
         '.SingleTaskPane-projects .TaskProjectPill-projectName',
         elem.parentNode


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

Auto filling description when new asana task create and immediately start.

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

Asana task name change and TogglButton click immediately.
I can see filled changed task name in description area.

## :memo: Links to relevant issues or information

issue #1212 
