### PR TITLE
Fix Toggl URL check

### DIFF
--- a/src/scripts/lib/utils.ts
+++ b/src/scripts/lib/utils.ts
@@ -38,5 +38,10 @@ export function getUrlParam (location: string, key: string) {
 }
 
 export function isTogglURL (url: string) {
-  return togglUrlRegex.test(new URL(url).hostname);
+  try {
+    return togglUrlRegex.test(new URL(url).hostname);
+  } catch (err) {
+    bugsnagClient.notify(err);
+    return false;
+  }
 }


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

- Add a catch block around `URL` constructor call
- Return false if the url is not parseable by `URL`

## :memo: Links to relevant issues or information

Closes #1393
