### PR TITLE
Revamp Settings UI

### DIFF
--- a/src/html/settings.html
+++ b/src/html/settings.html
@@ -8,7 +8,7 @@
     <ul class="tab-links">
       <li class="tab-link">General</li>
       <li class="tab-link">Pomodoro Timer</li>
-      <li class="tab-link">Permissions</li>
+      <li class="tab-link">Integrations</li>
       <li class="tab-link">Telemetry</li>
     </ul>
   </header>
@@ -55,121 +55,179 @@
       </div>
       <div class="tabs">
         <div class="tab tab-1">
-          <ul class="list">
-            <li>
-              <label for="default-project">Default Project</label>
-              <div id="default-project-container">
+          <div class="fields">
+            <div class="field">
+              <div class="field__label">
+                <label for="default-project">Default Project</label>
+                <div class="description">The default project will be selected when timer is started with no matched project</div>
               </div>
-              <div class="description">The default project will be selected when timer is started with no matched project</div>
-            </li>
-            <li>
-              <label for="remember-project-per">Remember project per</label>
-              <select id="remember-project-per">
-                <option value="false">Use global default</option>
-                <option value="service">Service</option>
-                <option value="url">URL</option>
-              </select>
-              <div class="description">This will remember the last project used on each service/url separately. Overrides default project.</div>
-            </li>
-            <li>
-              <input type="checkbox" id="enable-auto-tagging">
-              <label for="enable-auto-tagging">Enable automatic tagging</label>
-              <div class="description">If a service supports tags or labels, this setting will automatically add them to the timer and create them in Toggl. Not available in all services.</div>
-            </li>
-            <li>
-              <input type="checkbox" id="show_right_click_button">
-              <label for="show_right_click_button">Show "Start timer" item in right click menu</label>
-              <div class="description">Makes it super easy to start timer with any copied text as description. If something is copied to clipboard you can start timer with that text. If clipboard is empty, page title is used as the description.</div>
-            </li>
-            <li>
-              <input type="checkbox" id="start_automatically">
-              <label for="start_automatically">Start automatically</label>
-              <div class="description">Start time tracking of latest task when the browser starts</div>
-            </li>
-            <li>
-              <input type="checkbox" id="stop_automatically">
-              <label for="stop_automatically">Stop automatically</label>
-              <div class="description">Stop time tracking when the browser is closed</div>
-            </li>
-            <li>
-              <input type="checkbox" id="show_post_start_popup">
-              <label for="show_post_start_popup">Show post-start popup</label>
-              <div class="description">Opens up edit form right after clicking "Start timer" link</div>
-            </li>
-            <li class="nag-nanny">
-              <input type="checkbox" id="nag-nanny">
-              <label for="nag-nanny">Remind me to track</label>
-              <p class="description">Shows reminder notification if user has forgot to start timer while working</p>
-              <div class="subsettings-details">
-                <span>Track activity on workdays</span>
-                <p>
-                  <label for="nag-nanny-from">From:</label>
-                  <input type="time" id="nag-nanny-from">
-                  &nbsp;&nbsp;
-                  <label for="nag-nanny-to">To:</label>
-                  <input type="time" id="nag-nanny-to">
-                </p>
-                <p>
-                  <label for="nag-nanny-interval">Minutes since stopping last Time Entry</label>
-                  <input type="number" id="nag-nanny-interval" min="1">
-                </p>
+
+              <div>
+                <div id="default-project-container">
+                </div>
               </div>
-            </li>
-            <li class="discard-notification">
-              <input type="checkbox" id="idle-detection">
-              <label for="discard-notification">Idle detection</label>
-              <div class="description">Shows notification when timer was tracking but user has been idle and allows to discard idle time</div>
-            </li>
-            <li class="stop-at-day-end">
-              <input type="checkbox" id="stop-at-day-end">
-              <label for="stop-at-day-end">Stop automatically at the end of the day</label>
-              <p class="description">The timer will be stopped automatically at this time of day</p>
-              <div class="subsettings-details">
-                <p>
-                  <label for="day-end-time">End of day time:</label>
-                  <input type="time" id="day-end-time">
-                </p>
+            </div>
+
+            <div class="field">
+              <div class="field__label">
+                <label for="remember-project-per">Remember last chosen project</label>
+                <div class="description">Remembers the last project you used on each integration or URL. Overrides the default project.</div>
               </div>
-            </li>
-            <li class="danger-zone">
-              <hr />
-              <h3>Danger Zone</h3>
-              <button id="reset-all-settings">Reset all settings to default</button>
-              <p><strong>This action is irreversible.</strong> All Toggl Button settings will be reset and you will be logged out.</p>
-            </li>
-          </ul>
+
+              <div>
+                <select id="remember-project-per">
+                  <option value="false">Use global default</option>
+                  <option value="service">Service</option>
+                  <option value="url">URL</option>
+                </select>
+              </div>
+            </div>
+
+            <div class="field">
+              <div class="field__label">
+                <label for="enable-auto-tagging">Enable automatic tagging</label>
+                <div class="description">If an integration supports tags or labels, automatically add them to the timer and
+                  create them in Toggl. Not available in all integrations.</div>
+              </div>
+
+              <div>
+                <input type="checkbox" id="enable-auto-tagging">
+              </div>
+            </div>
+
+            <hr />
+
+            <div class="field">
+              <div class="field__label">
+                <label for="start_automatically">Start timer automatically</label>
+                <div class="description">Starts the timer with the most recent task when the browser is opened</div>
+              </div>
+              <div>
+                <input type="checkbox" id="start_automatically">
+              </div>
+            </div>
+
+            <div class="field">
+              <div class="field__label">
+                <label for="stop_automatically">Stop timer automatically</label>
+                <div class="description">Stops the timer when the browser is closed</div>
+              </div>
+              <div>
+                <input type="checkbox" id="stop_automatically">
+              </div>
+            </div>
+
+            <div class="field nag-nanny">
+              <div class="field__label">
+                <label for="nag-nanny">Remind me to track time</label>
+                <div class="description">Receive a notification if you forget to track time during work hours</div>
+                <div class="subsettings-details">
+                    On weekdays from <input type="time" id="nag-nanny-from"> to <input type="time" id="nag-nanny-to">&nbsp;, after <input type="number" id="nag-nanny-interval" min="1"> minutes since the last time entry was stopped.
+                </div>
+              </div>
+              <div>
+                <input type="checkbox" id="nag-nanny">
+              </div>
+            </div>
+
+            <div class="field">
+              <div class="field__label">
+                <label for="discard-notification">Idle detection</label>
+                <div class="description">Receive a notification when you've been idle and the timer was running, allowing you to discard the time.</div>
+              </div>
+              <div>
+                <input type="checkbox" id="idle-detection">
+              </div>
+            </div>
+
+            <div class="field stop-at-day-end">
+              <div class="field__label">
+                <label for="stop-at-day-end">Stop timer automatically at the end of the day</label>
+                <div class="description">The timer will be stopped automatically when your day ends</div>
+                <div class="subsettings-detail">
+                  <div class="subsettings-details">
+                    <label for="day-end-time">End of day time:</label>
+                    <input type="time" id="day-end-time">
+                  </div>
+                </div>
+              </div>
+
+              <div>
+                <input type="checkbox" id="stop-at-day-end">
+              </div>
+            </div>
+
+            <hr />
+
+            <div class="field">
+              <div class="field__label">
+                <label for="show_post_start_popup">Show post-start popup</label>
+                <div class="description">Opens the edit form immediately after clicking a "Start timer" link</div>
+              </div>
+              <div>
+                <input type="checkbox" id="show_post_start_popup">
+              </div>
+            </div>
+
+            <div class="field">
+              <div class="field__label">
+                <label for="show_right_click_button">Show "Start timer" item in right click menu</label>
+                <div class="description">Makes it super easy to start a timer with any highlighted text. If you highlight text on the page, you can start a timer for it in the right-click menu. If nothing is selected, page title is used as the description.</div>
+              </div>
+              <div>
+                <input type="checkbox" id="show_right_click_button">
+              </div>
+            </div>
+
+            <div class="field danger-zone">
+              <div class="field__label">
+                <h3>Reset all settings</h3>
+                <p><strong>This action is irreversible.</strong> All Toggl Button settings will be reset and you will be logged out.</p>
+              </div>
+              <div>
+                <button id="reset-all-settings">Reset all settings to default</button>
+              </div>
+            </div>
+          </div>
+
         </div>
         <div class="tab tab-2">
-          <ul class="list">
-            <li class="pomodoro-mode">
-              <input type="checkbox" id="pomodoro-mode">
-              <label for="pomodoro-mode">Enable Pomodoro Timer</label>
-              <p class="description">Allows user to define Pomodoro Timer interval. Pomodoro timer starts running every time a time entry is started. At the end of the interval the user is shown notification to take a break.
-                User can set an option to stop or continue time tracking when pomodoro timer ends.</p>
-              <div class="subsettings-details">
-                <p>
-                  <label for="pomodoro-interval">Pomodoro timer interval in minutes</label>
-                  <input type="number" id="pomodoro-interval" min="1">
-                </p>
-                <p>
-                  <input type="checkbox" id="pomodoro-stop-time">
-                  <label for ="pomodoro-stop-time">Stop time tracking when pomodoro time ends</label>
-                </p>
-                <div class="pomodoro-sound">
-                  <input type="checkbox" id="enable-sound-signal">
-                  <label for="enable-sound-signal">Enable sound notification at the end of an interval</label>
+          <div class="fields">
+            <div class="field pomodoro-mode">
+              <div class="field__label">
+                <label for="pomodoro-mode">Enable Pomodoro Timer</label>
+                <div class="description">A Pomodoro timer is started when you start a time entry. At the end of the Pomodoro interval, you will receive a notification to take a break.</div>
 
-                  <p class="pomodoro-sound-volume">
-                    <label for="sound-volume">Sound volume</label>
-                    <input type="range" id="sound-volume">
-                    <span id="volume-label">100%</span>
-                    <br>
-                    <button id="sound-test">Test &#9658;</button>
+                <div class="subsettings-details">
+                  <div>
+                    <label for="pomodoro-interval">Pomodoro timer interval in minutes</label>
+                    <input type="number" id="pomodoro-interval" min="1">
+                  </div>
+                  <p>
+                    <input type="checkbox" id="pomodoro-stop-time">
+                    <label for="pomodoro-stop-time">Stop time tracking when pomodoro time ends</label>
                   </p>
+                  <div class="pomodoro-sound">
+                    <input type="checkbox" id="enable-sound-signal">
+                    <label for="enable-sound-signal">Enable sound notification at the end of an interval</label>
+
+                    <p class="pomodoro-sound-volume">
+                      <label for="sound-volume">Sound volume</label>
+                      <input type="range" id="sound-volume">
+                      <span id="volume-label">100%</span>
+                      <button id="sound-test">Test &#9658;</button>
+                    </p>
+                  </div>
                 </div>
+
+              </div>
+              <div>
+                <input type="checkbox" id="pomodoro-mode">
+
+              </div>
             </div>
-            </li>
-          <ul>
+
+          </div>
         </div>
         <div class="tab tab-3">
           <div class="section">

--- a/src/html/settings.html
+++ b/src/html/settings.html
@@ -181,7 +181,7 @@
 
             <div class="field danger-zone">
               <div class="field__label">
-                <h3>Reset all settings</h3>
+                <label>Reset all settings</label>
                 <p><strong>This action is irreversible.</strong> All Toggl Button settings will be reset and you will be logged out.</p>
               </div>
               <div>

--- a/src/html/settings.html
+++ b/src/html/settings.html
@@ -6,7 +6,7 @@
   </head>
   <header>
     <ul class="tab-links">
-      <li class="tab-link">General</li>
+      <li class="tab-link active">General</li>
       <li class="tab-link">Pomodoro Timer</li>
       <li class="tab-link">Integrations</li>
       <li class="tab-link">Telemetry</li>
@@ -54,7 +54,7 @@
         </div>
       </div>
       <div class="tabs">
-        <div class="tab tab-1">
+        <div class="tab tab-1 active">
           <div class="fields">
             <div class="field">
               <div class="field__label">

--- a/src/html/settings.html
+++ b/src/html/settings.html
@@ -24,9 +24,9 @@
             <p><i>This Permissions settings tab allows to enable/disable integrations and define custom domains.</i>
             </p>
             <p>
-              You can enable all integrations you want to use with the Toggl Button by clicking the "Enable all" button under "Url Permissions". Also you can pick the tools you want by ticking the checkboxes.
+              You can enable all integrations you want to use with the Toggl Button by clicking the "Enable all" button under "URL Permissions". Also you can pick the tools you want by ticking the checkboxes.
             </p>
-            <p>You can also define custom domains in the "Custom Domain Url Permissions" section of the page. Just type in the domain address, select the tool you are running on it and press "Add".</p>
+            <p>You can also define custom domains in the "Custom Domain URL Permissions" section of the page. Just type in the domain address, select the tool you are running on it and press "Add".</p>
             <p>The telemetry settings tab allows you to control sending usage metrics and error reports to help make Toggl Button better.</p>
           </div>
 
@@ -36,7 +36,7 @@
             <p>
               You can enable/disable all tools you by clicking the buttons on top of the list. Also you can pick the tools you want by ticking the checkbox in front of them.
             </p>
-            <p>You can also define custom domains in the "Custom Domain Url Permissions" section of the page. Just type in the domain address, select the tool you are running on that domain and press "Add"</p>
+            <p>You can also define custom domains in the "Custom Domain URL Permissions" section of the page. Just type in the domain address, select the tool you are running on that domain and press "Add"</p>
           </div>
 
           <div data-id="2">

--- a/src/html/settings.html
+++ b/src/html/settings.html
@@ -173,7 +173,8 @@
         </div>
         <div class="tab tab-3">
           <div class="section">
-            <h2>Url Permissions</h2>
+            <h2>Integrations</h2>
+            <p>Enable the tools you want to use with Toggl Button. You can enable everything by clicking the "Enable all" button.</p>
             <div class="permissions-toolbar" data-id="regular">
               <input type="text" id="permission-filter" placeholder="Filter permissions"/>
               <a href="javascript:void(0)" id="filter-clear">&times;</a>
@@ -183,13 +184,12 @@
               </div>
             </div>
             <div id="perm-container"></div>
-            <p class="description">Enable tools you want to use with Toggl Button. You can enable all by clicking "Enable all" button in the top.</p>
           </div>
 
           <div class="section">
-            <h2>Custom Domain Url Permissions</h2>
+            <h2>Custom Integrations</h2>
+            <p>If you use a tool hosted on a custom domain, you can enable it here. Enter the domain name in the format "toggl.com" and select the integration from the dropdown. <em>Ports are not supported.</em></p>
             <input type="text" id="new-permission" placeholder="Custom domain url"/>
-            <p class="description">Define custom domains here. Just type in the domain name without http(s) in format "toggl.com" and select the integration from dropdown. Ports are currently not supported.</p>
             <div class="button-container">
                 <div id="origins-container"></div>
                 <button id="add-permission">Add</button>

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -372,7 +372,7 @@ const Settings = {
                 }
 
                 dom = document.createElement('div');
-                dom.textContent = key;
+                dom.textContent = `${TogglOrigins[key].name} - ${key}`;
 
                 li.appendChild(input);
                 li.appendChild(dom);
@@ -663,7 +663,7 @@ document.addEventListener('DOMContentLoaded', async function (e) {
 
       const permissionItems = document.querySelectorAll('#permissions-list li');
       permissionItems.forEach((item) => {
-        if (item.id.indexOf(val) !== -1) {
+        if (item.textContent.toLowerCase().indexOf(val) !== -1) {
           item.classList.add('filter');
         } else if (item.classList) {
           item.classList.remove('filter');

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -647,10 +647,6 @@ document.addEventListener('DOMContentLoaded', async function (e) {
       db.set('show-permissions-info', 0);
     }
 
-    // Change active tab.
-    const settingsActiveTab = await db.get('settings-active-tab', 0);
-    const activeTab = Number.parseInt(settingsActiveTab, 10);
-    changeActiveTab(activeTab);
     document.querySelector('body').style.display = 'flex';
 
     Settings.showPage();

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -20,7 +20,7 @@ if (FF) {
   document.body.classList.add('ff');
 }
 
-document.querySelector('#version').textContent = `(${process.env.VERSION})`;
+document.querySelector('#version').textContent = process.env.VERSION;
 
 const Settings = {
   $startAutomatically: null,
@@ -651,7 +651,7 @@ document.addEventListener('DOMContentLoaded', async function (e) {
     const settingsActiveTab = await db.get('settings-active-tab', 0);
     const activeTab = Number.parseInt(settingsActiveTab, 10);
     changeActiveTab(activeTab);
-    document.querySelector('body').style.display = 'block';
+    document.querySelector('body').style.display = 'flex';
 
     Settings.showPage();
 

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -95,6 +95,8 @@ const Settings = {
       );
       Settings.toggleState(Settings.$postPopup, showPostPopup);
       Settings.toggleState(Settings.$nanny, nannyCheckEnabled);
+      document.querySelector('.field.nag-nanny').classList.toggle('field--showDetails', nannyCheckEnabled);
+
       Settings.toggleState(
         Settings.$idleDetection,
         idleDetectionEnabled
@@ -103,6 +105,7 @@ const Settings = {
         Settings.$pomodoroMode,
         pomodoroModeEnabled
       );
+      document.querySelector('.field.pomodoro-mode').classList.toggle('field--showDetails', pomodoroModeEnabled);
       Settings.toggleState(
         Settings.$pomodoroSound,
         pomodoroSoundEnabled
@@ -131,6 +134,7 @@ const Settings = {
 
       Settings.toggleState(Settings.$stopAtDayEnd, stopAtDayEnd);
       document.querySelector('#day-end-time').value = dayEndTime;
+      document.querySelector('.field.stop-at-day-end').classList.toggle('field--showDetails', stopAtDayEnd);
 
       Settings.fillDefaultProject();
 
@@ -712,6 +716,7 @@ document.addEventListener('DOMContentLoaded', async function (e) {
     Settings.$nanny.addEventListener('click', async function (e) {
       const nannyCheckEnabled = await db.get('nannyCheckEnabled');
       Settings.toggleSetting(e.target, !nannyCheckEnabled, 'toggle-nanny');
+      document.querySelector('.field.nag-nanny').classList.toggle('field--showDetails', !nannyCheckEnabled);
     });
     Settings.$idleDetection.addEventListener('click', async function (e) {
       const idleDetectionEnabled = await db.get('idleDetectionEnabled');
@@ -720,6 +725,7 @@ document.addEventListener('DOMContentLoaded', async function (e) {
     Settings.$pomodoroMode.addEventListener('click', async function (e) {
       const pomodoroModeEnabled = await db.get('pomodoroModeEnabled');
       Settings.toggleSetting(e.target, !pomodoroModeEnabled, 'toggle-pomodoro');
+      document.querySelector('.field.pomodoro-mode').classList.toggle('field--showDetails', !pomodoroModeEnabled);
     });
     Settings.$pomodoroSound.addEventListener('click', async function (e) {
       const pomodoroSoundEnabled = await db.get('pomodoroSoundEnabled');
@@ -733,6 +739,7 @@ document.addEventListener('DOMContentLoaded', async function (e) {
     Settings.$stopAtDayEnd.addEventListener('click', async function (e) {
       const stopAtDayEnd = await db.get('stopAtDayEnd');
       Settings.toggleSetting(e.target, !stopAtDayEnd, 'toggle-stop-at-day-end');
+      document.querySelector('.field.stop-at-day-end').classList.toggle('field--showDetails', !stopAtDayEnd);
     });
 
     Settings.$rememberProjectPer.addEventListener('change', function (e) {

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -48,7 +48,13 @@ input[type='number'] {
 }
 
 .tab.active {
-  display: block;
+  display: flex;
+}
+
+@media (max-width: 860px) {
+  .tab.active {
+    display: block;
+  }
 }
 
 .list {
@@ -175,7 +181,7 @@ header li:hover {
 }
 
 .section {
-  width: 400px;
+  flex: 1;
 }
 
 .section:hover .description {

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -1,7 +1,12 @@
+html {
+  --main-bg-color: #ffffff;
+}
+
 html,
 body {
   margin: 0;
   padding: 0;
+  background: var(--main-bg-color);
   /* font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; */
 }
 

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -203,6 +203,7 @@ header li:hover {
 .origin-list li {
   height: 23px;
   border-bottom: 1px solid #e8e8e8;
+  cursor: pointer;
 }
 
 .origin-list li:hover {

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -93,10 +93,6 @@ body {
   padding: 10px 0;
 }
 
-.field:not(:first-of-type) {
-  /* border-top: 1px solid rgba(0, 0, 0, 0.1); */
-}
-
 .field__label {
   flex: 5;
 }
@@ -168,16 +164,9 @@ input[type='checkbox'] {
 }
 
 .description {
-  /* position: absolute; */
-  /* display: block; */
-  /* right: 0; */
-  /* border-left: 2px solid #dfdfdf; */
   color: rgb(119, 119, 119);
-  /* visibility: hidden; */
   padding: 5px;
   align-self: stretch;
-  /* width: 40%; */
-  /* margin: 0 20px !important; */
   width: 100%;
   padding: 5px 0;
 }
@@ -348,12 +337,6 @@ header li:hover {
   position: relative;
   text-align: center;
   margin-top: 3px;
-}
-
-#filter-clear:hover {
-  color: #ffffff;
-  background-color: #6b6969;
-  border-radius: 20px;
 }
 
 .filtered ~ #filter-clear {

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -1,7 +1,17 @@
 html {
   --main-bg-color: #ffffff;
-  --tab-background: #fdfdfd;
+  --tab-background: #fafbfc;
+  --footer-background: #fafbfc;
+  --text-color: #333333;
+  --light-text: #7b7b7b;
+  --danger: #E20505;
+}
+
+html.dark {
+  --main-bg-color: #222222;
+  --tab-background: #222222;
   --footer-background: #f5f5f5;
+  --text-color: #eeeeee;
 }
 
 html,
@@ -9,6 +19,7 @@ body {
   margin: 0;
   padding: 0;
   background: var(--main-bg-color);
+  color: var(--text-color);
   /* font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; */
 }
 
@@ -39,7 +50,6 @@ body {
   width: 800px;
   max-width: 800px;
   background-color: var(--main-bg-color);
-  color: #505050;
 }
 
 .tabs {
@@ -103,7 +113,7 @@ body {
 }
 
 .field .description {
-  color: rgb(119, 119, 119);
+  color: var(--light-text);
   padding: 5px;
   align-self: stretch;
   width: 100%;
@@ -447,6 +457,10 @@ header li:hover {
 
 .danger-zone {
   max-width: 800px;
+}
+
+.danger-zone p {
+  color: var(--danger);
 }
 
 .danger-zone hr {

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -2,7 +2,7 @@ html,
 body {
   margin: 0;
   padding: 0;
-  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  /* font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; */
 }
 
 input[type='number'],
@@ -34,6 +34,7 @@ input[type='number'] {
   overflow: hidden;
   height: calc(100vh - 35px - 42px);
   width: 100vw;
+
   transition: order 300ms ease-in-out;
   align-items: stretch;
   background-color: inherit;
@@ -41,6 +42,7 @@ input[type='number'] {
 
 .tab {
   display: none;
+  position: relative;
   flex: 1 0 100vw;
   overflow-y: auto;
   padding: 20px;
@@ -57,6 +59,68 @@ input[type='number'] {
   }
 }
 
+.fields {
+  max-width: 800px;
+}
+
+.field {
+  display: flex;
+  flex-direction: row;
+  padding: 10px 0;
+}
+
+.field:not(:first-of-type) {
+  /* border-top: 1px solid rgba(0, 0, 0, 0.1); */
+}
+
+.field__label {
+  flex: 5;
+}
+
+.field__label > label {
+  font-size: 16px;
+}
+
+.field > *:last-child {
+  flex: 1;
+  height: 100%;
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 1em;
+}
+
+.field .description {
+  color: rgb(119, 119, 119);
+  padding: 5px;
+  align-self: stretch;
+  width: 100%;
+  padding: 5px 0;
+}
+
+.field.danger-zone {
+  border-top: 1px solid darkgrey;
+}
+
+.field--showDetails .subsettings-details {
+  height: auto;
+}
+
+.field .subsettings-details input {
+  margin: 0 5px !important;
+}
+
+.subsettings-details {
+  overflow: hidden;
+  padding: 10px 0 5px;
+  height: 0px;
+  margin-left: 10px;
+  transition: height 300ms ease-in-out;
+}
+
+.subsettings-details span {
+  display: block;
+}
+
 .list {
   padding: 0;
   margin: 0;
@@ -64,20 +128,7 @@ input[type='number'] {
 }
 
 .list li {
-  position: relative;
   min-height: 40px;
-}
-
-.list li #nag-nanny:checked ~ div {
-  height: auto;
-}
-
-.list li #pomodoro-mode:checked ~ div {
-  height: 220px;
-}
-
-.list li #stop-at-day-end:checked ~ div {
-  height: 70px;
 }
 
 .list li label {
@@ -87,36 +138,24 @@ input[type='number'] {
   vertical-align: middle;
 }
 
-.list li input[type='checkbox'] {
-  height: 1.3em;
-  width: 1.3em;
-  margin: 0px 0.4em 0.3em 0px;
-}
-
-.subsettings-details {
-  overflow: hidden;
-  height: 0px;
-  margin-left: 25px;
-  transition: height 300ms ease-in-out;
-}
-
-.subsettings-details span {
-  display: block;
-  font-size: 14px;
-  padding-top: 10px;
+input[type='checkbox'] {
+  height: 1.5em;
+  width: 1.5em;
 }
 
 .description {
-  position: absolute;
-  display: block;
-  top: 0;
-  right: 0;
-  border-left: 2px solid #dfdfdf;
+  /* position: absolute; */
+  /* display: block; */
+  /* right: 0; */
+  /* border-left: 2px solid #dfdfdf; */
   color: rgb(119, 119, 119);
-  visibility: hidden;
+  /* visibility: hidden; */
   padding: 5px;
-  width: 40%;
-  margin: 0 20px !important;
+  align-self: stretch;
+  /* width: 40%; */
+  /* margin: 0 20px !important; */
+  width: 100%;
+  padding: 5px 0;
 }
 
 .list li:hover .description {
@@ -299,7 +338,6 @@ header li:hover {
 }
 
 #default-project {
-  margin-left: 5px;
   max-width: 280px;
 }
 
@@ -375,12 +413,6 @@ header li:hover {
   width: 40px;
   text-align: right;
   margin-right: 5px;
-}
-
-#sound-test {
-  position: relative;
-  right: -112px;
-  width: 80px;
 }
 
 .pomodoro-sound {

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -1,5 +1,7 @@
 html {
   --main-bg-color: #ffffff;
+  --tab-background: #fdfdfd;
+  --footer-background: #f5f5f5;
 }
 
 html,
@@ -26,11 +28,17 @@ input[type='number'] {
   width: 50px;
 }
 
+body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
 .container {
   position: relative;
   width: 800px;
   max-width: 800px;
-  background-color: #fff;
+  background-color: var(--main-bg-color);
   color: #505050;
 }
 
@@ -38,8 +46,7 @@ input[type='number'] {
   display: flex;
   overflow: hidden;
   height: calc(100vh - 35px - 42px);
-  width: 100vw;
-
+  width: 100%;
   transition: order 300ms ease-in-out;
   align-items: stretch;
   background-color: inherit;
@@ -48,7 +55,7 @@ input[type='number'] {
 .tab {
   display: none;
   position: relative;
-  flex: 1 0 100vw;
+  flex: 1 0 100%;
   overflow-y: auto;
   padding: 20px;
   box-sizing: border-box;
@@ -56,6 +63,7 @@ input[type='number'] {
 
 .tab.active {
   display: flex;
+  flex-direction: column;
 }
 
 @media (max-width: 860px) {
@@ -108,6 +116,7 @@ input[type='number'] {
 
 .field--showDetails .subsettings-details {
   height: auto;
+  padding: 10px 0 5px;
 }
 
 .field .subsettings-details input {
@@ -116,7 +125,6 @@ input[type='number'] {
 
 .subsettings-details {
   overflow: hidden;
-  padding: 10px 0 5px;
   height: 0px;
   margin-left: 10px;
   transition: height 300ms ease-in-out;
@@ -168,6 +176,9 @@ input[type='checkbox'] {
 }
 
 header {
+  width: 100%;
+  display: flex;
+  justify-content: center;
   box-shadow: inset 0px -1px 1px -1px #bbb;
   position: relative;
   z-index: 1;
@@ -184,7 +195,7 @@ header ul {
 
 header .tab-link {
   box-sizing: border-box;
-  background: #fdfdfd;
+  background: var(--tab-background);
   border-bottom: 1px solid #eee;
   padding: 10px 20px;
   cursor: pointer;
@@ -434,14 +445,24 @@ header li:hover {
   height: 64px;
 }
 
+.danger-zone {
+  max-width: 800px;
+}
+
+.danger-zone hr {
+  margin-top: 18px;
+  margin-bottom: 38px;
+}
+
 .footer {
   display: flex;
   align-items: center;
   justify-content: space-between;
   height: 42px;
   padding: 0 15px;
-  background-color: #f5f5f5;
+  background-color: var(--footer-background);
   border-top: 1px solid #e5e5e5;
   color: #8a8888;
   font-size: 12px;
+  min-width: 360px;
 }

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -20,7 +20,7 @@ body {
   padding: 0;
   background: var(--main-bg-color);
   color: var(--text-color);
-  /* font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; */
+  font-family: Arial, sans-serif;
 }
 
 input[type='number'],
@@ -40,6 +40,7 @@ input[type='number'] {
 }
 
 body {
+  font-size: 75%;
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

<!-- Concise description of what this PR achieves, including any context. -->

- New layout for settings page(s)
- Permissions may be searched by integration name
- Permissions shows both integration name and the domain
- Center settings container to not look awkward on wider viewports
- Super-secret dark mode settings
- Delete the "remember active tab" feature. Its statefulness has broken the settings more than once. It can come back when settings is stable if desired.

## :bug: Recommendations for testing

- Open and test all settings across both browsers
- To test dark mode paste this incantation in the settings view console
```javascript
document.documentElement.classList.toggle('dark')
```

## :memo: Links to relevant issues or information

Closes #1313
