### PR TITLE
Add Scrapbox integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Add Toggl one-click time tracking to popular web tools.
 - [Rindle](https://rindle.com/)
 - [Rollbar](https://rollbar.com/)
 - [Salesforce](http://www.salesforce.com/)
+- [Scrapbox](https://scrapbox.io/)
 - [Sentry](https://sentry.io/)
 - [SherpaDesk](http://www.sherpadesk.com/)
 - [Sifter](https://www.sifterapp.com/)

--- a/src/scripts/content/scrapbox.js
+++ b/src/scripts/content/scrapbox.js
@@ -1,0 +1,20 @@
+'use strict';
+/* global togglbutton, $ */
+
+togglbutton.render(
+  '.telomere-border .description:not(.toggl)',
+  { observe: true },
+  $container => {
+    const descriptionSelector = () => {
+      const $description = $container.closest('.line').querySelector('.text');
+      return $description.textContent.trim();
+    };
+
+    const link = togglbutton.createTimerLink({
+      className: 'scrapbox',
+      description: descriptionSelector
+    });
+
+    $container.appendChild(link);
+  }
+);

--- a/src/scripts/origins.js
+++ b/src/scripts/origins.js
@@ -431,6 +431,10 @@ export default {
     name: 'Salesforce Lightning',
     file: 'salesforce.js'
   },
+  'scrapbox.io': {
+    url: '*://scrapbox.io/*',
+    name: 'Scrapbox'
+  },
   'sentry.io': {
     url: '*://*.sentry.io/*',
     name: 'Sentry'

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1587,3 +1587,28 @@ label > .toggl-button.outlook {
 .toggl-button.dropbox-paper {
   vertical-align: middle;
 }
+
+/********* SCRAPBOX *********/
+.toggl-button.scrapbox {
+  margin: 0 1px 0 2px;
+  font-size: 12px;
+  height: 25px;
+  line-height: 25px;
+  background-color: white;
+  padding-left: 27px;
+  padding-right: 8px;
+  background-position: 4px 2px;
+  border: 1px solid #eaeaea;
+  position: relative;
+  left: 4px;
+  background-color: #f5f5f5;
+}
+
+.toggl-button.scrapbox:not(.active) {
+  color: #6a7479;
+}
+
+.toggl-button.scrapbox:hover {
+  background-color: #f5f5f5 !important;
+  color: #6a7479;
+}


### PR DESCRIPTION
## :star2: What does this PR do?
This PR adds [Scrapbox](https://scrapbox.io) integration.

[Scrapbox](https://scrapbox.io) is a new kind of wiki application.
This PR adds Toggl Button to elements which shows line metadata.

![scrapbox io_diverdown_test](https://user-images.githubusercontent.com/1734148/53694032-31e24780-3dec-11e9-84a2-fba56415b079.png)

![scrapbox io_diverdown_test 1](https://user-images.githubusercontent.com/1734148/53694034-34dd3800-3dec-11e9-8ef7-86a46e29d487.png)

<!-- Concise description of what this PR achieves, including any context. -->

## :bug: Recommendations for testing
All changes should be tested across Chrome and Firefox.

