### PR TITLE
feat: Enable gmail integration to work with Drag-app popup view

### DIFF
--- a/src/scripts/content/google-mail.js
+++ b/src/scripts/content/google-mail.js
@@ -16,3 +16,19 @@ togglbutton.render('.ha:not(.toggl)', { observe: true }, function (elem) {
 
   elem.appendChild(link);
 });
+
+// This enables support for popup gmail view used by dragapp.com extension
+togglbutton.render('div.subject:not(.toggl)', { observe: true }, function (elem) {
+  const description = $('span', elem);
+
+  if (!description) {
+    return;
+  }
+
+  const link = togglbutton.createTimerLink({
+    className: 'google-mail',
+    description: description.textContent
+  });
+
+  elem.children[0].insertBefore(link, elem.children[0].children[1]);
+});


### PR DESCRIPTION
## :star2: What does this PR do?

Enables support for popup email view that [drag-app](https://dragapp.com) uses.

![Screenshot from 2019-09-09 13-23-33](https://user-images.githubusercontent.com/17459600/64527225-a818b700-d305-11e9-82f0-3185a9d1d7d8.png)
![Screenshot from 2019-09-09 13-26-48](https://user-images.githubusercontent.com/17459600/64527232-aa7b1100-d305-11e9-9b81-aa741cd6f7d8.png)
