### PR TITLE
fix(any.do): Hide in list view when delete button is visible

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -441,6 +441,10 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
   visibility: visible;
 }
 
+.TaskItemControls--in + .toggl-button.anydo--2018__taskItem {
+  visibility: hidden;
+}
+
 /********* WUNDERLIST *********/
 .toggl-button.wunderlist {
   text-decoration: none;


### PR DESCRIPTION
## :star2: What does this PR do?

Hides the Toggl Button in the list view when the Any.do delete button should be visible (i.e. when task is completed).

## :bug: Recommendations for testing

- if a task is active, the Toggl Button should be displayed
- if a task is complete, the Any.do delete button should be displayed
![anydo](https://user-images.githubusercontent.com/50156618/68348532-34045f00-014e-11ea-911f-41b8cbd6ddce.png)

## :memo: Links to relevant issues or information

Closes #1525 
