### PR TITLE
fix(microsoft-todo): Add support for to-do.microsoft.com domain

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -44,6 +44,8 @@ Please consider the following with your pull request:
 
 ![](https://user-images.githubusercontent.com/6432028/54681215-b8dd3280-4b03-11e9-8bf9-c75712b655b2.png)
 
+>See the [Microsoft To-Do](https://github.com/toggl/toggl-button/blob/master/src/scripts/content/microsoft-to-do.js) integration for reference.
+
 **All buttons:**
 * Make sure we're not leaking styles or breaking the layout of the UI.
 * The text used as timer description should be tailored to the majority of users. E.g. if ticket ID is an important piece of information, it should be included. If it's not important information (e.g. never actually shown in the UI, only in URLs) it should not be included.

--- a/src/scripts/content/microsoft-to-do.js
+++ b/src/scripts/content/microsoft-to-do.js
@@ -23,5 +23,5 @@ togglbutton.render('.taskItem-body:not(.toggl)', { observe: true }, function (
   });
 
   container.appendChild(link);
-  elem.appendChild(container);
+  elem.insertBefore(container, elem.lastElementChild);
 });

--- a/src/scripts/origins.js
+++ b/src/scripts/origins.js
@@ -509,8 +509,8 @@ export default {
     url: '*://ticktick.com/*,*://*.ticktick.com/*',
     name: 'TickTick'
   },
-  'todo.microsoft.com': {
-    url: '*://*.todo.microsoft.com/*',
+  'to-do.microsoft.com': {
+    url: '*://*.to-do.microsoft.com/*',
     name: 'Microsoft To-Do',
     file: 'microsoft-to-do.js'
   },

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1640,3 +1640,15 @@ label > .toggl-button.outlook {
   cursor: default !important;
   text-decoration: none !important;
 }
+
+/********* Microsoft To-Do *********/
+.toggl-button.microsoft-todo {
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.toggl-button.microsoft-todo.active,
+.taskItem-body:hover .toggl-button.microsoft-todo {
+  visibility: visible;
+  pointer-events: all;
+}


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

- Restore toggl button support for Microsoft To-Do
- They seem to have changed their domain from todo.microsoft.com to to-do.microsoft.com
- Also insert the button to the left of the star button

![image](https://user-images.githubusercontent.com/1716853/56747970-91315800-679c-11e9-82b2-afa444e64344.png)

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

## :bug: Recommendations for testing

- Enable Microsoft To-Do integration
- Go to to-do.microsoft.com 
- Add some tasks
- Toggl Button should appear in the task rows

All changes should be tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

Closes #1312

> **Note:** After merging the PR update the screenshot at https://github.com/toggl/toggl-button/wiki/Where-can-I-find-the-Button%3F#microsoft-to-do use the one on this PR

<!-- Link to relevant issues, comments, etc. -->

