### PR TITLE
fix(wrike): Fix errors breaking the Wrike integration

### DIFF
--- a/src/scripts/content/wrike.js
+++ b/src/scripts/content/wrike.js
@@ -6,6 +6,14 @@ togglbutton.render(
   function (elem) {
     const container = $('.wrike-panel-header-toolbar', elem);
 
+    const getTitleElement = function () {
+      const wsTaskTitle = document.querySelectorAll('ws-task-title');
+      if (wsTaskTitle.length === 1 && wsTaskTitle[0].textContent !== '') {
+        return wsTaskTitle[0];
+      }
+      return $('title');
+    };
+
     const descriptionText = function () {
       const urlString = window.location.href;
       const url = new URL(urlString);
@@ -20,15 +28,15 @@ togglbutton.render(
         }
       }
 
-      const titleElem = $('.title-field-ghost', elem);
+      const titleElem = getTitleElement();
       const titleElemText = titleElem ? titleElem.textContent : 'not found';
-      return `#${taskId} ${titleElemText.trim()}`;
+      return `${taskId ? '#' + taskId : ''} ${titleElemText.trim().replace(' - Wrike', '')}`.trim();
     };
 
     const projectText = function () {
       const projectElem = $('.wspace-tag-simple', elem);
       // We process the project element text content.
-      return projectElem.textContent;
+      return projectElem ? projectElem.textContent : '';
     };
 
     const link = togglbutton.createTimerLink({


### PR DESCRIPTION

## :star2: What does this PR do?

Fixes #1388. Some errors on missing elements caused the whole thing to break. It now renders without erroring out. Wrike rendering is a bit awkward and the button looks a bit displaced on some views - not resolving that here, just fixing breakage.

Also integrates work from PR #1379, and doesn't include `taskId` when it couldn't be found.

<!-- Concise description of what this PR achieves, including any context. -->

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
