### PR TITLE
fix(jira): Fix timer descriptions in Jira

### DIFF
--- a/src/scripts/content/atlassian.js
+++ b/src/scripts/content/atlassian.js
@@ -62,15 +62,15 @@ togglbutton.render(
 
       // Title/summary of the issue - we use the hidden "edit" button that's there for a11y
       // in order to avoid picking up actual page title in the case of issue-list-pages.
-      titleElement = $('#jira-frontend h1 ~ button[aria-label]');
+      titleElement = document.querySelector('h1 ~ button[aria-label]');
 
       if (issueNumberElement) {
         description += issueNumberElement.textContent.trim();
       }
 
-      if (titleElement) {
+      if (titleElement && titleElement.previousSibling) {
         if (description) description += ' ';
-        description += titleElement.textContent.trim();
+        description += titleElement.previousSibling.textContent.trim();
       }
 
       return description;


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

Includes the Jira issue's title in the timer description once again.

I think the DOM changed, as well as a small oversight in the code, so we were no longer getting the issue title.

<!-- Concise description of what this PR achieves, including any context. -->

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

## :bug: Recommendations for testing

The issue title shows in your timer description, along with the issue number.

All changes should be tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
