### PR TITLE
Trigger notification after 5 minutes

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -1417,13 +1417,19 @@ window.TogglButton = {
       };
     };
 
+    const FIVE_MINUTES = 5 * 60;
+
+    const shouldTriggerNotification = (seconds) => {
+      const offsets = [-2, -1, 0, 1, 2];
+      return offsets.some(offset => seconds % (FIVE_MINUTES + offset) === 0);
+    };
+
     if (TogglButton.$user && ['active', 'idle'].includes(state) && TogglButton.$curEntry) {
       // trigger discard time notification once the user has been idle for
       // at least 5min
-      const FIVE_MINUTES = 5 * 60;
       if (
         TogglButton.$lastWork.id === TogglButton.$curEntry.id &&
-        inactiveSeconds % FIVE_MINUTES === 0 ||
+        shouldTriggerNotification(inactiveSeconds) ||
         (state === 'active' && inactiveSeconds >= FIVE_MINUTES)
       ) {
         TogglButton.showIdleDetectionNotification(inactiveSeconds);

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -1410,20 +1410,29 @@ window.TogglButton = {
     TogglButton.$userState = state;
     const now = new Date();
     const inactiveSeconds = Math.floor((now - TogglButton.$lastWork.date) / 1000);
-
-    if (TogglButton.$user && state === 'active' && TogglButton.$curEntry) {
-      // trigger discard time notification once the user has been idle for
-      // at least 5min
-      if (
-        TogglButton.$lastWork.id === TogglButton.$curEntry.id &&
-        inactiveSeconds >= 5 * 60
-      ) {
-        TogglButton.showIdleDetectionNotification(inactiveSeconds);
-      }
+    const updateLastWork = (date) => {
       TogglButton.$lastWork = {
         id: TogglButton.$curEntry.id,
-        date: now
+        date: date || now
       };
+    };
+
+    if (TogglButton.$user && ['active', 'idle'].includes(state) && TogglButton.$curEntry) {
+      // trigger discard time notification once the user has been idle for
+      // at least 5min
+      const FIVE_MINUTES = 5 * 60;
+      if (
+        TogglButton.$lastWork.id === TogglButton.$curEntry.id &&
+        inactiveSeconds % FIVE_MINUTES === 0 ||
+        (state === 'active' && inactiveSeconds >= FIVE_MINUTES)
+      ) {
+        TogglButton.showIdleDetectionNotification(inactiveSeconds);
+        updateLastWork(TogglButton.$lastWork.date);
+      }
+
+      if (state === 'active') {
+        updateLastWork();
+      }
     }
     clearTimeout(TogglButton.$checkingUserState);
     TogglButton.$checkingUserState = null;


### PR DESCRIPTION
According to https://github.com/toggl/toggl-button/issues/1444, The idle notification should be triggered after 5 minutes, but it will only be triggered when the user's state change from **idle** to **active**. 

This PR attempts to Trigger the idle notification after 5 minutes of idle time regardless of the use state.
Also if the user's state change from **idle** to **active**  and the inactive period were more than 5 minutes, I believe this is what the desktop app does. 
 