### PR TITLE
Refactor "link activation" to query DOM instead of storing list of links

### DIFF
--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -95,7 +95,6 @@ window.togglbutton = {
   $billable: null,
   isStarted: false,
   element: null,
-  links: [],
   serviceName: '',
   projectBlurTrigger: null,
   taskBlurTrigger: null,
@@ -499,9 +498,6 @@ window.togglbutton = {
       return false;
     });
 
-    // Add created link to links array
-    togglbutton.links.push({ params: params, link: link });
-
     return link;
   },
 
@@ -514,10 +510,16 @@ window.togglbutton = {
 
   // Make button corresponding to 'entry' active, if any. ; otherwise inactive.
   updateTimerLink: function (entry) {
-    const current = togglbutton.links.find(
-      button => invokeIfFunction(button.params.description) === entry.description);
+    if (!entry) {
+      togglbutton.deactivateAllTimerLinks();
+      return;
+    }
+
+    const current = Array.from(document.querySelectorAll('.toggl-button:not(.toggl-button-edit-form-button)'))
+      .find(button => button.title.indexOf(entry.description) !== -1);
+
     if (current) {
-      togglbutton.activateTimerLink(current.link);
+      togglbutton.activateTimerLink(current);
     } else {
       togglbutton.deactivateAllTimerLinks();
     }
@@ -542,6 +544,7 @@ window.togglbutton = {
 
   deactivateTimerLink: function (link) {
     link.classList.remove('active');
+    link.style.color = '';
     const minimal = link.classList.contains('min');
     if (!minimal) {
       link.textContent = 'Start timer';

--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -122,6 +122,7 @@ window.togglbutton = {
               // If mutationSelector is defined, render the start timer link only when an element
               // matching the selector changes.
               // Multiple selectors can be used by comma separating them.
+              // mutationSelector = mutationSelector ? `${mutationSelector},*:not(.toggl-button)` : '*:not(.toggl-button)';
               if (mutationSelector) {
                 const matches = mutations.filter(function (mutation) {
                   return mutation.target.matches(mutationSelector);
@@ -526,11 +527,16 @@ window.togglbutton = {
   },
 
   activateTimerLink: function (link) {
+    if (link.classList.contains('active')) {
+      return;
+    }
+
     togglbutton.deactivateAllTimerLinks();
     link.classList.add('active');
     link.style.color = '#1ab351';
-    const minimal = link.classList.contains('min');
-    if (!minimal) {
+
+    const isMinimal = link.classList.contains('min');
+    if (!isMinimal) {
       link.textContent = 'Stop timer';
     }
   },


### PR DESCRIPTION
*Merging to feature branch*.

Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

<!-- Concise description of what this PR achieves, including any context. -->

Cleans up link activation/deactivation further.

The `togglbutton.links` list was in fact a "memory leak" of detached DOM elements and would infinitely increase in size over time. I did not see it used anywhere else.

It also caused buggy functionality with "activating" the active timer link on the page, due to old link references never being removed.

Also a bonus fix for stopped links appearing green when they should not. 

Second commit fixes "infinite re-render". Upon activation, the button class list would be mutated too much and cause re-renders to happen in integrations that did not have mutation selectors. In future, we should seek to completely construct the button before adding it to the DOM. There is an opportunity to *always* include `*:not(.toggl-button)` in mutation selectors by default in future, but I did not do that here.

Related to #1275.

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

Recommended to test that Trello or Todoist perform as expected. I developed against Trello.

Links should activate/deactivate correctly. So if you have a timer running, and you open the related Trello card for example, the link will show as `Stop Timer` because it's already running, no matter how many times you open and close the card.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

