### PR TITLE
feat(todoist): Add to task view

### DIFF
--- a/src/scripts/content/todoist.js
+++ b/src/scripts/content/todoist.js
@@ -3,6 +3,7 @@
 
 const todoistEditor = document.getElementById('content');
 
+// main list view
 togglbutton.render(
   '.task_item .task_item_actions:not(.toggl)',
   { observe: true, observeTarget: todoistEditor, debounceInterval: 100 },
@@ -15,9 +16,7 @@ togglbutton.render(
     const tagsSelector = () => {
       const tags = content.querySelectorAll('a.label');
 
-      return [...tags].map(tag => {
-        return tag.textContent;
-      });
+      return [...tags].map(tag => tag.textContent);
     };
 
     const link = togglbutton.createTimerLink({
@@ -29,10 +28,86 @@ togglbutton.render(
     });
 
     const wrapper = document.createElement('div');
-    wrapper.classList.add('task_info', 'task_content_item');
+    wrapper.classList.add('task_content_item');
     wrapper.style.display = 'flex';
     wrapper.style.alignItems = 'center';
     wrapper.style.justifyContent = 'center';
+    wrapper.appendChild(link);
+
+    elem.insertBefore(wrapper, elem.firstChild);
+  }
+);
+
+// task view
+togglbutton.render('.item_detail:not(.toggl)', { observe: true }, elem => {
+  const container = elem.querySelector('.item_actions');
+
+  const descriptionSelector = () =>
+    elem.querySelector('.item_overview_content').firstChild.textContent;
+
+  const tagsSelector = () => {
+    const tags = elem.querySelectorAll('a.item_overview_label');
+
+    return [...tags].map(tag => tag.textContent);
+  };
+
+  const project = getParentIfProject(elem);
+
+  const link = togglbutton.createTimerLink({
+    className: 'todoist-detail',
+    description: descriptionSelector,
+    projectName: project,
+    tags: tagsSelector,
+    buttonType: 'minimal'
+  });
+
+  const wrapper = document.createElement('div');
+  wrapper.classList.add('item_action');
+  wrapper.style.display = 'flex';
+  wrapper.style.alignItems = 'center';
+  wrapper.style.justifyContent = 'center';
+  wrapper.appendChild(link);
+
+  if (container) {
+    container.insertBefore(wrapper, container.firstChild);
+  }
+});
+
+// task view - subtasks
+togglbutton.render(
+  '.task_list_item .task_list_item__actions:not(.toggl)',
+  { observe: true, observeTarget: todoistEditor, debounceInterval: 100 },
+  elem => {
+    const content = elem.closest('.task_list_item').querySelector('.task_list_item__content');
+
+    const descriptionSelector = () => content.querySelector('.task_list_item__text').textContent;
+
+    let project = '';
+    const projectId = elem.closest('.task_list_item').getAttribute('data-item-id');
+    if (document.getElementById(`item_${projectId}`)) {
+      const projectContent = document.getElementById(`item_${projectId}`).querySelector('.content');
+      project = getProjectNames(projectContent);
+    } else {
+      project = getParentIfProject(elem.closest('.item_detail'));
+    }
+
+    const tagsSelector = () => {
+      const tags = content.querySelectorAll('.task_list_item__info_tags__label');
+
+      return [...tags].map(tag => tag.textContent);
+    };
+
+    const link = togglbutton.createTimerLink({
+      className: 'todoist-detail-subtask',
+      description: descriptionSelector,
+      projectName: project,
+      buttonType: 'minimal',
+      tags: tagsSelector
+    });
+
+    const wrapper = document.createElement('div');
+    wrapper.style.display = 'flex';
+    wrapper.style.marginTop = '3px';
     wrapper.appendChild(link);
 
     elem.insertBefore(wrapper, elem.firstChild);
@@ -143,4 +218,15 @@ function getProjectNames (elem) {
     }
     return projectNames;
   };
+}
+
+function getParentIfProject (elem) {
+  const parent = elem.querySelector('.item_detail_parent_info');
+  let project = '';
+
+  if (parent.querySelector('circle, .item_detail_parent_icon__inbox_icon')) {
+    project = parent.querySelector('.item_detail_parent_name').textContent;
+  }
+
+  return project;
 }


### PR DESCRIPTION
## :star2: What does this PR do?

Adds the button to todoist's new task view.

## :bug: Recommendations for testing

Open a task in task view and test the button there (selected task and subtasks):
![image](https://user-images.githubusercontent.com/50156618/68272678-8135f180-00b8-11ea-8735-0b5ea64aa249.png)

*Important note:* project selection is not great. See #1549 for details.

Another note: there is a bug with Todoist's dark mode, where the subtask's actions aren't visible on hover unless you disable this:
![todoist](https://user-images.githubusercontent.com/50156618/68274630-c01a7600-00bd-11ea-948a-b4958a119843.png)


## :memo: Links to relevant issues or information

Closes #1528 

Opened https://github.com/toggl/toggl-button/issues/1547 for the below issue:

> WIP note: there is a bug in Firefox where if you track in the list view, then the task view (or vice versa), the button popup doesn't appear (does still track though):
![button](https://user-images.githubusercontent.com/50156618/68170701-f4f6d200-ffc4-11e9-819a-e28bc650dfea.gif)
