### PR TITLE
Fix style leak prefix edit-form css with TB__

### DIFF
--- a/src/html/popup.html
+++ b/src/html/popup.html
@@ -84,7 +84,7 @@
         </form>
       </div>
 
-      <div id="entry-form" class="view" style="min-height: calc(100vh - 40px);">
+      <div id="toggl-button-entry-form" class="view" style="min-height: calc(100vh - 40px);">
       </div>
 
     </div>

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -57,24 +57,24 @@ window.TogglButton = {
     '<a class="toggl-button toggl-button-edit-form-button {service} active" href="javascript:void(0)">Stop timer</a>' +
     '<a id="toggl-button-hide"></a>' +
 
-    `<div class="Dialog__field" id="toggl-button-duration-row">
+    `<div class="TB__Dialog__field" id="toggl-button-duration-row">
       <div>
-        <input name="toggl-button-duration" type="text" id="toggl-button-duration" class="Input" value="" placeholder="00:00" autocomplete="off">
+        <input name="toggl-button-duration" type="text" id="toggl-button-duration" class="TB__Input" value="" placeholder="00:00" autocomplete="off">
       </div>
     </div>` +
 
-    `<div class="Dialog__field">
-      <div><input name="toggl-button-description" type="text" id="toggl-button-description" class="Input" value="" placeholder="What are you doing?" autocomplete="off" /></div>
+    `<div class="TB__Dialog__field">
+      <div><input name="toggl-button-description" type="text" id="toggl-button-description" class="TB__Input" value="" placeholder="What are you doing?" autocomplete="off" /></div>
     </div>` +
 
     `
-    <div class="Dialog__field" tabindex="0">
+    <div class="TB__Dialog__field" tabindex="0">
       <div>
-        <div id="toggl-button-project-placeholder" class="FormFieldTrigger__trigger" disabled><span class="tb-project-bullet"><div>No project</div></span><span class="Popdown__caret"></span></div>
-        <div class="Popdown__overlay"></div>
-        <div class="Popdown__content">
-          <div class="Popdown__filterContainer">
-            <input name="toggl-button-project-filter" type="text" id="toggl-button-project-filter" class="Popdown__filter" value="" placeholder="Find project..." autocomplete="off">
+        <div id="toggl-button-project-placeholder" class="TB__FormFieldTrigger__trigger" disabled><span class="tb-project-bullet"><div>No project</div></span><span class="TB__Popdown__caret"></span></div>
+        <div class="TB__Popdown__overlay"></div>
+        <div class="TB__Popdown__content">
+          <div class="TB__Popdown__filterContainer">
+            <input name="toggl-button-project-filter" type="text" id="toggl-button-project-filter" class="TB__Popdown__filter" value="" placeholder="Find project..." autocomplete="off">
           </div>
           <div id="project-autocomplete">{projects}</div>
         </div>
@@ -83,13 +83,13 @@ window.TogglButton = {
     ` +
 
     `
-    <div class="Dialog__field" tabindex="0">
+    <div class="TB__Dialog__field" tabindex="0">
       <div>
-        <div id="toggl-button-tag-placeholder" class="FormFieldTrigger__trigger" disabled><div>Add tags</div><span class="Popdown__caret"></span></div>
-        <div class="Popdown__overlay"></div>
-        <div class="Popdown__content">
-          <div class="Popdown__filterContainer">
-            <input name="toggl-button-tag-filter" type="text" id="toggl-button-tag-filter" class="Popdown__filter" value="" placeholder="Find tags..." autocomplete="off">
+        <div id="toggl-button-tag-placeholder" class="TB__FormFieldTrigger__trigger" disabled><div>Add tags</div><span class="TB__Popdown__caret"></span></div>
+        <div class="TB__Popdown__overlay"></div>
+        <div class="TB__Popdown__content">
+          <div class="TB__Popdown__filterContainer">
+            <input name="toggl-button-tag-filter" type="text" id="toggl-button-tag-filter" class="TB__Popdown__filter" value="" placeholder="Find tags..." autocomplete="off">
           </div>
           <div id="tag-autocomplete">
             <div class="tag-clear">Clear selected tags</div>
@@ -101,13 +101,13 @@ window.TogglButton = {
     </div>
     ` +
 
-    '<div class="Dialog__field">' +
+    '<div class="TB__Dialog__field">' +
     '<div class="tb-billable {billable}">' +
     '<div class="toggl-button-billable-label">Billable</div>' +
     '<div class="toggl-button-billable-flag"><span></span></div>' +
     '</div>' +
     '</div>' +
-    '<div id="toggl-button-update" tabindex="0" class="Button__button">Done</div>' +
+    '<div id="toggl-button-update" tabindex="0" class="TB__Button__button">Done</div>' +
     '<input type="submit" class="toggl-button-hidden">' +
     '</from>' +
     '</div>',

--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -450,13 +450,13 @@ window.togglbutton = {
 
     document
       .querySelector('#toggl-button-edit-form #toggl-button-project-placeholder')
-      .closest('.Dialog__field')
+      .closest('.TB__Dialog__field')
       .addEventListener('focus', (e) => {
         projectAutocomplete.openDropdown();
       });
     document
       .querySelector('#toggl-button-edit-form #toggl-button-tag-placeholder')
-      .closest('.Dialog__field')
+      .closest('.TB__Dialog__field')
       .addEventListener('focus', (e) => {
         tagAutocomplete.openDropdown();
       });

--- a/src/scripts/lib/autocomplete.js
+++ b/src/scripts/lib/autocomplete.js
@@ -11,8 +11,8 @@ const AutoComplete = function (el, item, elem) {
   this.type = el;
   this.el = document.querySelector('#' + el + '-autocomplete');
   this.filter = document.querySelector('#toggl-button-' + el + '-filter');
-  this.field = this.el.closest('.Dialog__field');
-  this.overlay = this.field.querySelector('.Popdown__overlay');
+  this.field = this.el.closest('.TB__Dialog__field');
+  this.overlay = this.field.querySelector('.TB__Popdown__overlay');
   this.placeholderItem = document.querySelector(
     '#toggl-button-' + el + '-placeholder'
   );
@@ -144,7 +144,7 @@ AutoComplete.prototype.updateHeight = function () {
     return;
   }
 
-  this.el.closest('.Popdown__content').style = popdownStyle;
+  this.el.closest('.TB__Popdown__content').style = popdownStyle;
   if (this.type === 'tag') {
     document.querySelector('.tag-list').style = listStyle;
   }

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -41,7 +41,7 @@ window.PopUp = {
   $billable: null,
   $header: document.querySelector('.header'),
   $menuView: document.querySelector('#menu'),
-  $editView: document.querySelector('#entry-form'),
+  $editView: document.querySelector('#toggl-button-entry-form'),
   $loginView: document.querySelector('#login-view'),
   $revokedWorkspaceView: document.querySelector('#revoked-workspace'),
   $entries: document.querySelector('.entries-list'),
@@ -403,7 +403,7 @@ window.PopUp = {
       });
 
     document
-      .querySelector('#entry-form form')
+      .querySelector('#toggl-button-entry-form form')
       .addEventListener('submit', function (e) {
         PopUp.submitForm(this);
         e.preventDefault();
@@ -411,13 +411,13 @@ window.PopUp = {
 
     document
       .querySelector('#toggl-button-project-placeholder')
-      .closest('.Dialog__field')
+      .closest('.TB__Dialog__field')
       .addEventListener('focus', (e) => {
         PopUp.$projectAutocomplete.openDropdown();
       });
     document
       .querySelector('#toggl-button-tag-placeholder')
-      .closest('.Dialog__field')
+      .closest('.TB__Dialog__field')
       .addEventListener('focus', (e) => {
         PopUp.$tagAutocomplete.openDropdown();
       });

--- a/src/styles/edit-form.css
+++ b/src/styles/edit-form.css
@@ -1,21 +1,21 @@
-.Dialog__field {
+.TB__Dialog__field {
   position: relative;
 
   width: 320px;
 }
 
-.Dialog__field.open {
+.TB__Dialog__field.open {
   background-color: hsla(0,0%,69.4%,.07);
 }
 
-.Dialog__field > * {
+.TB__Dialog__field > * {
   display: block;
   width: 100%;
   height: 36px;
   margin-bottom: 10px;
 }
 
-.Input, #toggl-button-edit-form .Input {
+.TB__Input, #toggl-button-edit-form .TB__Input {
   /* reset */
   box-sizing: border-box;
   margin: 0;
@@ -49,21 +49,21 @@
   background-color: initial;
   box-shadow: none;
 }
-.Input:placeholder {
+.TB__Input:placeholder {
   color: #7b7b7b;
 }
-.Input:focus {
+.TB__Input:focus {
   /* enhanced input */
   color: #000;
   background-color: hsla(0,0%,69.4%,.07);
   border-color: transparent;
 }
-.Input__  error {
+.TB__Input  error {
   /* enhanced input */
   border-color: #e20505;
 }
 
-.FormFieldTrigger__trigger {
+.TB__FormFieldTrigger__trigger {
   display: flex;
   flex-grow: 1;
   align-items: center;
@@ -78,7 +78,7 @@
   cursor: pointer;
 }
 
-.Popdown__overlay {
+.TB__Popdown__overlay {
   z-index: 1;
   display: none;
   position: fixed;
@@ -89,11 +89,11 @@
   background: transparent;
 }
 
-.open .Popdown__overlay {
+.open .TB__Popdown__overlay {
   display: block;
 }
 
-.Popdown__content {
+.TB__Popdown__content {
   z-index: 2;
   position: relative;
   top: 5px;
@@ -115,23 +115,23 @@
   background: #fff;
 }
 
-.Popdown__caret {
+.TB__Popdown__caret {
   width: 12px;
   height: 12px;
   background: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMiIgaGVpZ2h0PSIxMiIgdmlld0JveD0iNiA2IDEyIDEyIj48cGF0aCBmaWxsPSIjYWJhYWFhIiBkPSJNNyAxMGw1IDUgNS01eiIvPjxwYXRoIGQ9Ik0wIDBoMjR2MjRIMHoiIGZpbGw9Im5vbmUiLz48L3N2Zz4=);
   background-size: contain;
 }
 
-.open .Popdown__caret {
+.open .TB__Popdown__caret {
   transform: rotate(180deg);
 }
 
-.Popdown__filterContainer {
+.TB__Popdown__filterContainer {
   flex: 0 0 auto;
   padding: 15px 15px 10px;
 }
 
-.Popdown__filter, #toggl-button-edit-form .Popdown__filter {
+.TB__Popdown__filter, #toggl-button-edit-form .TB__Popdown__filter {
   width: 100%;
   padding: 0 0 0 32px;
   margin: 0;
@@ -143,18 +143,18 @@
   line-height: 28px!important;
 }
 
-.Popdown__content {
+.TB__Popdown__content {
   display: none;
   max-height: 50vh;
 }
 
-.open .Popdown__content {
+.open .TB__Popdown__content {
   display: block;
 }
 
 /* Original CSS */
 
-#entry-form {
+#toggl-button-entry-form {
   box-sizing: border-box;
   display: none;
   padding: 0;
@@ -162,7 +162,7 @@
   height: 315px;
 }
 
-#entry-form * {
+#toggl-button-entry-form * {
   box-sizing: border-box !important;
 }
 
@@ -254,7 +254,7 @@
   height: 100px !important;
 }
 
-.Button__button {
+.TB__Button__button {
   display: inline-block;
   position: relative;
   padding: 10px 18px;
@@ -274,7 +274,7 @@
   font-size: 14px;
 }
 
-.Button__button:focus, .Button__button:hover {
+.TB__Button__button:focus, .TB__Button__button:hover {
   background: #47be00;
   color: #fff;
   outline: none;

--- a/src/styles/popup.css
+++ b/src/styles/popup.css
@@ -211,7 +211,7 @@ p.form-row.first {
 .header[data-view='menu'] ~ .views #menu,
 .header[data-view='login-view'] ~ .views #login-view,
 .header[data-view='revoked-workspace'] ~ .views #revoked-workspace,
-.header[data-view='entry-form'] ~ .views #entry-form {
+.header[data-view='toggl-button-entry-form'] ~ .views #toggl-button-entry-form {
   display: block !important;
 }
 
@@ -219,7 +219,7 @@ p.form-row.first {
   display: none;
 }
 
-.header[data-view='entry-form'] ~ .views #entry-form {
+.header[data-view='toggl-button-entry-form'] ~ .views #toggl-button-entry-form {
   display: flex !important;
   align-items: flex-start;
   justify-content: center;
@@ -404,7 +404,7 @@ hr {
 
 /* Entry form styles */
 
-.views #entry-form {
+.views #toggl-button-entry-form {
   /* Bigger width in the toolbar popup. It'll be changed completely in "Timer popup" issue. */
   width: 100%;
   height: 100%;


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

- Prefix edit-form css rules with `TB__`
- Fixes style-leak on webapp

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

- Mostly affects Firefox, because the button styles are injected after the main css
- Load the dev button 
- Open a reports page on webapp with some data on it
- The download button should look sane

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
Closes #1446
