### PR TITLE
Use minimal button for Todoist integration

### DIFF
--- a/src/scripts/content/todoist.js
+++ b/src/scripts/content/todoist.js
@@ -51,6 +51,7 @@ togglbutton.render(
       className: 'todoist',
       description: descriptionSelector,
       projectName: getProjectNames(elem),
+      buttonType: 'minimal',
       tags: tagsSelector
     });
 
@@ -71,7 +72,7 @@ E.g.
 - Toggl Button will first check if MyFeatureProject exists, and if it doesn't, try to use the next parent etc.
 */
 
-function getProjectNameFromLabel(elem) {
+function getProjectNameFromLabel (elem) {
   let projectLabel = '';
   const projectLabelEle = $('.project_item__name', elem.parentNode.parentNode);
   if (projectLabelEle) {
@@ -80,7 +81,7 @@ function getProjectNameFromLabel(elem) {
   return projectLabel;
 }
 
-function getParentEle(sidebarCurrentEle) {
+function getParentEle (sidebarCurrentEle) {
   const levelPattern = /(?:^|\s)indent_(\d*?)(?:\s|$)/;
   const curLevel = sidebarCurrentEle.className.match(levelPattern)[1];
   const parentClass = 'indent_' + (curLevel - 1);
@@ -95,11 +96,11 @@ function getParentEle(sidebarCurrentEle) {
   return parentCandidate;
 }
 
-function isTopLevelProject(sidebarCurrentEle) {
+function isTopLevelProject (sidebarCurrentEle) {
   return sidebarCurrentEle.classList.contains('indent_1');
 }
 
-function getProjectNameHierarchy(sidebarCurrentEle) {
+function getProjectNameHierarchy (sidebarCurrentEle) {
   const projectName = $(
     '.name',
     sidebarCurrentEle
@@ -113,11 +114,11 @@ function getProjectNameHierarchy(sidebarCurrentEle) {
   return [projectName].concat(getProjectNameHierarchy(parentProjectEle));
 }
 
-function projectWasJustCreated(projectId) {
+function projectWasJustCreated (projectId) {
   return projectId.startsWith('_');
 }
 
-function getSidebarCurrentEle(elem) {
+function getSidebarCurrentEle (elem) {
   let projectId;
   let sidebarRoot;
   let sidebarColorEle;
@@ -140,7 +141,7 @@ function getSidebarCurrentEle(elem) {
   return sidebarCurrentEle;
 }
 
-function getProjectNames(elem) {
+function getProjectNames (elem) {
   // Return a function for timer link to use, in order for projects to be retrieved
   // at the moment the button is clicked (rather than only on load)
   return () => {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -716,10 +716,8 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
 
 /********* TODOIST *********/
 .toggl-button.todoist {
-  font-size: 12px;
   padding-left: 20px;
-  background-size: 18px;
-  margin-left: 7px;
+  margin-bottom: -6px;
   visibility: hidden;
 }
 
@@ -727,7 +725,7 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
   visibility: visible;
 }
 
-.task_content_item:hover .toggl-button {
+.task_item:hover .toggl-button.todoist {
   visibility: visible;
 }
 


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

* Uses minimal button for Todoist integration.

* Improves hover behavior in Todoist integration by using the proper parent hover div (`task_item` instead of `task_content_item`).  `task_content_item` is lower in the DOM, so hovering parts of the task would not cause the toggl button to appear.

## :bug: Recommendations for testing

Tested in chrome

## :memo: Links to relevant issues or information

Split off from [here](https://github.com/toggl/toggl-button/pull/1277#issuecomment-462009197)