### PR TITLE
fix wunderlist and ticktick task rename

### DIFF
--- a/src/scripts/content/ticktick.js
+++ b/src/scripts/content/ticktick.js
@@ -3,8 +3,10 @@
 togglbutton.render('#task-detail-view:not(.toggl)', { observe: true }, function(
   elem
 ) {
-  var text = $('.task-title', elem).textContent,
-    project = $('#project-setting input', elem).getAttribute('value'),
+  var project = $('#project-setting input', elem).getAttribute('value'),
+    text = function() {
+      return $('.task-title', elem).textContent
+    },
     link = togglbutton.createTimerLink({
       className: 'TickTick',
       description: text,

--- a/src/scripts/content/wunderlist.js
+++ b/src/scripts/content/wunderlist.js
@@ -9,12 +9,15 @@ togglbutton.render(
       listElem = $('.lists-scroll'),
       titleElem = $('.taskItem-titleWrapper-title', elem),
       projectElem = $('.active', listElem),
-      projectTitleElem = $('.title', projectElem);
+      projectTitleElem = $('.title', projectElem),
+      description = function() {
+        return titleElem.textContent;
+      };
 
     link = togglbutton.createTimerLink({
       className: 'wunderlist',
       buttonType: 'minimal',
-      description: titleElem.textContent,
+      description: description,
       projectName: projectTitleElem.textContent
     });
 
@@ -29,15 +32,18 @@ togglbutton.render('.subtask:not(.toggl)', { observe: true }, function(elem) {
     container = createTag('span', 'detailItem-toggl small'),
     listElem = $('.lists-scroll'),
     chkBxElem = $('.checkBox', elem),
-    titleElem = $('.title-container'),
+    titleElem = $('.title-container .display-view'),
     projectElem = $('.active', listElem),
     projectTitleElem = $('.title', projectElem),
-    taskElem = $('.display-view', elem);
+    taskElem = $('.display-view', elem),
+    description = function() {
+      return titleElem.textContent + ' - ' + taskElem.textContent
+    };
 
   link = togglbutton.createTimerLink({
     className: 'wunderlist',
     buttonType: 'minimal',
-    description: titleElem.textContent + ' - ' + taskElem.textContent,
+    description: description,
     projectName: projectTitleElem.textContent
   });
 


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?
fix filling description text when task rename (Wunderlist or Ticktick.com)
![anim](https://user-images.githubusercontent.com/13980441/51008137-d33be280-158d-11e9-8b7f-3867b0a0b420.gif)

<!-- Concise description of what this PR achieves, including any context. -->

## :bug: Recommendations for testing

Tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information
fix #1065 
<!-- Link to relevant issues, comments, etc. -->
