### PR TITLE
Fix automatic start/stop feature on browser open/close

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -137,13 +137,8 @@ window.TogglButton = {
                 });
               }
               if (resp.data.time_entries) {
-                resp.data.time_entries.some(function (timeEntry) {
-                  if (timeEntry.duration < 0) {
-                    entry = timeEntry;
-                    return true;
-                  }
-                  return false;
-                });
+                const { time_entries: timeEntries } = resp.data;
+                entry = timeEntries.find(te => te.duration < 0) || null;
               }
 
               if (TogglButton.hasWorkspaceBeenRevoked(resp.data.workspaces)) {
@@ -578,6 +573,11 @@ window.TogglButton = {
         }
       });
     });
+  },
+
+  latestEntry: function () {
+    const timeEntries = TogglButton.$user.time_entries || [ null ];
+    return timeEntries[timeEntries.length - 1];
   },
 
   checkPomodoroAlarm: async function (entry) {
@@ -2042,10 +2042,8 @@ window.TogglButton = {
       startAutomatically &&
       !!TogglButton.$user
     ) {
-      const lastEntryString = await db.get('latestStoppedEntry');
-      if (lastEntryString) {
-        const lastEntry = JSON.parse(lastEntryString);
-        TogglButton.$latestStoppedEntry = lastEntry;
+      TogglButton.$latestStoppedEntry = TogglButton.latestEntry();
+      if (TogglButton.$latestStoppedEntry) {
         TogglButton.createTimeEntry(TogglButton.$latestStoppedEntry, null);
         TogglButton.hideNotification('remind-to-track-time');
       }


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

- Fix start/stop TE automatically options
- Extract the latest entry from the time-entries list instead of `localStorage`
- TODO for a different issue remove calls to `localStorage` from files other than `db.js`

## :bug: Recommendations for testing

- Enable start/stop automatically option
- Restart the browser
- The latest TE should continue
- Close the browser
- The running TE should stop (takes a few seconds to reflect on the other clients)

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

Closes #1375
