### PR TITLE
fix(Todoist): Fix time entry edit form on dark mode

### DIFF
--- a/src/styles/autocomplete.css
+++ b/src/styles/autocomplete.css
@@ -5,6 +5,10 @@
   padding: 0 6px;
 }
 
+#tag-autocomplete::-webkit-scrollbar-track, .TB__Popdown__content::-webkit-scrollbar-track {
+  background: initial !important;
+}
+
 #tag-autocomplete {
   /* aligned with filter bar whilst it's the "old" tag design as opposed to a list */
   padding: 0 15px;

--- a/src/styles/autocomplete.css
+++ b/src/styles/autocomplete.css
@@ -197,7 +197,7 @@
   opacity: 0.7;
 }
 
-.add-new-tag {
+#tag-autocomplete .add-new-tag {
   display: none;
   border: solid 1px #ececec;
   font-size: 14px;
@@ -211,12 +211,12 @@
   margin-bottom: 2px;
 }
 
-.add-new-tag:hover {
+#tag-autocomplete .add-new-tag:hover {
   background-color: rgba(75, 200, 0, 0.2);
   cursor: pointer;
 }
 
-.open .add-allowed .add-new-tag {
+.open #tag-autocomplete.add-allowed .add-new-tag {
   display: block;
 }
 

--- a/src/styles/edit-form.css
+++ b/src/styles/edit-form.css
@@ -144,6 +144,10 @@
   color: black;
 }
 
+#toggl-button-edit-form .TB__Popdown__filter::placeholder {
+  color: #7b7b7b !important;
+}
+
 .TB__Popdown__content {
   display: none;
   max-height: 50vh;
@@ -173,16 +177,18 @@
   align-items: center;
 }
 
-#toggl-button-edit-form .toggl-button {
+#toggl-button-edit-form a.toggl-button {
   margin: 0 0 1rem 0 !important;
   border: none !important;
   visibility: visible !important;
   float: none !important;
   opacity: 1 !important;
+  color: black;
 }
 
-#toggl-button-edit-form .toggl-button:hover {
+#toggl-button-edit-form a.toggl-button:hover {
   background-color: transparent;
+  text-decoration: underline;
 }
 
 #toggl-button-edit-form .toggl-button-input {


### PR DESCRIPTION
## :star2: What does this PR do?

Follow up to #1532.

There were more elements not visible or just weird because of Todoist's dark mode. These fixes should improve things in other tools using dark mode as well.

## :bug: Recommendations for testing

Make sure Todoist works in both "Todoist" (default) and "Dark" themes. I also tested with Github but It'd be nice to check in a third tool just in case.

List of things fixed by this PR (all in Dark theme):

1. Label for the stop timer button inside the edit form didn't appear:
![image](https://user-images.githubusercontent.com/371426/67569550-11724f00-f727-11e9-9ff5-33c0ea82c83f.png)

2. Add new tag button looked weird:
![image](https://user-images.githubusercontent.com/371426/67569487-e7b92800-f726-11e9-864b-72c6bf505833.png)

3. No placeholder in popdown filter inputs:
![image](https://user-images.githubusercontent.com/371426/67569523-fdc6e880-f726-11e9-818e-9b4992745f25.png)


## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
