### PR TITLE
fix(google-calendar): Support Google Calendar detail view

### DIFF
--- a/src/scripts/content/google-calendar.js
+++ b/src/scripts/content/google-calendar.js
@@ -1,30 +1,75 @@
 'use strict';
 /* global $, togglbutton */
 
-// Popup view Google Calendar Modern
-togglbutton.render('div[data-chips-dialog="true"]', { observe: true }, elem => {
-  // We manually check for presence of button, as one popup element
-  // gets recycled by calendar when clicking between different calendar entries.
-  if ($('.toggl-button', elem)) {
-    return;
+/**
+ * Google Calendar Modern
+ *
+ * Detail view and popup view support.
+ *
+ * Implementation notes:
+ * - The popup view is re-used when a user clicks between each event without
+ *   dismissing the popup.
+ * - The way Calendar re-uses the popup view causes the .toggl class to
+     remain on the popup div.
+ * - Detail view's container does not appear to be re-used, so the pseudo-class
+ *   selector (i.e. ":not(.toggl)") works for detail view.
+ * - When implementing a selector, do not select on an aria-label's value;
+ *   i18n will cause that selector to fail.
+ */
+
+const notTogglPseudoClass = ':not(.toggl)';
+const popupDialogSelector = 'div[data-chips-dialog="true"]';
+const detailContainerSelector = 'div[data-is-create="false"]';
+const rootLevelSelectors = [
+  `${popupDialogSelector}`,
+  `${detailContainerSelector}${notTogglPseudoClass}`
+].join(',');
+
+togglbutton.render(rootLevelSelectors, { observe: true }, elem => {
+  const elemIsPopup = $(popupDialogSelector, elem.parentElement);
+  const elemIsDetail = $(detailContainerSelector, elem.parentElement);
+  let getDescription;
+  let target;
+
+  if (elemIsPopup) {
+    // Popup selector reaches here repeatedly, so we need to prevent the
+    // creation of more than one Toggl button for a popup view.
+    if ($('.toggl-button', elem)) {
+      return;
+    }
+
+    const closeButton = $('[aria-label]:last-child', elem);
+
+    getDescription = () => {
+      const titleSpan = $('span[role="heading"]', elem);
+      return titleSpan ? titleSpan.textContent.trim() : '';
+    };
+    target = closeButton.parentElement.nextSibling; // Left of the left-most action
+  } else if (elemIsDetail) {
+    const closeButton = $('div[aria-label]', elem);
+
+    getDescription = () => {
+      const titleInput = $('input[data-initial-value]', elem);
+      return titleInput ? titleInput.value.trim() : '';
+    };
+    target =
+      closeButton.parentElement.nextElementSibling.lastElementChild
+        .lastElementChild; // Date(s)/All day section
   }
 
-  // Grab the "toolbar" by finding "Close" button, which is _always_ present.
-  // Note: do not use the aria-label values, it will break with i18n.
-  const target = $('[aria-label]:last-child', elem).parentElement.nextSibling;
   if (!target || target.tagName.toLowerCase() !== 'div') {
-    // Looks like the "create event" dialog, don't attempt to insert a button.
+    // Prevent adding a Toggl button to other dialogs/views, e.g. Create Event
     return;
   }
-
-  const getDescription = () => {
-    const title = $('span[role="heading"]', elem);
-    return title ? title.textContent.trim() : '';
-  };
 
   const link = togglbutton.createTimerLink({
     className: 'google-calendar-modern',
     description: getDescription
   });
-  target.prepend(link);
+
+  if (elemIsPopup) {
+    target.prepend(link);
+  } else if (elemIsDetail) {
+    target.appendChild(link);
+  }
 });


### PR DESCRIPTION
## :star2: What does this PR do?
- Refactored Google Calendar implementation to support popup and detail view
- Added implementation notes in `google-calendar.js`

<img width="1132" alt="Screen Shot 2019-10-29 at 10 47 40 PM" src="https://user-images.githubusercontent.com/6334517/67829833-2db31a80-fa9e-11e9-95ee-94c08b2baade.png">

## :bug: Testing notes

I verified the following in both Chrome and Firefox on macOS 10.14.6:
- The popup view works the same as before.  I did not change the underlying selectors for the popup view dialog.
- Detail view implementation works the same across both browsers

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information
- Closes #955 