### PR TITLE
Render stopped entries in edit view

### DIFF
--- a/src/scripts/components/TimeEntriesList.tsx
+++ b/src/scripts/components/TimeEntriesList.tsx
@@ -107,13 +107,8 @@ function TimeEntriesListItem ({ timeEntries, project }: TimeEntriesListItemProps
   const entriesCount = timeEntries.length;
   const earliestStartTime = format(timeEntries[timeEntries.length - 1].start, 'HH:mm');
 
-  const editEntry = (e) => {
-    e.preventDefault();
-    window.PopUp.updateEditForm(window.PopUp.$editView);
-  };
-
   return (
-    <EntryItem onClick={editEntry}>
+    <EntryItem onClick={editEntry(timeEntry)}>
       <EntryItemRow>
         {entriesCount > 1 &&
           <GroupedEntryCounter title={`${entriesCount} entries since ${earliestStartTime}`}>{entriesCount}</GroupedEntryCounter>
@@ -132,6 +127,11 @@ function TimeEntriesListItem ({ timeEntries, project }: TimeEntriesListItemProps
     </EntryItem>
   );
 }
+
+const editEntry = (timeEntry: Toggl.TimeEntry) => (e: React.MouseEvent) => {
+  e.preventDefault();
+  window.PopUp.renderEditForm(timeEntry);
+};
 
 const GroupedEntryCounter = styled.div`
   display: flex;

--- a/src/scripts/components/Timer.tsx
+++ b/src/scripts/components/Timer.tsx
@@ -44,9 +44,8 @@ function RunningTimer(props: { entry: Toggl.TimeEntry, project: Toggl.Project | 
   const { entry, project } = props;
   const tags = (entry.tags || []).join(', ');
 
-  const editEntry = (e) => {
-    e.preventDefault();
-    window.PopUp.updateEditForm(window.PopUp.$editView);
+  const editEntry = (e: React.MouseEvent) => {
+    window.PopUp.renderEditForm(entry);
   };
   const stopTimer = (e) => {
     e.preventDefault();

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -1,3 +1,5 @@
+/// <reference path="./index.d.ts" />
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { isSameDay } from 'date-fns';
@@ -219,28 +221,31 @@ window.PopUp = {
   },
 
   /* Edit form functions */
-  updateEditForm: function (view) {
-    const pid = TogglButton.$curEntry.pid ? TogglButton.$curEntry.pid : 0;
-    const tid = TogglButton.$curEntry.tid ? TogglButton.$curEntry.tid : 0;
-    const wid = TogglButton.$curEntry.wid;
+
+  /**
+   * Render edit-form for given time entry object
+   * @param timeEntry {Toggl.TimeEntry} - The time entry object to render
+   */
+  renderEditForm: function (timeEntry) {
+    const pid = timeEntry.pid || 0;
+    const tid = timeEntry.id || 0;
+    const wid = timeEntry.wid;
     const togglButtonDescription = document.querySelector(
       '#toggl-button-description'
     );
     const togglButtonDuration = document.querySelector('#toggl-button-duration');
 
-    togglButtonDescription.value = TogglButton.$curEntry.description
-      ? TogglButton.$curEntry.description
-      : '';
+    togglButtonDescription.value = timeEntry.description || '';
     togglButtonDuration.value = secToHhmmImproved(
-      new Date() - new Date(TogglButton.$curEntry.start),
+      new Date() - new Date(timeEntry.start),
       { html: false }
     );
 
     PopUp.$projectAutocomplete.setup(pid, tid);
-    PopUp.$tagAutocomplete.setup(TogglButton.$curEntry.tags, wid);
+    PopUp.$tagAutocomplete.setup(timeEntry.tags, wid);
 
-    PopUp.setupBillable(!!TogglButton.$curEntry.billable, pid);
-    PopUp.switchView(view);
+    PopUp.setupBillable(!!timeEntry.billable, pid);
+    PopUp.switchView(PopUp.$editView);
 
     // Put focus to the beginning of desctiption field
     togglButtonDescription.focus();
@@ -248,7 +253,11 @@ window.PopUp = {
     togglButtonDescription.scrollLeft = 0;
 
     PopUp.durationChanged = false;
-    PopUp.updateDurationInput(true);
+
+    // Setup duration updater if entry is running
+    if (TogglButton.$curEntry.id === timeEntry.id) {
+      PopUp.updateDurationInput(true);
+    }
   },
 
   updateDurationInput: function (startTimer) {

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { isSameDay } from 'date-fns';
+import { isSameDay, differenceInSeconds } from 'date-fns';
 
 import { secToHhmmImproved } from './@toggl/time-format-utils';
 import Summary from './components/Summary';
@@ -234,12 +234,14 @@ window.PopUp = {
       '#toggl-button-description'
     );
     const togglButtonDuration = document.querySelector('#toggl-button-duration');
+    const isCurrentEntry = TogglButton.$curEntry.id === timeEntry.id;
 
-    togglButtonDescription.value = timeEntry.description || '';
-    togglButtonDuration.value = secToHhmmImproved(
-      new Date() - new Date(timeEntry.start),
-      { html: false }
+    const duration = differenceInSeconds(
+      new Date(isCurrentEntry ? undefined : timeEntry.stop),
+      new Date(timeEntry.start)
     );
+    togglButtonDescription.value = timeEntry.description || '';
+    togglButtonDuration.value = secToHhmmImproved(duration, { html: false });
 
     PopUp.$projectAutocomplete.setup(pid, tid);
     PopUp.$tagAutocomplete.setup(timeEntry.tags, wid);
@@ -253,9 +255,8 @@ window.PopUp = {
     togglButtonDescription.scrollLeft = 0;
 
     PopUp.durationChanged = false;
-
     // Setup duration updater if entry is running
-    if (TogglButton.$curEntry.id === timeEntry.id) {
+    if (isCurrentEntry) {
       PopUp.updateDurationInput(true);
     }
   },


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

<!-- Concise description of what this PR achieves, including any context. -->

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

- Renders stopped entries when they are clicked on

#### Known issues
  - Behaviour with grouped entries is incorrect
  - Suggested workaround to allow expanding grouped entries

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

- On popup click any non-grouped TE
- It should render the edit form with TE info
- On popup click the running entry
- It should also render the edit form with correct info

## :memo: Links to relevant issues or information

Closes #1564 