### PR TITLE
Fix local dev server losing the manifest after changes

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -106,7 +106,7 @@ module.exports = config(({ development, bugsnagApiKey, production, release, vers
         to: 'firefox/manifest.json',
         transform: transformManifest('firefox')
       }
-    ]),
+    ], { copyUnmodified: true }),
     production && release &&
       new BugsnagSourceMapUploaderPlugin({
         apiKey: bugsnagApiKey,


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?
Fixes webpack loosing assets between rebuilds.

## :bug: Recommendations for testing
* `npm start`
* `dist/chrome`, `dist/firefox` should have `manifest.json` and `images` directory full
* modify some content script
* files should still be there 

## :memo: Links to relevant issues or information
Closes #1468 