### PR TITLE
fix(popup): Fix tag/project dropdown toggle

### DIFF
--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -410,18 +410,6 @@ window.PopUp = {
       });
 
     document
-      .querySelector('#toggl-button-project-placeholder')
-      .closest('.TB__Dialog__field')
-      .addEventListener('focus', (e) => {
-        PopUp.$projectAutocomplete.openDropdown();
-      });
-    document
-      .querySelector('#toggl-button-tag-placeholder')
-      .closest('.TB__Dialog__field')
-      .addEventListener('focus', (e) => {
-        PopUp.$tagAutocomplete.openDropdown();
-      });
-    document
       .querySelector('#toggl-button-duration')
       .addEventListener('focus', (e) => {
         PopUp.stopDurationInput();


### PR DESCRIPTION
## :star2: What does this PR do?


 - fd069fa - **fix(popup): Fix tag/project dropdown toggle**

    There are two event handlers configured that are triggering the popdown (by calling the `toggleDropdown` function):

     1. A focus event configured in the class `TB_Dialog_field` (parent of the element with id `toggl-button-(tag|project)-placeholder`)
     2. A click event configured in the element with id `toggl-button-(tag|project)-placeholder`

    This commit removes the 'focus' event handler from `TB_Dialog_field`, since it seems that it's no longer necessary.
    Another possible solution would be to add a `e.stopPropagation` on the click event handler.
![bdropdown](https://user-images.githubusercontent.com/1160976/65621407-9993f600-dfbb-11e9-9831-9f9754b1722b.png)


## :bug: Recommendations for testing
 - Check if the tag/project dropdown stays open after clicking on it (more info on #1422)
All changes should be tested across Chrome and Firefox.

## :memo: Links to relevant issues or information
Related #1422
