### PR TITLE
Show running entry project and tags

### DIFF
--- a/src/scripts/components/TimeEntriesList.tsx
+++ b/src/scripts/components/TimeEntriesList.tsx
@@ -143,18 +143,18 @@ function TimeEntryDuration ({ duration }: { duration: number }) {
   );
 }
 
-const TimeEntryDescription = styled.div`
+export const TimeEntryDescription = styled.div`
   flex: 1;
 
   white-space: nowrap;
   text-overflow: ellipsis;
-  cursor: text;
-  line-height: normal;
+  line-height: 24px;
   overflow: hidden;
   color: #222;
+  cursor: ${(props: { running?: boolean }) => props.running ? 'pointer' : 'text'};
 `;
 
-function TimeEntryProject ({ project }: { project: Project }) {
+export function TimeEntryProject ({ project }: { project: Project }) {
   return (
     <div style={{ flex: 1 }}>
       {project &&
@@ -193,11 +193,12 @@ const EntryList = styled.ul`
 const itemPadding = '.5rem .8rem';
 const itemShadow = 'rgb(232, 232, 232) 0px -1px 0px 0px inset';
 const EntryItem = styled.li`
+  box-sizing: border-box;
   display: flex;
   flex-direction: column;
 
   padding: ${itemPadding};
-  height: 50px;
+  height: 66px;
 
   color: ${color.grey};
   font-size: 14px;

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -98,7 +98,8 @@ window.PopUp = {
   renderTimer: function () {
     const rootElement = document.getElementById('root-timer');
     const entry = TogglButton.$curEntry;
-    ReactDOM.render(<Timer entry={entry} />, rootElement);
+    const project = entry && TogglButton.findProjectByPid(entry.pid) || null;
+    ReactDOM.render(<Timer entry={entry} project={project} />, rootElement);
   },
 
   sendMessage: function (request) {

--- a/src/styles/popup.css
+++ b/src/styles/popup.css
@@ -411,7 +411,6 @@ hr {
   display: block;
   padding: 0 30px;
   line-height: 20px;
-  margin-top: 5px;
 }
 
 .error.show {


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

<!-- Concise description of what this PR achieves, including any context. -->

* Shows the running entry's project and tags in the toolbar popup. Description will get ellipsified `...` if it's long. Description is allowed to take up more space, but project will still have some spacing around it.
* Any part of the running timer can be clicked to edit the entry now.

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

* Shows the running entry's project and tags in the toolbar popup.
  * Description is correctly ellipsified
  * Nothing weird happens with elements flowing etc.
* Any part of the running timer can be clicked to edit the entry now.
* The stop button still stops the entry correctly.
* No issues clicking a particular part of the timer

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

Closes #1370