### PR TITLE
Handle some error cases in noisy extensions

### DIFF
--- a/src/scripts/content/google-calendar.js
+++ b/src/scripts/content/google-calendar.js
@@ -12,6 +12,10 @@ togglbutton.render('div[data-chips-dialog="true"]', { observe: true }, elem => {
   // Grab the "toolbar" by finding "Close" button, which is _always_ present.
   // Note: do not use the aria-label values, it will break with i18n.
   const target = $('[aria-label]:last-child', elem).parentElement.nextSibling;
+  if (!target || target.tagName.toLowerCase() !== 'div') {
+    // Looks like the "create event" dialog, don't attempt to insert a button.
+    return;
+  }
 
   const getDescription = () => {
     const title = $('span[role="heading"]', elem);

--- a/src/scripts/content/slack.js
+++ b/src/scripts/content/slack.js
@@ -20,14 +20,19 @@ togglbutton.render('#channel_name:not(.toggl)', { observe: true }, () => {
 
 togglbutton.render('.c-message--hover:not(.toggl)', { observe: true }, elem => {
   const placeholder = $('.c-message_actions__button:last-child');
-  const description = $('.c-message__body', elem).textContent.trim();
-  const projectName = $('#team_name').textContent.trim();
-  const button = document.createElement('button');
+  const description = $('.c-message__body', elem);
+  const projectName = $('#team_name');
 
+  if (!description) {
+    // Non-text message, don't insert button.
+    return;
+  }
+
+  const button = document.createElement('button');
   const link = togglbutton.createTimerLink({
     className: 'slack-message',
-    projectName,
-    description,
+    projectName: projectName.textContent.trim(),
+    description: description.textContent.trim(),
     buttonType: 'minimal'
   });
 


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

<!-- Concise description of what this PR achieves, including any context. -->

- Google Calendar: ignore "create event" dialog

- Slack: ignore non-text message types

## :bug: Recommendations for testing

All still works good.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->
