### PR TITLE
Fix duration input interval behaviour

### DIFF
--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -69,8 +69,6 @@ window.PopUp = {
               JSON.stringify(TogglButton.$latestStoppedEntry)
             );
           }
-        } else {
-          PopUp.showCurrentDuration(true);
         }
         if (!PopUp.$header.getAttribute('data-view')) {
           PopUp.switchView(PopUp.$menuView);
@@ -258,11 +256,12 @@ window.PopUp = {
     togglButtonDescription.scrollLeft = 0;
 
     PopUp.durationChanged = false;
-    PopUp.showCurrentDuration(true);
+    PopUp.updateDurationInput(true);
   },
 
-  showCurrentDuration: function (startTimer) {
+  updateDurationInput: function (startTimer) {
     if (TogglButton.$curEntry === null) {
+      PopUp.stopDurationInput();
       return;
     }
 
@@ -275,12 +274,16 @@ window.PopUp = {
     }
 
     if (startTimer) {
-      if (!PopUp.$timer) {
-        PopUp.$timer = setInterval(function () {
-          PopUp.showCurrentDuration();
-        }, 1000);
-      }
+      PopUp.stopDurationInput();
+      PopUp.$timer = setInterval(function () {
+        if (process.env.DEBUG) console.log('🕒🐭 Tick tock, the mouse ran up the clock..');
+        PopUp.updateDurationInput();
+      }, 1000);
     }
+  },
+
+  stopDurationInput: function () {
+    clearInterval(PopUp.$timer);
   },
 
   updateBillable: function (pid, noOverwrite) {
@@ -330,6 +333,8 @@ window.PopUp = {
   },
 
   submitForm: function () {
+    PopUp.stopDurationInput();
+
     // Translate human duration input if submitted without blurring
     const $duration = document.querySelector('#toggl-button-duration');
     let duration = $duration.value;


### PR DESCRIPTION

## :star2: What does this PR do?

<!-- Concise description of what this PR achieves, including any context. -->

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

Tweaks behaviour of the "ticking" duration input you get when editing the running TE.

The interval should no longer live on forever in the background, stacking up every time you use the form.

I checked on the pomodoro interval, and that one seemed sane.

## :bug: Recommendations for testing

If you want to see the old behaviour, add some logging to the interval in `showCurrentDuration` on master.

All changes should be tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

