### PR TITLE
fix: Wrike - getting correct title

### DIFF
--- a/src/scripts/content/wrike.js
+++ b/src/scripts/content/wrike.js
@@ -6,6 +6,10 @@ togglbutton.render('.wspace-task-view:not(.toggl)', { observe: true }, function 
   const container = $('.wrike-panel-header-toolbar', elem);
 
   const titleElem = function () {
+    const wsTaskTitle = document.querySelectorAll('ws-task-title');
+    if (wsTaskTitle.length === 1 && wsTaskTitle[0].textContent !== '') {
+      return wsTaskTitle[0].textContent;
+    }
     return $('title').textContent.replace(' - Wrike', '');
   };
 


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

Timer description is extracted from Title of page. On Inbox page (https://www.wrike.com/workspace.htm?acc=XXXXX#path=inbox), the title is "Inbox" which creates not a correct description.

I want to parse the title from `ws-task-title` tag, which seems to be always placed just once on a page and is correct.

Because of "future-proof", this tag is used only if:

- is just one on a page (in case, there will be more tasks titles)
- is not empty

As a fallback, the current solution (title tag) is used.

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
