### PR TITLE
Avoid highlighting of timer link text

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -45,6 +45,8 @@
 
 .toggl-button {
   display: inline-block !important;
+  user-select: none;
+  -moz-user-select: none;
   line-height: 20px;
   height: 20px;
   padding-left: 23px;


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

This avoids integration buttons interfering with user copy/paste behaviour. Don't want to move any buttons around. Resolves #1249.

I couldn't forsee this causing any problems so I applied it as default style. Can just apply it to Jira for now if there is any reason to.

## :bug: Recommendations for testing

See it resolves the described issue

## :memo: Links to relevant issues or information

resolves #1249
