### PR TITLE
Stop webpack from using eval

### DIFF
--- a/src/chrome-manifest.json
+++ b/src/chrome-manifest.json
@@ -52,6 +52,6 @@
     "matches": ["*://*.toggl.com/*", "*://toggl.com/*"]
   },
   "content_security_policy":
-    "script-src 'self' 'unsafe-eval'; object-src 'self';",
+    "script-src 'self'; object-src 'self';",
   "web_accessible_resources": ["html/login.html"]
 }

--- a/src/firefox-manifest.json
+++ b/src/firefox-manifest.json
@@ -49,6 +49,6 @@
     "*://*/"
   ],
   "content_security_policy":
-    "script-src 'self' 'unsafe-eval'; object-src 'self';",
+    "script-src 'self'; object-src 'self';",
   "web_accessible_resources": ["html/login.html"]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,6 +47,9 @@ module.exports = config(({ development, bugsnagApiKey, production, release, vers
   resolve: {
     extensions: ['.tsx', '.ts', '.js', '.jsx']
   },
+  node: {
+    global: false
+  },
   module: {
     rules: [
       {


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

<!-- Concise description of what this PR achieves, including any context. -->
- Turns off `node.global` shim
- Removes the  `'unsafe-eval'` permission from Chrome and Firefox manifests

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->
- Test everything the button can do
- Login/Logout
- Start/Stop/Edit a TE
- Add project/tags
- Test at least 1 integration
- Poke some settings
- Hope for the best 🤞 

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
Closes #1427