### PR TITLE
Fix styles not being applied

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1535,7 +1535,7 @@ label > .toggl-button.outlook {
 }
 
 /********* NOTION *********/
-.toggl-button.notion {
+#notion-app .toggl-button.notion {
   cursor: pointer;
   margin-right: 13px;
   margin-top: 6px;


### PR DESCRIPTION
The `#notion-app a` selector Notion uses is more specific than `.toggl-button.notion` and thus the `cursor: pointer` declaration is not overriding the `cursor: inherit` that Notion sets.

This commit adds the `#notion-app` ancestor selector with a descendant combinator before the selector for the Toggl Button, increasing the specificity to 3, above Notion's specificity of 2.

Ref (Original PR): #1203