### PR TITLE
Fix tag input behaviour when using keyboard

### DIFF
--- a/src/scripts/lib/autocomplete.js
+++ b/src/scripts/lib/autocomplete.js
@@ -631,6 +631,10 @@ TagAutoComplete.prototype.addEvents = function() {
   });
 
   this.filter.addEventListener('keydown', function (e) {
+    if (e.code === 'Tab') {
+      that.closeDropdown();
+    }
+
     if (e.keyCode === 13) {
       e.preventDefault();
       that.addNew()

--- a/src/scripts/lib/autocomplete.js
+++ b/src/scripts/lib/autocomplete.js
@@ -604,18 +604,54 @@ TagAutoComplete.prototype.setup = function(selected, wid) {
 
 TagAutoComplete.prototype.addEvents = function() {
   var that = this;
-  this.super.addEvents.call(this);
+
+  that.placeholderItem.addEventListener('click', function(e) {
+    setTimeout(function() {
+      that.filter.focus();
+    }, 50);
+  });
+
+  window.addEventListener(
+    'focus',
+    function(e) {
+      if (e.target === that.filter) {
+        that.openDropdown();
+      }
+    },
+    true
+  );
 
   this.el.addEventListener('click', function(e) {
     e.stopPropagation();
     that.selectTag(e);
   });
 
+  this.filter.addEventListener('keyup', function(e) {
+    that.filterSelection();
+  });
+
+  this.filter.addEventListener('keydown', function (e) {
+    if (e.keyCode === 13) {
+      e.preventDefault();
+      that.addNew()
+    }
+
+    if (e.keyCode === 27) {
+      e.preventDefault();
+      that.closeDropdown();
+    }
+  })
+
+  this.filterClear.addEventListener('click', function(e) {
+    that.closeDropdown();
+    e.preventDefault();
+  });
+
   this.clearSelected.addEventListener('click', function(e) {
     that.clearSelectedTags();
   });
 
-  that.addLink.addEventListener('click', function(e) {
+  this.addLink.addEventListener('click', function(e) {
     that.addNew();
   });
 };

--- a/src/scripts/lib/autocomplete.js
+++ b/src/scripts/lib/autocomplete.js
@@ -792,6 +792,10 @@ TagAutoComplete.prototype.addNew = function(text) {
     list = this.el.querySelector('.' + this.type + '-list'),
     item = document.createElement('li');
 
+  if (!val) {
+    return
+  }
+
   item.className = this.type + '-item selected-' + this.type;
   item.setAttribute('title', val);
   item.textContent = val;


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

<!-- Concise description of what this PR achieves, including any context. -->
The root cause is we cannot refer tag input value within event `keyup` listener  `TagAutoComplete`, also there's no preventDefault when enter key is pressed.

I need to refactor `TagAutoComplete.prototype.addEvents`, To make it possible to make things works as expected.

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

Fix #1216 issue. 
