### PR TITLE
feat: add zammad integration for toggl button

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Add Toggl one-click time tracking to popular web tools.
 - [Wunderlist](https://www.wunderlist.com)
 - [Xero](https://www.xero.com/)
 - [YouTrack](http://www.jetbrains.com/youtrack/)
+- [Zammad](https://zammad.com/)
 - [Zendesk](https://www.zendesk.com/)
 - [Zube](https://zube.io/)
 - [VivifyScrum](https://www.vivifyscrum.com/)

--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -447,19 +447,6 @@ window.togglbutton = {
 
       tagAutocomplete.setWorkspaceId(wid);
     });
-
-    document
-      .querySelector('#toggl-button-edit-form #toggl-button-project-placeholder')
-      .closest('.TB__Dialog__field')
-      .addEventListener('focus', (e) => {
-        projectAutocomplete.openDropdown();
-      });
-    document
-      .querySelector('#toggl-button-edit-form #toggl-button-tag-placeholder')
-      .closest('.TB__Dialog__field')
-      .addEventListener('focus', (e) => {
-        tagAutocomplete.openDropdown();
-      });
   },
 
   createTimerLink: function (params) {

--- a/src/scripts/content/zammad.js
+++ b/src/scripts/content/zammad.js
@@ -1,0 +1,61 @@
+'use strict';
+/* global togglbutton, $ */
+
+// Zammad 3.1 add toggl button to the ticket controls
+togglbutton.render(
+  '.ticketZoom-header:not(.toggl)',
+  { observe: true },
+  $element => {
+    const $container = $('.ticketZoom-controls');
+    const togglLink = togglbutton.createTimerLink({
+      className: 'zammad-toggle-btn',
+      description: descriptionSelector,
+      projectName: projectSelector,
+      tags: tagsSelector,
+      buttonType: 'minimal'
+    });
+    // Append the button to the ticket controls
+    appendTogglLinkAsButton(togglLink, $container);
+  }
+);
+
+function appendTogglLinkAsButton (togglLink, $container) {
+  // First append a spacer
+  const spacer = document.createElement('div');
+  spacer.className = 'spacer';
+  $container.appendChild(spacer);
+  // Now append the wrapped button
+  const wrapper = document.createElement('div');
+  wrapper.className = 'btn btn--action centered';
+  wrapper.appendChild(togglLink);
+  $container.appendChild(wrapper);
+}
+
+function descriptionSelector () {
+  const $ticketId = $('.ticket-number');
+  const $ticketTitle = $('.ticket-title');
+  return (($ticketId) ? '#' + $ticketId.textContent + ': ' : '') + $ticketTitle.textContent.trim();
+}
+
+/**
+ * We take the client name as project if one is found and append the organization if the client is assigned
+ * @returns {string}
+ */
+function projectSelector () {
+  const client = document.querySelectorAll('[data-tab="customer"] [title="Name"]');
+  const organization = document.querySelectorAll('[data-tab="organization"] [title="Name"]');
+  let clientName = '';
+  if (client.length === 1) {
+    clientName = client[0].textContent.trim();
+  }
+  if (organization.length === 1) {
+    clientName += ' (' + organization[0].textContent.trim() + ')';
+  }
+  return clientName;
+}
+
+function tagsSelector () {
+  let tags = document.querySelectorAll('.tags .list-item-name');
+  tags = tags ? Array.from(tags).map(tag => tag.textContent.trim()) : null;
+  return tags;
+}

--- a/src/scripts/origins.js
+++ b/src/scripts/origins.js
@@ -675,5 +675,9 @@ export default {
     url: '*://app.vivifyscrum.com/*',
     name: 'VivifyScrum',
     clone: 'true'
+  },
+  'zammad.com': {
+    url: '*://*.zammad.com/*',
+    name: 'Zammad'
   }
 };


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

I request the merge of the zammad integration. Zammad is a helpdesk and support software see  https://zammad.com.

The toggl button is placed in the ticket details in the tool-area at the top right (see screenshot below).

The changes have been linted and the integration has been checked in Chrome and Firefox.

<img width="1417" alt="zammad" src="https://user-images.githubusercontent.com/1197748/66273603-a21ae500-e875-11e9-9927-613981f33a81.png">

