### PR TITLE
Fix Tags being overridden

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -1288,31 +1288,26 @@ window.TogglButton = {
   },
 
   fillTags: function () {
-    let html = '<ul class="tag-list">';
-    const tags = TogglButton.$user.tagMap;
-    let i;
-    let key = null;
-    const keys = [];
+    const tags = TogglButton
+      .$user
+      .tags
+      .sort((t1, t2) => t1.name.localeCompare(t2.name))
+      .map(t => `
+        <li
+          class="tag-item"
+          data-wid=${escapeHtml(t.wid)}
+          title=${escapeHtml(t.name)}
+        >
+        ${escapeHtml(t.name)}
+        </li>
+      `.trim()
+      ).join('\n');
 
-    for (key in tags) {
-      if (tags.hasOwnProperty(key)) {
-        keys.push(key);
-      }
-    }
-    keys.sort();
-
-    for (i = 0; i < keys.length; i++) {
-      key = keys[i];
-      html +=
-        '<li class="tag-item" data-wid="' +
-        escapeHtml(tags[key].wid) +
-        '" title="' +
-        escapeHtml(tags[key].name) +
-        '">' +
-        escapeHtml(tags[key].name) +
-        '</li>';
-    }
-    return html + '</ul>';
+    return `
+      <ul class="tag-list">
+        ${tags}
+      </ul>
+    `.trim();
   },
 
   refreshPage: function () {

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -137,7 +137,6 @@ window.TogglButton = {
           const projectMap = {};
           const clientMap = {};
           const clientNameMap = {};
-          const tagMap = {};
           let projectTaskList = null;
           let entry = null;
 
@@ -159,11 +158,6 @@ window.TogglButton = {
                 resp.data.clients.forEach(function (client) {
                   clientMap[client.id] = client;
                   clientNameMap[client.name.toLowerCase() + client.id] = client;
-                });
-              }
-              if (resp.data.tags) {
-                resp.data.tags.forEach(function (tag) {
-                  tagMap[tag.name] = tag;
                 });
               }
               if (resp.data.tasks) {
@@ -201,7 +195,6 @@ window.TogglButton = {
               TogglButton.$user.projectMap = projectMap;
               TogglButton.$user.clientMap = clientMap;
               TogglButton.$user.clientNameMap = clientNameMap;
-              TogglButton.$user.tagMap = tagMap;
               TogglButton.$user.projectTaskList = projectTaskList;
               if (!TogglButton.$user.default_wid) {
                 const defaultWS = TogglButton.$user.workspaces[0];

--- a/src/scripts/index.d.ts
+++ b/src/scripts/index.d.ts
@@ -122,9 +122,6 @@ declare module Toggl {
   export interface ClientNameMap {
     [clientName: string]: Client;
   }
-  export interface TagMap {
-    [tagName: string]: Tag;
-  }
 
   export interface Task {
     id: number;
@@ -185,7 +182,6 @@ declare module Toggl {
     projectMap: ProjectMap;
     clientMap: ClientMap;
     clientNameMap: ClientNameMap;
-    tagMap: TagMap;
     projectTaskList: ProjectTaskList;
   }
 }


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

<!-- Concise description of what this PR achieves, including any context. -->

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

- Fix tags with same names across workspaces being overridden/hidden in popdown

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

- Create same tags across different workspaces
- The duplicated tag should still show up in the autocomplete list
- Verify that removing `TogglButton.$user.tagMap` hasn't caused any regressions
- See #1535 for detailed info and case

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
Closes #1535 
