### PR TITLE
Fix Timer stops abruptly if stop at end of day is enabled

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -1436,11 +1436,12 @@ window.TogglButton = {
 
   checkWorkDayEnd: async function () {
     const stopAtDayEnd = await db.get('stopAtDayEnd');
+    const hasWorkdayEnded = await TogglButton.workdayEnded();
     if (
       TogglButton.$user &&
       stopAtDayEnd &&
       TogglButton.$curEntry &&
-      TogglButton.workdayEnded()
+      hasWorkdayEnded
     ) {
       let title = 'Continue';
       if (TogglButton.$curEntry.description) {


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

- Fix end of workday check

## :bug: Recommendations for testing

- Enable Stop at end of work day in button settings
- Start a TE
- Wait for ~30 seconds
- TE shouldn't stop automatically


## :memo: Links to relevant issues or information

Closes #1341 
