### PR TITLE
fix(asana): Fix project selection in list views

### DIFF
--- a/src/scripts/content/asana.js
+++ b/src/scripts/content/asana.js
@@ -11,15 +11,24 @@ togglbutton.render('.SpreadsheetRow .SpreadsheetTaskName:not(.toggl)', { observe
     }
 
     const descriptionSelector = () => taskNameCell.querySelector('textarea').textContent.trim();
+    const projectHeaderSelector = () => {
+      // Try to look for for page project title instead.
+      const projectHeader = document.querySelector('.TopbarPageHeaderStructure.ProjectPageHeader .TopbarPageHeaderStructure-title');
+      if (!projectHeader) {
+        return '';
+      }
+      return projectHeader.textContent.trim();
+    };
     const projectSelector = () => {
       const projectCell = container.querySelector('.SpreadsheetTaskRow-projectsCell');
       if (!projectCell) {
-        return '';
+        // Try to look for for page project title instead.
+        return projectHeaderSelector();
       }
 
       // There can be multiple projects, but we can't support trying to match multiple yet.
       const firstProject = projectCell.querySelector('.Pill');
-      return firstProject ? firstProject.textContent.trim() : '';
+      return firstProject ? firstProject.textContent.trim() : projectHeaderSelector();
     };
 
     const link = togglbutton.createTimerLink({


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

<!-- Concise description of what this PR achieves, including any context. -->

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

Improve/fix project selection in list views.

It now tries to extract the project from the project cell (if spreadsheet view), falling back to the page header if it is a project page.

## :bug: Recommendations for testing

See that the project is or isn't selected correctly in all the different situations you can find. Recommended to use the test account and the `Toggl Button Project` project in Asana.

- Regular list views
  - Task detail view
- Project page list views
  - Task detail view
- Others?

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
