### PR TITLE
Ensure default settings are loaded in case of invalid value

### DIFF
--- a/src/scripts/lib/bugsnag.js
+++ b/src/scripts/lib/bugsnag.js
@@ -25,7 +25,7 @@ function getBugsnagClient () {
     collectUserIp: false,
     beforeSend: async function (report) {
       const db = browser.extension.getBackgroundPage().db;
-      const sendErrorReports = await db.get('sendErrorReports', true);
+      const sendErrorReports = await db.get('sendErrorReports');
       if (!sendErrorReports) {
         report.ignore();
         return false;

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -631,7 +631,7 @@ document.addEventListener('DOMContentLoaded', async function (e) {
     if (
       !dontShowPermissions
     ) {
-      const showPermissionsInfo = await db.get('show-permissions-info', 0);
+      const showPermissionsInfo = await db.get('show-permissions-info');
       document.querySelector('.guide-container').style.display = 'flex';
       document.querySelector(
         ".guide > div[data-id='" + (showPermissionsInfo || 0) + "']"
@@ -644,7 +644,7 @@ document.addEventListener('DOMContentLoaded', async function (e) {
     }
 
     // Change active tab.
-    const settingsActiveTab = await db.get('settings-active-tab');
+    const settingsActiveTab = await db.get('settings-active-tab', 0);
     const activeTab = Number.parseInt(settingsActiveTab, 10);
     changeActiveTab(activeTab);
     document.querySelector('body').style.display = 'block';


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

<!-- Concise description of what this PR achieves, including any context. -->

Ensure default settings are loaded in case of invalid value. Horrible bugs aside, this is valuable so that user can recover seamlessly if anything does go wrong with the stored settings.

`async`-ness of `load()` is removed because it was not used correctly (😬) and can definitely cause severe settings problems in some browsers, it seems.

## :bug: Recommendations for testing

First time I loaded Toggl Button into Firefox **Developer** Edition, all of my settings became `null` 😱 . The root cause is probably the incorrect `async` usage - each value was not retrieved before it was attempted to be saved again in `load`, so it was saved as `null`. *(This re-saving is on the cards to remove, but this fix is still needed in the meantime).*

Please check all of the browsers, including Firefox Developer Edition. Settings should load flawlessly on reloads, etc. Inspect the background console.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->

Should fix symptoms of #1357. 
