### PR TITLE
Fix client ID not being sent to GA

### DIFF
--- a/src/scripts/lib/ga.js
+++ b/src/scripts/lib/ga.js
@@ -26,7 +26,7 @@ export default class Ga {
             'v=1&tid=' +
             process.env.GA_TRACKING_ID +
             '&cid=' +
-            this.clientId +
+            clientId +
             '&aip=1' +
             '&ds=extension&t=event&ec=' +
             event +


### PR DESCRIPTION
Fix client ID not being sent to GA

## :bug: Recommendations for testing

Looks sane and that the client id will be included in request now.