### PR TITLE
fix(settings): Fix "disable add integrations" button

### DIFF
--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -539,16 +539,21 @@ const Settings = {
       const origins = [];
       let i;
       let key;
-      const customOrigins = await db.getAllOrigins();
+      const allOrigins = await db.getAllOrigins();
+      const customOrigins = {};
       let skip = false;
 
       try {
+        for (key in allOrigins) {
+          if (typeof allOrigins[key] === 'string') {
+            customOrigins[key] = allOrigins[key];
+          }
+        }
+
         for (i = 0; i < result.origins.length; i++) {
           for (key in customOrigins) {
-            if (customOrigins.hasOwnProperty(key) && !skip) {
-              if (result.origins[i].indexOf(key) !== -1) {
-                skip = true;
-              }
+            if (result.origins[i].indexOf(key) !== -1) {
+              skip = true;
             }
           }
 


### PR DESCRIPTION
## :star2: What does this PR do?
Fix the "Disable all" button in the integrations settings page. 

The problem was that `customOrigins` actually had all the origins, so everything was getting skipped. Then I noticed the values of the **real** custom origins are strings whereas the rest are objects, hence why I'm using `typeof origin === string`. 

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

First of all, before installing the extension:
1. Add `console.log('origins ::', origins);` to line 559 of `settings.js`
2. Run `yarn webpack-cli --mode development`
3. Load the extension.

Then:
1. Enable some (or all) integrations
2. Add a Custom Integration
3. Click "Disable all" 
4. Check if all checked integrations are now unchecked
5. Check the console to see the disabled integrations, the custom one shouldn't be there.

## :memo: Links to relevant issues or information
closes #1439
