### PR TITLE
chore(websocket): Do not try to report socket onerror events

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -306,9 +306,9 @@ window.TogglButton = {
       }
     };
 
-    TogglButton.websocket.socket.onerror = function (error) {
-      bugsnagClient.notify(error, { context: 'websocket' });
-      return console.log('onerror: ', error);
+    TogglButton.websocket.socket.onerror = function (event) {
+      // Note: The error event for websockets doesn't really contain anything reportable.
+      return console.error('Websocket error: ', event);
     };
 
     TogglButton.websocket.socket.onclose = function () {


### PR DESCRIPTION


Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

<!-- Concise description of what this PR achieves, including any context. -->

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

It is not an error, and this attempt to report is actually generating errors in itself 🤦‍♂ [Bugsnag](https://app.bugsnag.com/toggl-dot-com/toggl-button/errors/5dcc1428f0b376001b2edb48?filters[event.since][0]=30d&filters[error.status][0]=open)

The events do not contain anything useful according to wise folks on the internet (for browser security reasons). According to the spec it'll be a generic `1006` with little no information about what actually went wrong with the connection.

## :bug: Recommendations for testing

Looks sane

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->


