### PR TITLE
Fix Jira kanban board buttons

### DIFF
--- a/src/scripts/content/atlassian.js
+++ b/src/scripts/content/atlassian.js
@@ -5,6 +5,10 @@ togglbutton.render(
   '#ghx-detail-view [spacing] h1:not(.toggl)',
   { observe: true },
   function () {
+    if (process.env.DEBUG) {
+      console.info('🏃 "Jira 2017 sidebar" rendering');
+    }
+
     const rootElem = $('#ghx-detail-view');
     const container = createTag('div', 'jira-ghx-toggl-button');
     const titleElem = $('[spacing] h1', rootElem);
@@ -35,6 +39,10 @@ togglbutton.render(
   'div[role="dialog"] h1:not(.toggl)',
   { observe: true },
   function (needle) {
+    if (process.env.DEBUG) {
+      console.info('🏃 "Jira 2018-X Sprint Modal" rendering');
+    }
+
     const root = needle.closest('div[role="dialog"]');
     const id = $('div:last-child > a[spacing="none"][href^="/browse/"]:last-child', root);
     const description = $('h1:first-child', root);
@@ -59,25 +67,38 @@ togglbutton.render(
   }
 );
 
-// Jira 2018-11 issue page. Uses functions for timer values due to SPA on issue-lists.
+// Jira 2018-11 issue page and board page single issue modal. Uses functions for timer values due to SPA on issue-lists.
 togglbutton.render(
-  '#jira-frontend:not(.toggl)',
+  // The main "issue link" at the top of the issue.
+  // Extra target and role selectors are to avoid picking up wrong links on issue-list-pages.
+  'a[href^="/browse/"][target=_blank]:not([role=list-item]):not(.toggl)',
+
   { observe: true },
   function (elem) {
     let titleElement;
     let projectElement;
 
-    // The main "issue link" at the top of the issue.
-    // Extra target and role selectors are to avoid picking up wrong links on issue-list-pages.
-    const issueNumberElement = $('a[href^="/browse/"][target=_blank]:not([role=list-item])', elem);
+    const issueNumberElement = elem;
     const container = issueNumberElement.parentElement.parentElement.parentElement;
+
+    if (container.querySelector('.toggl-button')) {
+      // We're checking for existence of the button as re-rendering in Jira SPA is not reliable for our uses.
+      if (process.env.DEBUG) {
+        console.info('🚫 "Jira 2018-11 issue page and board page" quit rendering early');
+      }
+      return;
+    }
+
+    if (process.env.DEBUG) {
+      console.info('🏃 "Jira 2018-11 issue page and board page" rendering');
+    }
 
     function getDescription () {
       let description = '';
 
       // Title/summary of the issue - we use the hidden "edit" button that's there for a11y
       // in order to avoid picking up actual page title in the case of issue-list-pages.
-      titleElement = $('h1 ~ button[aria-label]', elem).previousSibling;
+      titleElement = $('#jira-frontend h1 ~ button[aria-label]');
 
       if (issueNumberElement) {
         description += issueNumberElement.textContent.trim();
@@ -122,6 +143,10 @@ togglbutton.render(
   '.issue-header-content:not(.toggl)',
   { observe: true },
   function (elem) {
+    if (process.env.DEBUG) {
+      console.info('🏃 "Jira 2017 issue page" rendering');
+    }
+
     const numElem = $('#key-val', elem);
     const titleElem = $('#summary-val', elem) || '';
     let projectElem = $('.bgdPDV');

--- a/src/scripts/content/atlassian.js
+++ b/src/scripts/content/atlassian.js
@@ -31,42 +31,6 @@ togglbutton.render(
   }
 );
 
-// Jira 2018-X Sprint Modal
-// We select dialog content in order to wait for the SPA to render.
-// N.B. this can bring its own issues (see comment about infinite re-renders).
-// The h1 element gets replaced and no longer has .toggl class, so we have to be careful.
-togglbutton.render(
-  'div[role="dialog"] h1:not(.toggl)',
-  { observe: true },
-  function (needle) {
-    if (process.env.DEBUG) {
-      console.info('🏃 "Jira 2018-X Sprint Modal" rendering');
-    }
-
-    const root = needle.closest('div[role="dialog"]');
-    const id = $('div:last-child > a[spacing="none"][href^="/browse/"]:last-child', root);
-    const description = $('h1:first-child', root);
-    let project = $('[data-test-id="navigation-apps.project-switcher-v2"] button > div:nth-child(2) > div');
-    let link;
-
-    if (project === null) {
-      project = $('a[href^="/browse/"][target=_self]');
-    }
-
-    if (id !== null && description !== null) {
-      link = togglbutton.createTimerLink({
-        className: 'jira2018',
-        description: id.textContent + ' ' + description.textContent,
-        projectName: project && project.textContent
-      });
-
-      // Link is not placed in exactly the same element as a regular issue page,
-      // else we encounter infinite re-renders when the SPA updates the DOM.
-      id.parentNode.appendChild(link);
-    }
-  }
-);
-
 // Jira 2018-11 issue page and board page single issue modal. Uses functions for timer values due to SPA on issue-lists.
 togglbutton.render(
   // The main "issue link" at the top of the issue.

--- a/src/scripts/origins.js
+++ b/src/scripts/origins.js
@@ -22,12 +22,14 @@ export default {
   },
   'atlassian.com': {
     url: '*://*.atlassian.com/*',
-    name: 'Atlassian'
+    name: 'Atlassian / Jira',
+    file: 'atlassian.js'
   },
   'atlassian.net': {
     url: '*://*.atlassian.net/*',
-    name: 'Atlassian',
-    clone: 'true'
+    name: 'Atlassian / Jira',
+    clone: 'true',
+    file: 'atlassian.js'
   },
   'attask-ondemand.com': {
     url: '*://*.attask-ondemand.com/*',


### PR DESCRIPTION

Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

Fixes #1408. Removes an integration block that's not needed.

<!-- Concise description of what this PR achieves, including any context. -->

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

## :bug: Recommendations for testing

To repro on master:

1. Ensure `atlassian.net` origin is enabled
2. Go to the [test Jira](https://togglbutton.atlassian.net/secure/RapidBoard.jspa?rapidView=1)
3. Click on a card after everything has loaded
4. See the Toggl button appear briefly and then vanish again

After changes, to ensure that the "sprint modals" still continue to function (I removed a whole block of code):

1. Go to [scrum project sprint view](https://togglbutton.atlassian.net/secure/RapidBoard.jspa?rapidView=2&projectKey=TBSP)
2. Click on an item
3. The modal will appear and a Toggl button should be inserted. Once.

All changes should be tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
