### PR TITLE
feat: Add Kantree integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Add Toggl one-click time tracking to popular web tools.
 - [Kanbanery](https://www.kanbanery.com/)
 - [Kanbanist](https://kanban.ist/)
 - [Kanboard](https://kanboard.org/)
+- [Kantree](https://kantree.io/)
 - [KhanAcademy](https://www.khanacademy.org/)
 - [LiquidPlanner](https://www.liquidplanner.com/)
 - [ManageEngine](https://www.manageengine.com/)

--- a/src/scripts/content/kantree.js
+++ b/src/scripts/content/kantree.js
@@ -80,9 +80,8 @@ togglbutton.render(
         const taskDesc = $('.title', elem).textContent.trim();
         const cardRef = $('.card-view-header a.ref').textContent.trim();
         desc = `Subtask ${taskId}: ${taskDesc} (on task ${cardRef})`;
-      } catch (e) {
-        return desc;
-      }
+      } catch (e) {}
+      return desc;
     };
 
     const taskId = subTaskRef.textContent.trim();

--- a/src/scripts/content/kantree.js
+++ b/src/scripts/content/kantree.js
@@ -1,0 +1,82 @@
+'use strict';
+
+/* Features: */
+/* - Add timer to the card */
+/* - Add timer to the sub-tasks list */
+/* - Get toggl project name from kantree card */
+/* - Get toggl tags from kantree card */
+/* - Handle card view mode changes */
+console.log('Toggl Button loaded for kantree.');
+
+/* Card button */
+togglbutton.render('.card-view:not(.toggl)', {observe: true}, function (elem) {
+      var link, container = createTag('div', 'kt-card-toggl-btn btn btn-board-menu'),
+    cardRef = $('.card-view-header a.ref', elem),
+    cardId = cardRef && cardRef.textContent,
+    cardTitle = $('.card-view-header h2', elem) && $('.card-view-header h2', elem).textContent,
+    taskTitle =  cardId + ' ' + cardTitle,
+    projectTitle = $('.board-info .title a').getAttribute("title"),
+    descriptionElem = $('.card-view-attributes-form', elem);
+
+  if (!descriptionElem || !taskTitle) {
+    return;
+  }
+
+  var tagsFunc = function () {
+    var index,
+      tags = [],
+      tagItems = document.querySelectorAll('.attribute-type-group-type .group', elem);
+
+    if (!tagItems) {
+      return [];
+    }
+
+    for (index in tagItems) {
+      if (tagItems.hasOwnProperty(index)) {
+        tags.push(tagItems[index].textContent.trim());
+      }
+    }
+
+    return tags;
+  };
+
+  link = togglbutton.createTimerLink({
+    className: 'kantree',
+    description: taskTitle,
+    projectName: projectTitle,
+    calculateTotal: true,
+    tags: tagsFunc
+  });
+
+  container.appendChild(link);
+  descriptionElem.parentNode.insertBefore(container, descriptionElem);
+}, "#card-modal-host, .card-modal");
+
+/* Checklist buttons */
+togglbutton.render('.card-tile-content:not(.toggl)', {observe: true}, function (elem) {
+  var link,
+    projectTitle = $('.board-info .title a').getAttribute("title"),
+    subTaskRef = $('.ref', elem),
+    cardRef = $('.card-view-header a.ref').textContent,
+    taskDesc = $('.title', elem).textContent,
+    taskId = subTaskRef && $('.ref', elem).textContent;
+
+  link = togglbutton.createTimerLink({
+    className: 'kantree',
+    buttonType: 'minimal',
+    projectName: projectTitle,
+    description: taskId + ' ' + taskDesc + ' (parent ' + cardRef + ')'
+  });
+
+  link.classList.add('kt-checklist-item-toggl-btn');
+
+  if (!taskId) {
+    // run toggl after sub-task creation.
+    setTimeout(function () {
+      subTaskRef.parentNode.prepend(link);
+    }, 2000);
+  }
+  else {
+    subTaskRef.parentNode.prepend(link);
+  }
+}, ".card-view-children .children .card-tile, #card-modal-host, .card-modal");

--- a/src/scripts/origins.js
+++ b/src/scripts/origins.js
@@ -263,9 +263,15 @@ export default {
     url: '',
     name: 'Kanboard'
   },
+<<<<<<< c239e82af3e55ee98cc50a9bbf53aafb0310f7f5
   'kanban.ist': {
     url: '*://*.kanban.ist/*',
     name: 'Kanbanist'
+=======
+  'kantree.io': {
+    url: '*://*.kantree.io/*',
+    name: 'Kantree'
+>>>>>>> Add Kantree integration
   },
   'liquidplanner.com': {
     url: '*://app.liquidplanner.com/*',

--- a/src/scripts/origins.js
+++ b/src/scripts/origins.js
@@ -263,15 +263,13 @@ export default {
     url: '',
     name: 'Kanboard'
   },
-<<<<<<< c239e82af3e55ee98cc50a9bbf53aafb0310f7f5
   'kanban.ist': {
     url: '*://*.kanban.ist/*',
     name: 'Kanbanist'
-=======
+  },
   'kantree.io': {
     url: '*://*.kantree.io/*',
     name: 'Kantree'
->>>>>>> Add Kantree integration
   },
   'liquidplanner.com': {
     url: '*://app.liquidplanner.com/*',

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1326,6 +1326,7 @@ label > .toggl-button.outlook {
   top: 1px;
 }
 
+<<<<<<< c239e82af3e55ee98cc50a9bbf53aafb0310f7f5
 /********* NOTION *********/
 #notion-app .toggl-button.notion {
   cursor: pointer;
@@ -1421,4 +1422,18 @@ label > .toggl-button.outlook {
 .taskItem-body:hover .toggl-button.microsoft-todo {
   visibility: visible;
   pointer-events: all;
+=======
++/********* KANTREE **********/
+.kt-card-toggl-btn {
+  min-height: 34px;
+}
+
+.kt-checklist-item-toggl-btn {
+    background-color: #f5f5f5;
+    border: 0;
+    float: right;
+    font-size: 0;
+    display: inline-block;
+    margin: 0 10px;
+>>>>>>> Add Kantree integration
 }

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1326,7 +1326,6 @@ label > .toggl-button.outlook {
   top: 1px;
 }
 
-<<<<<<< c239e82af3e55ee98cc50a9bbf53aafb0310f7f5
 /********* NOTION *********/
 #notion-app .toggl-button.notion {
   cursor: pointer;
@@ -1422,18 +1421,18 @@ label > .toggl-button.outlook {
 .taskItem-body:hover .toggl-button.microsoft-todo {
   visibility: visible;
   pointer-events: all;
-=======
-+/********* KANTREE **********/
+}
+
+/********* KANTREE **********/
 .kt-card-toggl-btn {
   min-height: 34px;
 }
 
 .kt-checklist-item-toggl-btn {
-    background-color: #f5f5f5;
-    border: 0;
-    float: right;
-    font-size: 0;
-    display: inline-block;
-    margin: 0 10px;
->>>>>>> Add Kantree integration
+  background-color: #f5f5f5;
+  border: 0;
+  float: right;
+  font-size: 0;
+  display: inline-block;
+  margin: 0 10px;
 }


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

Adds a [kantree.io](https://kantree.io) integration with loading the project name and the task number as the description:
"#[task id] [task title]".

Works both either on single card or sub-tasks list.

Additional features:
- Gets toggl project name from kantree card
- Gets toggl tags from kantree card
- Works in both viewmodes (eg. modal window or sidebar panel)
- Adds toggl button even on newly created sub-task

<img width="167" alt="45095382-9fa40400-b126-11e8-9662-ecd958c337ab" src="https://user-images.githubusercontent.com/791060/60748377-fe7c1900-9f95-11e9-929d-02579205ef52.png">
<img width="454" alt="45095398-a6cb1200-b126-11e8-891a-f216e3b5256d" src="https://user-images.githubusercontent.com/791060/60748379-02a83680-9f96-11e9-84b5-21be263e5b40.png">

[video demo](http://take.ms/g6nJ0)

## :bug: Recommendations for testing
Check tracking time both in modal window mode and sidebar mode.

All changes should be tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information
This is an updated version of previous PR #1122 , have no idea how to update previous PR and reopen it.