### PR TITLE
Add Kanbanist integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Add Toggl one-click time tracking to popular web tools.
 - [Intercom](https://www.intercom.com/)
 - [Jira](https://www.atlassian.com/software/jira)
 - [Kanbanery](https://www.kanbanery.com/)
+- [Kanbanist](https://kanban.ist/)
 - [Kanboard](https://kanboard.org/)
 - [KhanAcademy](https://www.khanacademy.org/)
 - [LiquidPlanner](https://www.liquidplanner.com/)

--- a/src/scripts/content/kanbanist.js
+++ b/src/scripts/content/kanbanist.js
@@ -1,0 +1,29 @@
+'use strict';
+/* global togglbutton, $ */
+
+togglbutton.render(
+  '.ListItem:not(.toggl)',
+  { observe: true },
+  $container => {
+    const descriptionSelector = () => {
+      const $description = $('.ListItem-text', $container);
+      return $description.textContent.trim();
+    };
+
+    const projectSelector = () => {
+      const $project = $('.ListItem-project-name', $container);
+      return $project.textContent.trim();
+    };
+
+    const linkStyle = 'margin-left: 5px';
+    const link = togglbutton.createTimerLink({
+      className: 'kanbanist',
+      description: descriptionSelector,
+      projectName: projectSelector,
+      buttonType: 'minimal'
+    });
+    link.classList.add('task-link', 'sr-only', 'sr-only-focusable');
+    link.setAttribute('style', linkStyle);
+    $('.task-link', $container).after(link);
+  }
+);

--- a/src/scripts/origins.js
+++ b/src/scripts/origins.js
@@ -253,6 +253,10 @@ export default {
     url: '',
     name: 'Kanboard'
   },
+  'kanban.ist': {
+    url: '*://*.kanban.ist/*',
+    name: 'Kanbanist'
+  },
   'liquidplanner.com': {
     url: '*://app.liquidplanner.com/*',
     name: 'Liquidplanner'


### PR DESCRIPTION
## :star2: What does this PR do?
Add Kanbanist integration.  
Kanbanist is an inofficial tool that adds Kanban-like task management for Todoist. The toggl buttons will appear in each Kanban box just beside the task title when you hover the cursor on Kanban boxes. 

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information
- https://kanban.ist
- https://github.com/mwakerman/kanbanist/issues/33

## Screenshots
### Chrome
![image](https://user-images.githubusercontent.com/42759138/53190923-f6a68280-364d-11e9-8abf-4c7db9609707.png)
On hover:
![image](https://user-images.githubusercontent.com/42759138/53190955-06be6200-364e-11e9-8410-5498c06964ed.png)

### Firefox
![image](https://user-images.githubusercontent.com/42759138/53471228-48646800-3aa7-11e9-8b4a-9f0fcdb744a2.png)
On hover:
![image](https://user-images.githubusercontent.com/42759138/53471248-4f8b7600-3aa7-11e9-92c0-0b0b2415968c.png)
