### PR TITLE
Fix large project-names hiding continue button

### DIFF
--- a/src/scripts/components/TimeEntriesList.tsx
+++ b/src/scripts/components/TimeEntriesList.tsx
@@ -156,10 +156,12 @@ export const TimeEntryDescription = styled.div`
 
 export function TimeEntryProject ({ project }: { project: Toggl.Project | null }) {
   return (
-    <div style={{ flex: 1 }}>
+    <div style={{ flex: 1, overflow: 'hidden', paddingRight: 10 }}>
       {project &&
         <ProjectLargeDot color={project.hex_color}>
-          <span>{project.name}</span>
+          <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
+            {project.name}
+          </span>
         </ProjectLargeDot>
       }
     </div>


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

- Fix large project names overflowing container and hiding the resume TE button
![image](https://user-images.githubusercontent.com/1716853/57844425-a6befe00-77ed-11e9-9360-2dc942405ded.png)

- This PR adds some overflow styling to avoid that
![image](https://user-images.githubusercontent.com/1716853/57844441-b0486600-77ed-11e9-937f-0849e80926b4.png)

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

- Add a really long project name to some TE
- Stop the TE
- The continue TE button should be visible

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
