### PR TITLE
fix: YouTrack integration

### DIFF
--- a/src/scripts/content/youtrack.js
+++ b/src/scripts/content/youtrack.js
@@ -32,7 +32,8 @@ togglbutton.render(
   '.yt-issue-body:not(.toggl)',
   { observe: true },
   function (elem) {
-    const issueId = $('.js-issue-id').textContent;
+    const parent = elem.closest('.yt-issue-view');
+    const issueId = parent.querySelector('.js-issue-id').textContent;
     const link = togglbutton.createTimerLink({
       className: 'youtrack-new',
       description: issueId + ' ' + $('h1').textContent.trim(),


### PR DESCRIPTION


Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

When starting a timer from card popup in agile board wrong issue ID was
referenced. I believe that the logic for finding the element containing
the issue ID was querying the whole document resulting in the wrong ID
in most of the cases. This should fix that by finding the Toggle
button's parent element and then finding the child element of that
parent that contains the issue ID.

<!-- Concise description of what this PR achieves, including any context. -->

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

## :bug: Recommendations for testing

1. Go to YouTrack agile board with multiple cards in multiple lanes
2. Open issue view by double clicking on a card
3. Start a timer
4. Issue ID in the description should now correctly reflect issue ID of the card

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

closes #1509

<!-- Link to relevant issues, comments, etc. -->
