### PR TITLE
Add feature to reset all settings

### DIFF
--- a/src/chrome-manifest.json
+++ b/src/chrome-manifest.json
@@ -32,7 +32,8 @@
   },
   "options_ui": {
     "page": "html/settings.html",
-    "chrome_style": true
+    "chrome_style": true,
+    "open_in_tab": true
   },
   "permissions": [
     "*://*.toggl.com/*",

--- a/src/firefox-manifest.json
+++ b/src/firefox-manifest.json
@@ -30,7 +30,8 @@
     "128": "images/icon-128.png"
   },
   "options_ui": {
-    "page": "html/settings.html"
+    "page": "html/settings.html",
+    "open_in_tab": true
   },
   "permissions": [
     "*://*.toggl.com/*",

--- a/src/html/settings.html
+++ b/src/html/settings.html
@@ -131,6 +131,12 @@
                 </p>
               </div>
             </li>
+            <li class="danger-zone">
+              <hr />
+              <h3>Danger Zone</h3>
+              <button id="reset-all-settings">Reset all settings to default</button>
+              <p><strong>This action is irreversible.</strong> All Toggl Button settings will be reset and you will be logged out.</p>
+            </li>
           </ul>
         </div>
         <div class="tab tab-2">

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -1798,7 +1798,7 @@ window.TogglButton = {
           db.updateSetting('enableAutoTagging', request.state);
         } else if (request.type === 'settings-reset') {
           TogglButton.logoutUser();
-
+          resolve();
           // Background messages
         } else if (request.type === 'activate') {
           TogglButton.checkDailyUpdate();

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -1035,25 +1035,27 @@ window.TogglButton = {
     });
   },
 
-  logoutUser: function (sendResponse) {
-    TogglButton.ajax('/sessions?created_with=' + TogglButton.$fullVersion, {
-      method: 'DELETE',
-      onLoad: function (xhr) {
-        TogglButton.$user = null;
-        TogglButton.updateTriggers(null);
-        localStorage.removeItem('userToken');
-        sendResponse({ success: xhr.status === 200, xhr: xhr });
-        if (xhr.status === 200) {
-          TogglButton.setBrowserActionBadge();
+  logoutUser: function () {
+    return new Promise((resolve) => {
+      TogglButton.ajax('/sessions?created_with=' + TogglButton.$fullVersion, {
+        method: 'DELETE',
+        onLoad: function (xhr) {
+          TogglButton.$user = null;
+          TogglButton.updateTriggers(null);
+          localStorage.removeItem('userToken');
+          resolve({ success: xhr.status === 200, xhr: xhr });
+          if (xhr.status === 200) {
+            TogglButton.setBrowserActionBadge();
+          }
+          TogglButton.refreshPageLogout();
+        },
+        onError: function (xhr) {
+          resolve({
+            success: false,
+            type: 'logout'
+          });
         }
-        TogglButton.refreshPageLogout();
-      },
-      onError: function (xhr) {
-        sendResponse({
-          success: false,
-          type: 'logout'
-        });
-      }
+      });
     });
   },
 
@@ -1794,6 +1796,8 @@ window.TogglButton = {
           request.type === 'update-enable-auto-tagging'
         ) {
           db.updateSetting('enableAutoTagging', request.state);
+        } else if (request.type === 'settings-reset') {
+          TogglButton.logoutUser();
 
           // Background messages
         } else if (request.type === 'activate') {
@@ -1814,7 +1818,7 @@ window.TogglButton = {
             })
             .catch(() => resolve(undefined));
         } else if (request.type === 'logout') {
-          TogglButton.logoutUser(sendResponse);
+          TogglButton.logoutUser().then(resolve);
         } else if (request.type === 'sync') {
           TogglButton.fetchUser();
         } else if (request.type === 'timeEntry') {

--- a/src/scripts/lib/bugsnag.js
+++ b/src/scripts/lib/bugsnag.js
@@ -1,4 +1,5 @@
 import bugsnag from 'bugsnag-js';
+const browser = require('webextension-polyfill');
 
 function noop (fnName) {
   return function () {
@@ -23,6 +24,7 @@ function getBugsnagClient () {
     autoCaptureSessions: false,
     collectUserIp: false,
     beforeSend: async function (report) {
+      const db = browser.extension.getBackgroundPage().db;
       const sendErrorReports = await db.get('sendErrorReports', true);
       if (!sendErrorReports) {
         report.ignore();

--- a/src/scripts/lib/db.js
+++ b/src/scripts/lib/db.js
@@ -259,6 +259,18 @@ export default class Db {
     }
   }
 
+  resetAllSettings () {
+    const allSettings = { ...DEFAULT_SETTINGS, ...CORE_SETTINGS };
+    return this.setMultiple(allSettings)
+      .then(() => {
+        bugsnagClient.leaveBreadcrumb('Completed reset all settings');
+      })
+      .catch((e) => {
+        bugsnagClient.notify(e);
+        alert('Failed to reset settings. Please contact support@toggl.com for assistance or try re-installing the extension.');
+      });
+  }
+
   _migrateToStorageSync () {
     console.info('Migrating settings to v2');
     bugsnagClient.leaveBreadcrumb('Attempting settings migration to v2');

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -877,9 +877,9 @@ document.addEventListener('DOMContentLoaded', async function (e) {
       bugsnagClient.leaveBreadcrumb('Confirmed reset all settings');
       db.resetAllSettings()
         .then(() => {
-          // window.location.reload();
           browser.runtime
             .sendMessage({ type: 'settings-reset' })
+            .then(() => window.location.reload())
             .catch(() => window.location.reload());
         });
     });

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -475,6 +475,7 @@ const Settings = {
 
     if (e.target.tagName !== 'INPUT') {
       target = e.target.querySelector('input');
+      if (!target) target = e.target.parentElement.querySelector('input');
       target.checked = !target.checked;
     }
 

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -1,5 +1,5 @@
-import './lib/bugsnag';
 import TogglOrigins from './origins';
+import bugsnagClient from './lib/bugsnag';
 const browser = require('webextension-polyfill');
 
 let TogglButton = browser.extension.getBackgroundPage().TogglButton;
@@ -45,6 +45,7 @@ const Settings = {
   $sendUsageStatistics: null,
   $sendErrorReports: null,
   $enableAutoTagging: null,
+  $resetAllSettings: null,
   showPage: async function () {
     const pomodoroSoundVolume = await db.get('pomodoroSoundVolume');
     const volume = parseInt(pomodoroSoundVolume * 100, 10);
@@ -622,6 +623,7 @@ document.addEventListener('DOMContentLoaded', async function (e) {
     );
     Settings.$sendErrorReports = document.querySelector('#send-error-reports');
     Settings.$enableAutoTagging = document.querySelector('#enable-auto-tagging');
+    Settings.$resetAllSettings = document.querySelector('#reset-all-settings');
 
     // Show permissions page with notice
     const dontShowPermissions = await db.get('dont-show-permissions');
@@ -699,7 +701,7 @@ document.addEventListener('DOMContentLoaded', async function (e) {
       Settings.toggleSetting(e.target, !startAutomatically, 'toggle-start-automatically');
     });
     Settings.$stopAutomatically.addEventListener('click', async function (e) {
-      const stopAutomatically = await db.getItem('stopAutomatically');
+      const stopAutomatically = await db.get('stopAutomatically');
       Settings.toggleSetting(e.target, !stopAutomatically, 'toggle-stop-automatically');
     });
     Settings.$postPopup.addEventListener('click', async function (e) {
@@ -862,6 +864,24 @@ document.addEventListener('DOMContentLoaded', async function (e) {
         ).style.display =
           'none';
       });
+
+    Settings.$resetAllSettings.addEventListener('click', function (e) {
+      bugsnagClient.leaveBreadcrumb('Triggered reset all settings');
+      const isConfirmed = confirm('Are you sure you want to reset your settings?');
+      if (!isConfirmed) {
+        bugsnagClient.leaveBreadcrumb('Cancelled reset all settings');
+        return;
+      }
+
+      bugsnagClient.leaveBreadcrumb('Confirmed reset all settings');
+      db.resetAllSettings()
+        .then(() => {
+          // window.location.reload();
+          browser.runtime
+            .sendMessage({ type: 'settings-reset' })
+            .catch(() => window.location.reload());
+        });
+    });
 
     Settings.$sendUsageStatistics.addEventListener('click', async function (e) {
       const sendUsageStatistics = await db.get('sendUsageStatistics');

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -32,7 +32,7 @@ input[type='number'] {
 .tabs {
   display: flex;
   overflow: hidden;
-  height: 350px;
+  height: calc(100vh - 35px - 42px);
   width: 100vw;
   transition: order 300ms ease-in-out;
   align-items: stretch;


### PR DESCRIPTION
*Depends on PR #1296, base is set to that branch at the moment.*

Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

<!-- Concise description of what this PR achieves, including any context. -->

*Note*: This PR basically solves the core of "Settings standalone page" as well - #1287. I needed to move it in order to use `confirm()` etc. Other issue is probably still valid but estimate may be reduced for the final cleanup.

Adds a button in a new area at the bottom of the settings page. 

Clicking it will:
* Show a confirmation with option to cancel
* Re-set all `storage.sync` settings to default values
* Log out the user. This is the safest way to "reset" the extension and its state.


## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

Settings don't break, extension doesn't get into a completely broken state or anything like that.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

Closes #1317 .

<!-- Link to relevant issues, comments, etc. -->
