### PR TITLE
Fix stack filename replacement for Chrome

### DIFF
--- a/src/scripts/lib/bugsnag.js
+++ b/src/scripts/lib/bugsnag.js
@@ -32,7 +32,7 @@ function getBugsnagClient () {
         frame.file = frame.file.replace(/chrome-extension:/g, 'chrome_extension:');
         // Create consistent file paths for source mapping / error reporting.
         frame.file = frame.file.replace(
-          /(moz-extension|file):\/\/.*\/scripts\/(.*)/ig,
+          /.*(moz-extension|chrome_extension|chrome-extension|file):\/\/.*\/scripts\/(.*)/ig,
           'togglbutton://scripts/$2'
         );
         return frame;


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

<!-- Concise description of what this PR achieves, including any context. -->

Fixes some filename replacements for source mapping on bugsnag. The chrome prefix was missing from the regex.

The `.*` added to the beginning is to account for some strange strings that sometimes come in, like `@ [12]/<@moz-extension://......`

## :bug: Recommendations for testing

Looks good

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->
