### PR TITLE
Fix wordpress integration

### DIFF
--- a/src/scripts/content/wordpress.js
+++ b/src/scripts/content/wordpress.js
@@ -1,22 +1,34 @@
 'use strict';
 
-togglbutton.render('.editor__header:not(.toggl)', { observe: true }, function (
-  elem
-) {
-  const tabs = $('.editor__switch-mode', elem);
-
+// WP 4.9
+togglbutton.render('#poststuff:not(.toggl)', { observe: true }, function (elem) {
+  const heading = document.querySelector('.wp-heading-inline');
   const description = function () {
-    return document.querySelector('.editor-title__input').value;
+    return elem.querySelector('#title').value;
   };
-
-  if ($('.toggl-button')) {
-    return;
-  }
 
   const link = togglbutton.createTimerLink({
     className: 'wordpress',
     description: description
   });
 
-  tabs.parentElement.insertBefore(link, tabs);
+  heading.append(link);
+});
+
+// WP 5.1
+togglbutton.render('.edit-post-header:not(.toggl)', { observe: true }, function (
+  elem
+) {
+  const targetElement = elem.querySelector('.edit-post-header__settings');
+  const description = function () {
+    const titleInput = document.getElementById('post-title-0');
+    return titleInput ? titleInput.value : '';
+  };
+
+  const link = togglbutton.createTimerLink({
+    className: 'wordpress',
+    description: description
+  });
+
+  targetElement.prepend(link);
 });

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1238,8 +1238,9 @@ li > .toggl-button.phabricator {
 
 /********* WORDPRESS *********/
 .toggl-button.wordpress {
-  float: left;
+  float: right;
   margin-left: 10px;
+  margin-top: 5px;
 }
 
 /********* PLANBOX *********/


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?
Button wasn't appearing on WP 4.8.3, 4.9.8 and 5.1.1
Fixes Wordpress integration for
#### WP 4.x.x
![image](https://user-images.githubusercontent.com/360894/55115083-5e734180-50c2-11e9-8efa-bb394b728ee1.png)

#### and WP 5.1.x
![image](https://user-images.githubusercontent.com/360894/55115098-6e8b2100-50c2-11e9-88be-97bcbd51b043.png)

## :bug: Recommendations for testing
* I tried on a Wordpress 5.1.1 that had two types of post forms. The new, 5.x.x, and the previous one. Can verify both codes from a single WP installation. I also tested on an actual 4.9.8 installation.

## :memo: Links to relevant issues or information

Fixes #1362

