### PR TITLE
Enable websocket reconnection attempts

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -296,7 +296,7 @@ window.TogglButton = {
     });
 
     TogglButton.websocket.socket.onopen = function () {
-      TogglButton.resetWebsocketState();
+      TogglButton.resetWebsocketRetryCount();
       const data = JSON.stringify(authenticationMessage);
       try {
         return TogglButton.websocket.socket.send(data);
@@ -358,7 +358,7 @@ window.TogglButton = {
   },
 
   // Resets the reconnection state to give things another chance
-  resetWebsocketState: function () {
+  resetWebsocketRetryCount: function () {
     TogglButton.websocket.retryCount = 0;
   },
 


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

<!-- Concise description of what this PR achieves, including any context. -->

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

Syncing issues are cropping up between button and other clients. Websocket being closed and then not reconnecting is a likely cause.

Let's reimplement reconnection attempts.

Logic at time of opening PR:
- Each retry waits 5 seconds longer than the last.
- The maximum retry wait time is 1 minute
- The maximum number of retries is 30, at which point it gives up

Ideally we'd have some way to rekindle it in the UI, but it requires some further thought. I would like to merge this without adding on new features first.

I do think there really needs to be some way to easily kickstart it again after it goes  wrong.

## :bug: Recommendations for testing

To test the continual reconnection logic, I recommend:
- Set the reconnection interval to something short like `1`
- Set the maximum attempts to something small like `5`
- Change the websocket url to an invalid host
- Reload the extension. You will now see logging output in the background page inspector. After its retries it will stop.

At any time in the background page inspector, you can `TogglButton.websocket.close()` to close the connection and trigger a reconnect. All of the state is reset when reconnection is successful, so you'll normally only ever see one reconnect.

All changes should be tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->

Related to #1179
