### PR TITLE
Fix some settings being overwritten with default values on load

### DIFF
--- a/src/scripts/lib/db.js
+++ b/src/scripts/lib/db.js
@@ -222,16 +222,10 @@ export default class Db {
 
   async load (setting, defaultValue) {
     let value = await this.get(setting);
-
-    // Attempt to migrate from old localStorage settings.
-    if (value === null || typeof value === 'undefined') {
-      value = localStorage.getItem(setting);
-      if (value && typeof defaultValue === 'boolean') {
-        value = JSON.parse(value);
-      }
+    if (typeof value === 'undefined') {
+      value = defaultValue;
     }
 
-    value = value || defaultValue;
     this.set(setting, value);
     return value;
   }


### PR DESCRIPTION


Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

Removes some redundant "settings migration logic" and fixes bug where `false` settings would get overwritten with default values any time the extension was loaded (i.e. on browser start). *(This migration condition is redundant because we have a new migration [here](https://github.com/toggl/toggl-button/blob/master/src/scripts/background.js#L2155))*.

Closes #1353.

<!-- Concise description of what this PR achieves, including any context. -->

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

Before this change, you would observe the following with local extension running:

1. Change some settings, e.g. set `Show post popup` to `false`.
2. Reload via `about:debugging` / `chrome:extensions`
3. You will see in the background script console that the setting is loaded with the correct value, but then it is saved again with the default value, because it was falsey.

After the change, the setting should not be overwritten anymore.

Please briefly investigate if there is something else fishy here. The whole "settings are re-saved on extension load" thing needs to be refactored out (we should be specifying default values when calling `storage.sync.get`), but we'll refactor that properly in an independent issue.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
