### PR TITLE
fix(basecamp3): Improve layout and UX

### DIFF
--- a/src/scripts/content/basecamp.js
+++ b/src/scripts/content/basecamp.js
@@ -67,21 +67,23 @@ togglbutton.render(
 );
 
 // Basecamp 3
-togglbutton.render(
-  '.todos li.todo:not(.toggl):not(.completed)',
-  { observe: true },
-  function (elem) {
-    const parent = $('.checkbox__content', elem);
-    const description = parent.childNodes[1].textContent.trim();
-    let project = $('#a-breadcrumb-menu-button');
-    project = project ? project.textContent : '';
+togglbutton.render('.todos li.todo:not(.toggl)', { observe: true }, function (
+  elem
+) {
+  const parent = $('.checkbox__content', elem);
+  const description = parent.childNodes[1].textContent.trim();
+  let project = $('#a-breadcrumb-menu-button');
+  project = project ? project.textContent : '';
 
-    const link = togglbutton.createTimerLink({
-      className: 'basecamp3',
-      description: description,
-      projectName: project
-    });
+  const metadata = $('.metadata', parent);
 
-    parent.appendChild(link);
-  }
-);
+  const link = togglbutton.createTimerLink({
+    buttonType: metadata ? null : 'minimal',
+    className: 'basecamp3',
+    description: description,
+    projectName: project
+  });
+
+  const container = metadata || parent;
+  container.appendChild(link);
+});

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -287,17 +287,24 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
   position: absolute;
   opacity: 0;
   margin-top: 2px;
-  margin-left: 6px;
+  margin-left: 150px;
   white-space: nowrap;
 }
 
-.todo__unassigned-unscheduled + .toggl-button.basecamp3 {
-  margin-left: 90px;
-}
-
-.todo:not(.selected):hover .toggl-button.basecamp3 {
+.todo:not(.selected):hover .toggl-button.basecamp3,
+.todo:not(.selected) .toggl-button.basecamp3.active,
+.todo:not(.selected) .metadata .toggl-button.basecamp3 {
   opacity: 1;
 }
+.todo:not(.selected).completed .toggl-button.basecamp3 {
+  margin-left: 6px;
+  transform: scale(0.8) translateY(-3px);
+}
+.todo:not(.selected) .metadata .toggl-button.basecamp3 {
+  margin-left: 6px;
+  transform: scale(0.9) translateY(-2px);
+}
+
 
 .card-grid .toggl-button.basecamp3 {
   opacity: 0 !important;


### PR DESCRIPTION
## :star2: What does this PR do?
List of improvements:
- Prevents overlap with default Basecamp hover actions
- Uses minimal button style for list
- Makes button always visible in the card view
- Makes button visible after the task is completed (so the user doesn't forget to stop the timer) in both list/card views

List view:
<img width="366" alt="Screen Shot 2019-10-03 at 17 08 43" src="https://user-images.githubusercontent.com/371426/66160427-7f33cb00-e600-11e9-86f0-837e74fc9730.png">

Card view:
<img width="466" alt="Screen Shot 2019-10-03 at 17 08 51" src="https://user-images.githubusercontent.com/371426/66160430-80fd8e80-e600-11e9-86b9-2d3038444420.png">

## :bug: Recommendations for testing
Please test:
- [x] List view, unticked todo, stopped timer
- [x] List view, unticked todo, started timer, hovered
- [x] List view, unticked todo, started timer, non hovered
- [x] List view, ticked todo, stopped timer
- [x] List view, ticked todo, started timer
- [x] Card view, unticked todo, stopped timer
- [x] Card view, unticked todo, started timer
- [x] Card view, ticked todo, stopped timer
- [x] Card view, ticked todo, started timer

⚠️ This is for Basecamp 3, not 2! If using the Toggl Button test account you'll have the option to choose:
<img width="273" alt="Screen Shot 2019-10-03 at 17 06 02" src="https://user-images.githubusercontent.com/371426/66160293-354ae500-e600-11e9-9fdb-62c0199d213e.png">

## :memo: Links to relevant issues or information
#1426
