### PR TITLE
fix(popup): Get page height when opening popup

### DIFF
--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -106,7 +106,6 @@ window.togglbutton = {
   user: {},
   duration_format: '',
   currentDescription: '',
-  fullPageHeight: getFullPageHeight(),
   fullVersion: 'TogglButton',
   render: function (selector, opts, renderer, mutationSelector) {
     browser.runtime.sendMessage({ type: 'activate' })
@@ -204,7 +203,7 @@ window.togglbutton = {
     if (left + editFormWidth > window.innerWidth) {
       left = window.innerWidth - 10 - editFormWidth;
     }
-    if (top + editFormHeight > togglbutton.fullPageHeight) {
+    if (top + editFormHeight > getFullPageHeight()) {
       top = window.innerHeight + document.body.scrollTop - 10 - editFormHeight;
     }
     return { left: left, top: top };


### PR DESCRIPTION
## :star2: What does this PR do?

Checks the page height every time the popup is opened. This fixes a bug where after the Chrome window is shrunk, the position is wrong.

## :bug: Recommendations for testing

Currently in master:
1. Open Trello in a fairly long (700px+) Chrome window
2. Resize the window so it's quite short
3. Open a card
4. Scroll down until you can just see the "Start a timer" link
5. Click the link
6. The popup is partially hidden

This should no longer happen.

Try out some more combinations of resizing and opening the popup in Trello and other integrations.

## :memo: Links to relevant issues or information

Hopefully fixes #1498 
