### PR TITLE
feat(custom): Fast integration with any website

### DIFF
--- a/src/scripts/content/custom.js
+++ b/src/scripts/content/custom.js
@@ -1,0 +1,20 @@
+'use strict';
+
+togglbutton.render(
+  'span.toggl-custom-button[data-description]:not(.toggl)',
+  { observe: true },
+  function (elem) {
+    if (process.env.DEBUG) {
+      console.info('🏃 "custom" rendering');
+    }
+    const description = elem.dataset.description.trim();
+    const projectName = (elem.dataset['project-name'] || '').trim();
+
+    const link = togglbutton.createTimerLink({
+      className: 'custom',
+      description: description,
+      projectName: projectName
+    });
+
+    elem.appendChild(link);
+  });

--- a/src/scripts/origins.js
+++ b/src/scripts/origins.js
@@ -1,4 +1,9 @@
 export default {
+  '-- custom --': {
+    url: '*://*.example.com/*',
+    name: 'My website (custom integration only)',
+    file: 'custom.js'
+  },
   'agenocrm.com': {
     url: '*://*.agenocrm.com/*',
     name: 'AgenoCRM',

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1432,3 +1432,7 @@ label > .toggl-button.outlook {
   margin-right: 5px;
   margin-top: -7px;
 }
+
+/********* Custom *********/
+.toggl-button.custom {
+}


### PR DESCRIPTION
## :star2: What does this PR do?
It gives an ability to place start/stop timer button on any website.
I, as a web-developer, want to let my users log their time on our corporate website.

I can place tiny code on the webpage and give users instructions how to add our website to the integration list, after this they will be able to see Timer button.

## :bug: Recommendations for testing
1. add this html code on your website:
`<span class="toggl-custom-button" data-description="Timer description"></span>`
2. Go to extension's options
3. Open tab "Integrations"
4. Go to "Custom integrations" block
5. Type your domain and press "Add", option "My website (custom integration only)" should be selected already
6. Open the page of your website with the code from item "1" and enjoy!

## How it works
1. Create a test page:
```html
<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>Timer test</title></head><body>
<div> Basic test:<span class="toggl-custom-button" data-description="Timer description"></span></div>
<div> With project name:<span class="toggl-custom-button" data-description="Timer description with project name" data-project-name="Routine"></span></div>
</body></html>
```
2. Change extensions options:
![Selection_229](https://user-images.githubusercontent.com/361908/62761096-e9703980-baaf-11e9-8751-b7c2e95c40dc.png)

3. Start a server and open a page:
![Selection_231](https://user-images.githubusercontent.com/361908/62761123-fbea7300-baaf-11e9-9b2a-0ae42ce556dc.png)

4. Click on a button "Start timer":
![Selection_230](https://user-images.githubusercontent.com/361908/62761140-099ff880-bab0-11e9-8b93-0d056b78aa38.png)


## Known bug
Even if I set projectName (that I have in my account) it does appear to be selected after dialog pops up:
![Selection_233](https://user-images.githubusercontent.com/361908/62761193-2e946b80-bab0-11e9-8828-cb59de5fc5e3.png)

I need YOUR help to solve this issue.
