### PR TITLE
OpenProject: Remove toggl button from work package list.

### DIFF
--- a/src/scripts/content/openproject.js
+++ b/src/scripts/content/openproject.js
@@ -1,35 +1,13 @@
 'use strict';
 
-// Work packages list items
-togglbutton.render(
-  'table.work-package-table tbody tr td.id:not(.toggl)',
-  { observe: true },
-  function (elem) {
-    const container = elem;
-    const description = $(
-      'span[data-field-name="subject"]',
-      elem.parentNode
-    ).textContent.trim();
-    const projectName = $('#projects-menu').title.trim();
-
-    const link = togglbutton.createTimerLink({
-      className: 'openproject',
-      description: description,
-      projectName: projectName,
-      buttonType: 'minimal'
-    });
-
-    container.appendChild(link);
-  }
-);
-
 // Work packages details view
 togglbutton.render(
   '.work-packages--show-view:not(.toggl)',
   { observe: true },
   function (elem) {
+    const workPackageId = $('.work-packages--info-row > span:first-of-type').textContent.trim();
     const container = $('.attributes-group--header', elem);
-    const description = $('.subject').textContent.trim();
+    const description = '[OP' + workPackageId + '] ' + $('.subject').textContent.trim();
     const projectName = $('#projects-menu').title.trim();
 
     const link = togglbutton.createTimerLink({

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1043,17 +1043,6 @@ li > .toggl-button.phabricator {
   margin-bottom: 0.4rem;
 }
 
-table.work-package-table .wp-table--cell-td.id {
-  position: relative;
-  padding-right: 14px;
-}
-
-table.work-package-table .toggl-button.openproject {
-  position: absolute;
-  right: 0px;
-  top: 10px;
-}
-
 /********* ZUBE *********/
 #card-primary-attributes-container .toggl-button.zube {
   margin-left: 30px;


### PR DESCRIPTION
- Remove all buttons from the Work Package list, for example here: https://community.openproject.com/projects/openproject/work_packages
- Add work package ID to description. The new description format is `[OP#<Work Package ID>] <Work Package Subject>`. This helps to find the the work packages at a later point of time, as the work package subjects might change but the IDs do not.
- You can check that nothing has changed layout wise for the view when a work package is open, for example here:
https://community.openproject.com/projects/openproject/work_packages/1899/activity
![image](https://user-images.githubusercontent.com/327272/62171105-2872f200-b32e-11e9-9e9b-81b029b4ae32.png)


Closes #1471 