### PR TITLE
fix(asana): Fix project selection in Asana integration

### DIFF
--- a/src/scripts/content/asana.js
+++ b/src/scripts/content/asana.js
@@ -1,105 +1,5 @@
 'use strict';
 
-// Older UI
-togglbutton.render(
-  '.details-pane-body:not(.toggl)',
-  { observe: true },
-  function (elem) {
-    const container = $('.sticky-view-placeholder', elem);
-    const description = $('#details_property_sheet_title', elem);
-    const project = $('#details_pane_project_tokenizer .token_name', elem);
-
-    const descFunc = function () {
-      return description ? description.value : '';
-    };
-
-    const projectFunc = function () {
-      return (
-        (project && project.textContent) ||
-        ($('.ancestor-projects', elem) &&
-          $('.ancestor-projects', elem).textContent) ||
-        ''
-      );
-    };
-
-    const link = togglbutton.createTimerLink({
-      className: 'asana',
-      description: descFunc,
-      projectName: projectFunc
-    });
-
-    container.parentNode.insertBefore(link, container.nextSibling);
-  }
-);
-
-// New UI v1
-togglbutton.render(
-  '#right_pane__contents .SingleTaskPane:not(.toggl)',
-  { observe: true },
-  function (elem) {
-    const container = $('.SingleTaskTitleRow', elem);
-    const description = $('.SingleTaskTitleRow .simpleTextarea', elem);
-    const project = $('.TaskProjectPill-projectName div', elem);
-
-    if (!container) {
-      return;
-    }
-
-    const descFunc = function () {
-      return description ? description.value : '';
-    };
-
-    const projectFunc = function () {
-      return (
-        (project && project.textContent) ||
-        ($('.TaskAncestry-ancestorProjects', elem) &&
-          $('.TaskAncestry-ancestorProjects', elem).textContent) ||
-        ''
-      );
-    };
-
-    const link = togglbutton.createTimerLink({
-      className: 'asana-new',
-      description: descFunc,
-      projectName: projectFunc
-    });
-
-    container.after(link);
-  }
-);
-
-// New UI v2
-togglbutton.render(
-  '#right_pane__contents .SingleTaskPane-body:not(.toggl)',
-  { observe: true },
-  function (elem) {
-    const container = $('.TaskPaneAssigneeDueDateRowStructure', elem);
-    const description = $('.SingleTaskPane-titleRow .simpleTextarea', elem);
-    const project = $('.TaskProjectPill-projectName div', elem);
-
-    const descFunc = function () {
-      return description ? description.value : '';
-    };
-
-    const projectFunc = function () {
-      return (
-        (project && project.textContent) ||
-        ($('.TaskAncestry-ancestorProjects', elem) &&
-          $('.TaskAncestry-ancestorProjects', elem).textContent) ||
-        ''
-      );
-    };
-
-    const link = togglbutton.createTimerLink({
-      className: 'asana-new',
-      description: descFunc,
-      projectName: projectFunc
-    });
-
-    container.appendChild(link);
-  }
-);
-
 // New UI Board view v1 and v2
 togglbutton.render(
   '.BoardColumnCardsContainer-item:not(.toggl)',
@@ -123,32 +23,6 @@ togglbutton.render(
   }
 );
 
-// New UI Board task detail view v1
-togglbutton.render(
-  '.SingleTaskTitleRow:not(.toggl)',
-  { observe: true },
-  function (elem) {
-    if ($('.toggl-button', elem)) {
-      return;
-    }
-    const container = $('.SingleTaskPaneToolbar', elem.parentNode);
-    const description = $('.SingleTaskTitleRow textarea', elem.parentNode).textContent;
-    const projectElement = $(
-      '.SingleTaskPane-projects .TaskProjectPill-projectName',
-      elem.parentNode
-    );
-
-    const link = togglbutton.createTimerLink({
-      className: 'asana-board',
-      description: description,
-      projectName: projectElement ? projectElement.textContent : '',
-      buttonType: 'minimal'
-    });
-
-    container.appendChild(link);
-  }
-);
-
 // New UI Board task detail view v2
 togglbutton.render(
   '.SingleTaskPane-titleRow:not(.toggl)',
@@ -159,22 +33,26 @@ togglbutton.render(
     }
     const container = $('.SingleTaskPaneToolbar');
 
-    const description = function () {
+    const descriptionSelector = () => {
       return $(
         '.SingleTaskPane-titleRow .simpleTextarea',
         elem.parentNode
       ).textContent;
     };
 
-    const projectElement = $(
-      '.SingleTaskPane-projects .TaskProjectPill-projectName',
-      elem.parentNode
-    );
+    const projectSelector = () => {
+      const projectElement = $(
+        '.SingleTaskPane-projects .TaskProjectPill-projectName',
+        elem.parentNode
+      );
+
+      return projectElement ? projectElement.textContent : '';
+    };
 
     const link = togglbutton.createTimerLink({
       className: 'asana-board',
-      description: description,
-      projectName: projectElement ? projectElement.textContent : '',
+      description: descriptionSelector,
+      projectName: projectSelector,
       buttonType: 'minimal'
     });
 


### PR DESCRIPTION


Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

<!-- Concise description of what this PR achieves, including any context. -->

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

Removes dead /old integration code.

Fixes project auto-selection in Asana (when the Asana project exactly matches an existing project inside Toggl workspace).

The element selection became stale after changing task. It now selects the project element fresh when we need to retrieve the project name.

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

Repro in issue doesn't happen anymore. No matter how many tasks you switch between Asana, the project will be picked up correctly. (In our Asana test account, tasks in `Toggl Button` and `Toggl Button Project` should match a project in toggl).

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

Closes #1457.

<!-- Link to relevant issues, comments, etc. -->
