### PR TITLE
Add basic support for Salesforce Lightning's Console views

### DIFF
--- a/src/scripts/content/salesforce.js
+++ b/src/scripts/content/salesforce.js
@@ -1,95 +1,5 @@
 'use strict';
 
-// Updated Listing view
-togglbutton.render(
-  '.bMyTask .list tr.dataRow:not(.toggl)',
-  { observe: true },
-  function (elem) {
-    const container = elem.querySelectorAll(
-      '.bMyTask .list tr.dataRow .dataCell a'
-    )[0];
-    if (container === null) {
-      return;
-    }
-
-    const descFunc = () => {
-      return container.textContent;
-    };
-
-    const projectFunc = () => {
-      return (
-        ($('.accountBlock .mruText') &&
-          $('.accountBlock .mruText').textContent) ||
-        ''
-      );
-    };
-
-    const link = togglbutton.createTimerLink({
-      className: 'salesforce',
-      buttonType: 'minimal',
-      description: descFunc,
-      projectName: projectFunc
-    });
-
-    container.insertBefore(link, container.firstChild);
-  }
-);
-
-// Detail view
-togglbutton.render('#bodyCell:not(.toggl)', { observe: true }, function (elem) {
-  const container = $('.content', elem);
-
-  if (container === null) {
-    return;
-  }
-
-  const parent = $('.pageType', container);
-
-  if (!parent) {
-    return;
-  }
-
-  const descFunc = () => {
-    const desc = $('.pageDescription', container);
-    return desc ? desc.textContent.trim() : '';
-  };
-
-  const projectFunc = () => {
-    return (
-      ($('.accountBlock .mruText') &&
-        $('.accountBlock .mruText').textContent) ||
-      ''
-    );
-  };
-
-  const link = togglbutton.createTimerLink({
-    className: 'salesforce',
-    description: descFunc,
-    projectName: projectFunc
-  });
-
-  parent.appendChild(link);
-});
-
-// Lightning Task Detail view
-togglbutton.render(
-  '.runtime_sales_activitiesTaskCommon:not(.toggl)',
-  { observe: true },
-  function (elem) {
-    const getDescription = () => {
-      return $('.subject .uiOutputText', elem).textContent.trim();
-    };
-
-    const link = togglbutton.createTimerLink({
-      className: 'salesforce-lightning',
-      description: getDescription,
-      buttonType: 'minimal'
-    });
-
-    $('.left', elem).appendChild(link);
-  }
-);
-
 // Lightning Task List view/sidebar
 togglbutton.render(
   '.slds-split-view__list-item:not(.toggl)',
@@ -100,11 +10,44 @@ togglbutton.render(
     };
 
     const link = togglbutton.createTimerLink({
-      className: 'salesforce-lightning-list',
+      className: 'salesforce-list',
       description: getDescription,
       buttonType: 'minimal'
     });
 
     $('.uiOutputText', elem).parentElement.parentElement.appendChild(link);
   }
+);
+
+togglbutton.render(
+  '.slds-page-header__title:not(.toggl)',
+  { observe: true },
+  function (elem) {
+    const description = $('.uiOutputText:not(.selectedListView)', elem);
+    if (!description) {
+      // Looks like a title not relevant to a record, ignore.
+      return;
+    }
+
+    const getDescription = () => {
+      return description.textContent.trim();
+    };
+    const getProject = () => {
+      let project = $('[title="Account Name"]');
+      if (!project) project = $('[title="Related To"]');
+
+      if (project) {
+        return project.nextSibling.textContent.trim();
+      }
+      return getDescription();
+    };
+
+    const link = togglbutton.createTimerLink({
+      className: 'salesforce',
+      description: getDescription,
+      projectName: getProject,
+      buttonType: 'minimal'
+    });
+    description.appendChild(link);
+  }, 'header,.active,.oneRecordHomeFlexipage'
 );

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1068,28 +1068,23 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
 }
 
 /********* SALESFORCE *********/
-.toggl-button.salesforce {
-  padding-right: 5px;
-  margin-bottom: -6px;
+.toggl-button:not(.toggl-button-edit-form-button).salesforce {
+  margin-top: 0;
+  position: relative;
+  top: 2px;
+  left: 5px;
+}
+.custom-truncate .toggl-button.salesforce {
+  /* avoid button image being truncated */
+  padding-left: 25px;
 }
 
-.toggl-button.salesforce:not(.minimal) {
-  margin-left: 5px;
-  font-size: 12px;
-  text-decoration: none;
-  font-weight: normal;
-}
-
-.toggl-button.salesforce-lightning {
-  margin-top: 5px;
-}
-
-.slds-split-view__list-item .salesforce-lightning-list {
+.slds-split-view__list-item .salesforce-list {
   position: absolute;
   right: .5rem;
   visibility: hidden;
 }
-.slds-split-view__list-item:hover .salesforce-lightning-list {
+.slds-split-view__list-item:hover .salesforce-list {
   background-color: white !important;
   visibility: visible;
   z-index: 1;


### PR DESCRIPTION

Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

<!-- Concise description of what this PR achieves, including any context. -->

Related #734. We've been advised that the Console view is probably quite important, so I have added basic support for it.

Also Remove redundant Salesforce integration code, Remove lightning suffixes from Salesforce class names

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

In regular "Sales" mode, check the following (may need to select a record from the list)

* Task https://um5.lightning.force.com/lightning/o/Task/home
* Contact https://um5.lightning.force.com/lightning/r/Contact/0034J0000022CbpQAE/view
* Account https://um5.lightning.force.com/lightning/r/Account/0014J000002YJ2OQAW/view

(there are many others, but I'd say focus on what appears to be main records)

Then in "Sales Console" mode, check the same pages again.

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->

Related #734 
