### PR TITLE
feat(edit): Open edit view when clicking on an existing time entry

### DIFF
--- a/src/scripts/components/TimeEntriesList.tsx
+++ b/src/scripts/components/TimeEntriesList.tsx
@@ -42,7 +42,7 @@ const TimeEntriesFooter = () => (
         See more on <strong>toggl.com</strong>
       </Button>
     </a>
-  </Footer>);   
+  </Footer>);
 
 interface TimeEntriesListProps {
   timeEntries: Toggl.TimeEntry[][];
@@ -93,7 +93,6 @@ type TimeEntriesListItemProps = {
   project: Toggl.Project | null;
 };
 function TimeEntriesListItem ({ timeEntries, project }: TimeEntriesListItemProps) {
-  const tids = timeEntries.map(({ id }) => id);
   const timeEntry = timeEntries[0];
   const description = timeEntry.description || NO_DESCRIPTION;
   const isBillable = !!timeEntry.billable;

--- a/src/scripts/components/TimeEntriesList.tsx
+++ b/src/scripts/components/TimeEntriesList.tsx
@@ -93,6 +93,7 @@ type TimeEntriesListItemProps = {
   project: Toggl.Project | null;
 };
 function TimeEntriesListItem ({ timeEntries, project }: TimeEntriesListItemProps) {
+  const tids = timeEntries.map(({ id }) => id);
   const timeEntry = timeEntries[0];
   const description = timeEntry.description || NO_DESCRIPTION;
   const isBillable = !!timeEntry.billable;
@@ -107,8 +108,13 @@ function TimeEntriesListItem ({ timeEntries, project }: TimeEntriesListItemProps
   const entriesCount = timeEntries.length;
   const earliestStartTime = format(timeEntries[timeEntries.length - 1].start, 'HH:mm');
 
+  const editEntry = (e) => {
+    e.preventDefault();
+    window.PopUp.updateEditForm(window.PopUp.$editView);
+  };
+
   return (
-    <EntryItem>
+    <EntryItem onClick={editEntry}>
       <EntryItemRow>
         {entriesCount > 1 &&
           <GroupedEntryCounter title={`${entriesCount} entries since ${earliestStartTime}`}>{entriesCount}</GroupedEntryCounter>
@@ -246,6 +252,7 @@ const EntryItem = styled.li`
   font-size: 14px;
   box-shadow: ${itemShadow};
   background-color: ${color.white};
+  cursor: pointer;
 
   &:hover {
     background-color: ${color.listItemHover};


### PR DESCRIPTION
## :star2: What does this PR do?

Opens the edit view when clicking on an existing time entry.

WIP note: it currently opens the existing edit view, which only works when there is a currently running timer, and shows details of the currently running timer. #1565 will rework this view.

## :bug: Recommendations for testing

1. Click on an existing entry
2. The edit view should open

## :memo: Links to relevant issues or information

Closes #1564