### PR TITLE
fix: Fix errors on workdayEnd when $curEntry is null

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -1435,6 +1435,10 @@ window.TogglButton = {
   },
 
   checkWorkDayEnd: async function () {
+    if (!TogglButton.$curEntry) {
+      return;
+    }
+
     const stopAtDayEnd = await db.get('stopAtDayEnd');
     const hasWorkdayEnded = await TogglButton.workdayEnded();
     if (
@@ -1469,6 +1473,9 @@ window.TogglButton = {
   },
 
   workdayEnded: async function () {
+    if (!TogglButton.$curEntry) {
+      return false;
+    }
     const startedTime = new Date(TogglButton.$curEntry.start);
     const now = new Date();
     const endTime = new Date();


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

<!-- Concise description of what this PR achieves, including any context. -->

Resolve https://app.bugsnag.com/toggl-dot-com/toggl-button/errors/5c90c3e73728f4001bb193b7?filters[event.since][0][type]=eq&filters[event.since][0][value]=30d&filters[release.seen_in][0][type]=eq&filters[release.seen_in][0][value]=latest&filters[error.status][0][type]=eq&filters[error.status][0][value]=open&filters[event.class][0][type]=ne&filters[event.class][0][value]=Content

Add a defensive check. This seems to have come about because of async functions and the various ways this can be triggered. Not looking to refactor the flow at this time.

## :bug: Recommendations for testing

Should look like this error can not happen anymore even if it wanted to.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
