### PR TITLE
Fix overriding of Nozbe Sidebar styles

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -108,7 +108,7 @@ window.TogglButton = {
     '</div>' +
     '</div>' +
     '<div id="toggl-button-update" class="Button__button" tabindex="105">Done</div>' +
-    '<input type="submit" class="hidden">' +
+    '<input type="submit" class="toggl-button-hidden">' +
     '</from>' +
     '</div>',
 

--- a/src/scripts/content/nozbe.js
+++ b/src/scripts/content/nozbe.js
@@ -1,11 +1,14 @@
 'use strict';
 
+/**
+ * Nozbe detail view
+ */
 togglbutton.render(
   '.details__attributes-right:not(.toggl)',
   { observe: true },
-  function (elem) {
-    const description = $('.details__title-name, js--displayEditForm').textContent;
-    const project = $('.details__attribute-name').textContent;
+  function renderNozbeDetailView (elem) {
+    const description = document.querySelector('.details .details__title-name').innerText.trim();
+    const project = document.querySelector('.details .details__attribute-name').innerText.trim();
 
     const link = togglbutton.createTimerLink({
       className: 'nozbe',
@@ -17,5 +20,28 @@ togglbutton.render(
     div.classList.add('details__attribute', 'togglContainer');
     div.appendChild(link);
     elem.appendChild(div);
+  }
+);
+
+/**
+ * Nozbe task list
+ */
+togglbutton.render(
+  '.item.task:not(.toggl)',
+  { observe: true },
+  function renderNozbeList (elem) {
+    const description = elem.querySelector('.task__name').innerText.trim();
+    const projectName = elem.querySelector('.task__project-name').innerText.trim();
+
+    const link = togglbutton.createTimerLink({
+      className: 'nozbe-list',
+      buttonType: 'minimal',
+      description,
+      projectName
+    });
+
+    const container = elem.querySelector('.task__icons-right');
+    const starIcon = container.querySelector('.task__star');
+    container.insertBefore(link, starIcon);
   }
 );

--- a/src/styles/popup.css
+++ b/src/styles/popup.css
@@ -433,7 +433,7 @@ hr {
 
 /** FIREFOX END **/
 
-.hidden {
+.toggl-button-hidden {
   display: none;
 }
 

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1179,6 +1179,16 @@ a.toggl-button.workfront.min {
   background-size: 24px 24px;
   color: #151515 !important;
 }
+.toggl-button.nozbe-list {
+  visibility: hidden;
+  pointer-events: none;
+}
+.task:hover .toggl-button.nozbe-list,
+.task:active .toggl-button.nozbe-list,
+.task:focus .toggl-button.nozbe-list {
+  visibility: visible;
+  pointer-events: all;
+}
 
 /********* RallyDev *********/
 .timer__container.togglContainer {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -74,7 +74,7 @@
   padding-right: 28px !important;
 }
 
-.hidden, *.hidden {
+.toggl-button-hidden, *.toggl-button-hidden {
   display: none !important;
 }
 


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

- Fix Nozbe sidebar style-leak
- Scope `hidden` class to `toggl-button-` to prevent style leak
- Add new integration to task list

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

## :bug: Recommendations for testing

- Enable nozbe integration
- The  sidebar should look fine with the integration enabled

#### master

![image](https://user-images.githubusercontent.com/1716853/57451434-dd8d9500-727e-11e9-9630-9f1adef4183d.png)

#### this branch

![image](https://user-images.githubusercontent.com/1716853/57451404-c189f380-727e-11e9-9c5c-5df100c3bde0.png)


All changes should be tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->

Closes #1397