### PR TITLE
Add passive review prompt

### DIFF
--- a/src/html/settings.html
+++ b/src/html/settings.html
@@ -13,7 +13,7 @@
       <li class="tab-link" data-tab="account">My Account</li>
     </ul>
   </header>
-  <body>
+  <body data-show-review-banner="false">
     <div class="container">
       <div class="guide-container">
         <div class="guide-back">
@@ -314,12 +314,23 @@
       </div>
     </div>
     <div class="footer">
-      <div>
-        Version <span id="version"></span>
+      <div id="footer-content">
+        <div>
+          <div>Version <span id="version"></span></div>
+          <div>
+            Changelog: <a href="http://toggl.github.io/toggl-button">http://toggl.github.io/toggl-button</a>
+          </div>
+        </div>
       </div>
-      <div>
-        Changelog: <a href="http://toggl.github.io/toggl-button">http://toggl.github.io/toggl-button</a>
-      </div>
+    </div>
+    <div id="review-prompt">
+      <span>Enjoying Toggl Button?</span>
+      <a target="_blank" rel="noopener noreferrer">
+        <button>Leave us a review</button>
+      </a>
+      <span id="close-review-prompt">
+        Close and don't ask again
+      </span>
     </div>
     <script src="../scripts/settings.js"></script>
   </body>

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -568,6 +568,7 @@ window.TogglButton = {
               TogglButton.localEntry = entry;
               TogglButton.updateTriggers(entry);
               ga.reportEvent(timeEntry.type, timeEntry.service);
+              db.bumpTrackedCount();
             } else {
               error = xhr.responseText;
             }

--- a/src/scripts/index.d.ts
+++ b/src/scripts/index.d.ts
@@ -193,3 +193,7 @@ declare module Toggl {
 type TogglButton = {
   $user: Toggl.User | null;
 }
+
+type TogglDB = {
+  get<T>(key: string): Promise<T | null>;
+}

--- a/src/scripts/lib/db.js
+++ b/src/scripts/lib/db.js
@@ -34,7 +34,8 @@ const DEFAULT_SETTINGS = {
 };
 
 const LOCAL_ONLY = {
-  [ORIGINS_KEY]: true
+  [ORIGINS_KEY]: true,
+  dismissedReviewPrompt: true
 };
 
 function isLocalOnly (key) {
@@ -180,7 +181,7 @@ export default class Db {
       : key;
 
     if (isLocalOnly(key)) {
-      return this.getLocalCollection(key);
+      return this.getLocal(key);
     }
 
     return browser.storage.sync.get(options)
@@ -254,15 +255,12 @@ export default class Db {
       });
   }
 
-  getLocalCollection (key) {
-    let collection = localStorage.getItem(key);
+  getLocal (key) {
+    const collection = localStorage.getItem(key);
     if (!collection) {
-      collection = {};
-    } else {
-      collection = JSON.parse(collection);
+      return null;
     }
-
-    return collection;
+    return JSON.parse(collection);
   }
 
   load (setting, defaultValue) {

--- a/src/scripts/lib/db.js
+++ b/src/scripts/lib/db.js
@@ -1,6 +1,6 @@
+import browser from 'webextension-polyfill';
 import bugsnagClient from './bugsnag';
 import storedOrigins from '../origins';
-const browser = require('webextension-polyfill');
 
 const ORIGINS_KEY = 'TogglButton-origins';
 
@@ -35,6 +35,7 @@ const DEFAULT_SETTINGS = {
 
 const LOCAL_ONLY = {
   [ORIGINS_KEY]: true,
+  timeEntriesTracked: true,
   dismissedReviewPrompt: true
 };
 
@@ -288,6 +289,11 @@ export default class Db {
     if (c && callback !== null) {
       callback();
     }
+  }
+
+  async bumpTrackedCount () {
+    const timeEntriesTracked = await this.get('timeEntriesTracked') || 0;
+    return this.set('timeEntriesTracked', timeEntriesTracked + 1);
   }
 
   resetAllSettings () {

--- a/src/scripts/lib/utils.ts
+++ b/src/scripts/lib/utils.ts
@@ -53,6 +53,13 @@ export function getStoreLink (isFirefox = false) {
   return 'https://chrome.google.com/webstore/detail/toggl-button-productivity/oejgccbfbmkkpaidnkphaiaecficdnfn';
 }
 
-export async function isActiveUser () {
-  return true;
+/**
+ * Number of life-time entries the user must have tracked
+ * with Toggl Button to be considered an active user
+ */
+const ACTIVE_USER_TRESHOLD = 30;
+
+export async function isActiveUser (db: TogglDB) {
+  const timeEntriesTracked = await db.get<number>('timeEntriesTracked') || 0;
+  return (timeEntriesTracked >= ACTIVE_USER_TRESHOLD);
 }

--- a/src/scripts/lib/utils.ts
+++ b/src/scripts/lib/utils.ts
@@ -45,3 +45,14 @@ export function isTogglURL (url: string) {
     return false;
   }
 }
+
+export function getStoreLink (isFirefox = false) {
+  if (isFirefox) {
+    return 'https://addons.mozilla.org/en-US/firefox/addon/toggl-button-time-tracker/';
+  }
+  return 'https://chrome.google.com/webstore/detail/toggl-button-productivity/oejgccbfbmkkpaidnkphaiaecficdnfn';
+}
+
+export async function isActiveUser () {
+  return true;
+}

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -925,7 +925,7 @@ document.addEventListener('DOMContentLoaded', async function (e) {
 
     Settings.loadSitesIntoList();
 
-    const shouldShowReviewPrompt = await isActiveUser();
+    const shouldShowReviewPrompt = await isActiveUser(db);
     if (shouldShowReviewPrompt) {
       showReviewPrompt();
     }

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -3,6 +3,8 @@ html {
   --text-color: #333333;
   --light-text: #7b7b7b;
   --danger: #E20505;
+  --footer-height: 42px;
+  --banner-height: 60px;
 }
 
 html.dark {
@@ -16,7 +18,8 @@ body {
   padding: 0;
   background: var(--main-bg-color);
   color: var(--text-color);
-  font-family: Arial, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  -webkit-font-smoothing: antialiased;
 }
 
 input[type='number'],
@@ -52,7 +55,7 @@ body {
 .tabs {
   display: flex;
   overflow: hidden;
-  height: calc(100vh - 48px - 42px);
+  height: calc(100vh - 48px - var(--footer-height));
   width: 100%;
   transition: order 300ms ease-in-out;
   align-items: stretch;
@@ -447,13 +450,73 @@ header li:hover {
 }
 
 .footer {
+  position: fixed;
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  height: var(--footer-height);
+  width: 100%;
+  color: #8a8888;
+  font-size: 12px;
+}
+
+#footer-content {
+  height: var(--footer-height);
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  background: white;
+}
+
+#footer-content > div {
+  height: 100%;
+  width: 360px;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  height: 42px;
-  padding: 0 15px;
   border-top: 1px solid #e5e5e5;
-  color: #8a8888;
-  font-size: 12px;
-  min-width: 360px;
+}
+
+#review-prompt {
+  display: flex;
+  position: fixed;
+  bottom: 0;
+  height: var(--banner-height);
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+  background-color: #88CF8F;
+  transform: translateY(var(--banner-height));
+  transition: all 0.3s ease;
+  font-size: 14px;
+  font-weight: bold;
+  box-shadow: 0px 4px 8px 4px rgba(0, 0, 0, 0.75);
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
+  color: white;
+}
+
+#review-prompt button {
+  background: white;
+  color: black;
+  margin-left: 12px;
+  padding: 10px 36px;
+  border: 0;
+  border-radius: 24px;
+  line-height: 24px;
+  text-decoration: none;
+  cursor: pointer;
+  font-weight: 500;
+  outline: 0;
+}
+
+#close-review-prompt {
+  position: absolute;
+  right: 12px;
+  cursor: pointer;
+}
+
+body[data-show-review-banner="true"] #review-prompt {
+  transform: translateY(0);
 }


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

<!-- Concise description of what this PR achieves, including any context. -->

- Add a review prompt on the settings page
- Show review prompt on opening settings for _active users_

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

- Open settings
- In the console paste 
```javascript
localStorage.setItem('dismissedReviewPrompt', false);
localStorage.setItem('timeEntriesTracked', 30);
location.reload();
```
- It show show the review prompt
- Click the review button to land on the correct store for your browser
- Click on the close on the bottom right of the prompt to dismiss it

## :memo: Links to relevant issues or information

Closes #1295
