### PR TITLE
fix(visualstudio): use correct container to render button

### DIFF
--- a/src/scripts/content/visualstudio.js
+++ b/src/scripts/content/visualstudio.js
@@ -23,13 +23,15 @@ function projectSelector () {
   return projectElement ? projectElement.textContent : '';
 }
 
-function descriptionSelector () {
-  const formIdElem = $('.work-item-form-id span');
-  const formTitleElem = $('.work-item-form-title input');
+function descriptionSelectorFactory (container) {
+  return function () {
+    const formIdElem = $('.work-item-form-id span', container);
+    const formTitleElem = $('.work-item-form-title input', container);
 
-  return (formIdElem ? formIdElem.innerText : '') +
-    ' ' +
-    (formTitleElem ? formTitleElem.value : '');
+    return (formIdElem ? formIdElem.innerText : '') +
+      ' ' +
+      (formTitleElem ? formTitleElem.value : '');
+  };
 }
 
 function isElementVisible (element) {
@@ -41,11 +43,12 @@ togglbutton.render(
   { observe: true },
   function () {
     const activeButtonContainer = getContainer('.work-item-form-header-controls-container');
+    const activeHeaderContainer = getContainer('.work-item-form-main-header');
     const vsActiveClassElem = $('.commandbar.header-bottom > .commandbar-item > .displayed');
 
     const link = togglbutton.createTimerLink({
       className: 'visual-studio-online',
-      description: descriptionSelector,
+      description: descriptionSelectorFactory(activeHeaderContainer),
       projectName: projectSelector
     });
 

--- a/src/scripts/content/visualstudio.js
+++ b/src/scripts/content/visualstudio.js
@@ -6,6 +6,14 @@
 */
 'use strict';
 
+function getContainer (selector) {
+  const visibleContainers = Array
+    .from(document.querySelectorAll(selector))
+    .filter(isElementVisible);
+
+  return visibleContainers.length > 0 && visibleContainers[0];
+}
+
 // We need to find proper project element, which differs between old and new layout
 function projectSelector () {
   const oldLayoutProjectElement = $('.tfs-selector span');
@@ -32,15 +40,8 @@ togglbutton.render(
   '.witform-layout-content-container:not(.toggl)',
   { observe: true },
   function () {
-    const visibleContainers = Array
-      .from(document.querySelectorAll('.work-item-form-header-controls-container'))
-      .filter(isElementVisible);
-
-    const container = visibleContainers.length > 0 && visibleContainers[0];
-
-    const vsActiveClassElem = $(
-      '.commandbar.header-bottom > .commandbar-item > .displayed'
-    );
+    const activeButtonContainer = getContainer('.work-item-form-header-controls-container');
+    const vsActiveClassElem = $('.commandbar.header-bottom > .commandbar-item > .displayed');
 
     const link = togglbutton.createTimerLink({
       className: 'visual-studio-online',
@@ -54,7 +55,7 @@ togglbutton.render(
       vsActiveClassElem.textContent === 'Work Items' ||
       vsActiveClassElem.textContent === 'Backlogs'
     ) {
-      container.appendChild(link);
+      activeButtonContainer.appendChild(link);
     }
   }
 );

--- a/src/scripts/content/visualstudio.js
+++ b/src/scripts/content/visualstudio.js
@@ -24,11 +24,19 @@ function descriptionSelector () {
     (formTitleElem ? formTitleElem.value : '');
 }
 
+function isElementVisible (element) {
+  return element && element.offsetParent !== null;
+}
+
 togglbutton.render(
   '.witform-layout-content-container:not(.toggl)',
   { observe: true },
   function () {
-    const container = $('.work-item-form-header-controls-container');
+    const visibleContainers = Array
+      .from(document.querySelectorAll('.work-item-form-header-controls-container'))
+      .filter(isElementVisible);
+
+    const container = visibleContainers.length > 0 && visibleContainers[0];
 
     const vsActiveClassElem = $(
       '.commandbar.header-bottom > .commandbar-item > .displayed'


### PR DESCRIPTION
## :star2: What does this PR do?

Container DOM nodes in query view are cached so it's needed to get an active (visible) container to prevent rendering all buttons in the first container.

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

Should be tested with different task views (I only tested normal and queries views)

## :memo: Links to relevant issues or information

closes #1459