### PR TITLE
Fix Rally integration - show button in task/us details

### DIFF
--- a/src/scripts/content/rallydev.js
+++ b/src/scripts/content/rallydev.js
@@ -1,7 +1,7 @@
 'use strict';
 
 togglbutton.render(
-  '.chr-QuickDetailQuickDetailEditor',
+  '.chr-PeriscopeContainer',
   { observe: true },
   function (elem) {
     const descriptionElem = $(


### PR DESCRIPTION
## :star2: What does this PR do?

show toggl button in task details view (rallydev integration)

## :bug: Recommendations for testing

nope

## :memo: Links to relevant issues or information

#1445 

## 👳 Testing scenario

1. go to [rallydev](https://rally1.rallydev.com/slm/login.op) website
2. go to team status
3. click on user story/task
4. toggl button should be visible in right pane details view
5. click user story/task number from right pane
6. toggl button should be visible next to task number in user story/task full view
