### PR TITLE
fix(websocket): Ensure only one websocket connection is opened

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -288,6 +288,14 @@ window.TogglButton = {
   },
 
   setupSocket: function () {
+    // Don't reinitialize if socket is not closed
+    if (
+      TogglButton.websocket.socket &&
+      TogglButton.websocket.socket.readyState !== WebSocket.CLOSED
+    ) {
+      return;
+    }
+
     try {
       TogglButton.websocket.socket = new WebSocket('wss://stream.toggl.com/ws');
     } catch (error) {


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

<!-- Concise description of what this PR achieves, including any context. -->

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

Checks if a socket is already open or connecting before trying to replace it.

Prior to this change, multiple sockets are being opened by the extension, because there is no check. A new socket is opened each time the toolbar popup is opened, for example.

At some point we need to refactor this more, for today we need to fix the problem.

## :bug: Recommendations for testing

- Socket is still opened
- You do not get multiple sockets opened at any point (check Network, WS in background page inspector)
- If you close the connection `TogglButton.websocket.socket.close()`, it does eventually get reopened.
- You still do not ever get multiple sockets opened.

Before: multiple connections can exist at any point

<img width="1194" alt="Screenshot 2019-11-15 at 11 29 16" src="https://user-images.githubusercontent.com/6432028/68941345-83294000-079d-11ea-8f48-b9b5ab393df5.png">

After: (example of closed connections with reconnects)

<img width="1190" alt="Screenshot 2019-11-15 at 11 46 22" src="https://user-images.githubusercontent.com/6432028/68941385-a227d200-079d-11ea-80c5-9cd7375b9a28.png">


<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->

Probably related to #1561 