### PR TITLE
fix(popup): Fix cursor jump when focusing duration

### DIFF
--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -421,6 +421,16 @@ window.PopUp = {
       .addEventListener('focus', (e) => {
         PopUp.$tagAutocomplete.openDropdown();
       });
+    document
+      .querySelector('#toggl-button-duration')
+      .addEventListener('focus', (e) => {
+        PopUp.stopDurationInput();
+      });
+    document
+      .querySelector('#toggl-button-duration')
+      .addEventListener('blur', (e) => {
+        PopUp.updateDurationInput(true);
+      });
 
     PopUp.$projectAutocomplete.onChange(function (selected) {
       const project = TogglButton.findProjectByPid(selected.pid);


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

Removes the bug where the cursor would jump after focusing duration field in popup edit view. This PR adds focus event detection that will stop the timer from updating duration field data

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

1. Start timer
2. Go to edit view
3. Click on duration field (somewhere other than the end) 
4. See that the cursor is not moved to the end

If the duration field loses focus and was not edited the timer should continue tracking. If the user edited the field timer will not continue tracking and pressing Done will update the duration.

## :memo: Links to relevant issues or information

closes #1417
