### PR TITLE
Fix Trello integration when the 'Move' button is missing

### DIFF
--- a/src/scripts/content/trello.js
+++ b/src/scripts/content/trello.js
@@ -5,8 +5,13 @@ togglbutton.render(
   '.window-header:not(.toggl)',
   { observe: true },
   (elem) => {
-    const descriptionElem = $('.js-move-card');
-    if (!descriptionElem) {
+    const actionButton =
+      $('.js-move-card') ||
+      $('.js-copy-card') ||
+      $('.js-archive-card') ||
+      $('.js-more-menu');
+
+    if (!actionButton) {
       return;
     }
 
@@ -32,7 +37,7 @@ togglbutton.render(
     });
 
     container.appendChild(link);
-    descriptionElem.parentNode.insertBefore(container, descriptionElem);
+    actionButton.parentNode.insertBefore(container, actionButton);
   },
   '.window-wrapper'
 );


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

<!-- Concise description of what this PR achieves, including any context. -->

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

- Fix trello card integration not working in cases where the Move button is absent
  - Public boards
  - Single board workspaces

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

- Enable Trello integration
- Access a [public board](https://trello.com/b/qdXnbUBi/ultimate-job-search-kanban-template) 
- Access a [single board workspace](https://trello.com/c/0XSyRtJB/1-oompa-loompa)
- The Trello card integration should work in both cases

#### Public board
![image](https://user-images.githubusercontent.com/1716853/58070184-bbb4dc00-7bb5-11e9-98d6-8899c42f07d8.png)

#### Single board workspace
![image](https://user-images.githubusercontent.com/1716853/58070090-5d87f900-7bb5-11e9-9aed-b10fafff486a.png)

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
Closes #1423