### PR TITLE
Fix continued entries not copying tags

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -430,13 +430,15 @@ window.TogglButton = {
   },
 
   createTimeEntry: function(timeEntry, sendResponse) {
-    var project,
-      start = new Date(),
-      error = '',
-      defaultProject = db.getDefaultProject(),
-      rememberProjectPer = db.get('rememberProjectPer'),
-      entry;
+    const type = timeEntry.type;
+    const start = new Date();
+    const defaultProject = db.getDefaultProject();
+    const rememberProjectPer = db.get('rememberProjectPer');
     const enableAutoTagging = db.get('enableAutoTagging');
+    let entry;
+    let error = '';
+    let project;
+
     TogglButton.$curService = (timeEntry || {}).service;
     TogglButton.$curURL = (timeEntry || {}).url;
 
@@ -456,6 +458,8 @@ window.TogglButton = {
       return;
     }
 
+    const shouldIncludeTags = (enableAutoTagging || type === 'list-continue' || type === 'resume')
+
     entry = {
       start: start.toISOString(),
       stop: null,
@@ -464,7 +468,7 @@ window.TogglButton = {
       pid: timeEntry.pid || timeEntry.projectId || null,
       tid: timeEntry.tid || null,
       wid: timeEntry.wid || TogglButton.$user.default_wid,
-      tags: enableAutoTagging ? (timeEntry.tags || null) : null,
+      tags: shouldIncludeTags ? (timeEntry.tags || null) : null,
       billable: timeEntry.billable || false,
       created_with: timeEntry.createdWith || TogglButton.$fullVersion
     };
@@ -1705,11 +1709,11 @@ window.TogglButton = {
         TogglButton.createTimeEntry(request, sendResponse);
         TogglButton.hideNotification('remind-to-track-time');
       } else if (request.type === 'list-continue') {
-        TogglButton.createTimeEntry(request.data, sendResponse);
+        TogglButton.createTimeEntry({...request.data, type: request.type}, sendResponse);
         TogglButton.hideNotification('remind-to-track-time');
       } else if (request.type === 'resume') {
         TogglButton.createTimeEntry(
-          TogglButton.$latestStoppedEntry,
+          { ...TogglButton.$latestStoppedEntry, type: 'resume' },
           sendResponse
         );
         TogglButton.hideNotification('remind-to-track-time');


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

<!-- Concise description of what this PR achieves, including any context. -->

Ensures tags are included when continuing a time entry from the toolbar popup.

This was a regression introduced by the "enable auto tagging" flag. Resolves #1259.

`createTimeEntry` is used by all methods of creating or updating an entry; and it's not always clear where the request comes from. In the relevant cases, I have ensured that the request `type` is following through and check against that to determine if tags are included.

The only time tags should **not** be included is an event unrelated to continuing entries:
* starting a new timer from a tag-supported integration (E.g Todoist) when the `Enable autotagging` setting is disabled.

We are fixing:
* "Continue latest" button in the toolbar popup
* Clicking "Continue" on an entry in the toolbar popup list

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->

 Resolves #1259.
