### PR TITLE
feat(focus): Add focus mode for pomodoro

### DIFF
--- a/src/html/settings.html
+++ b/src/html/settings.html
@@ -208,6 +208,10 @@
                     <input type="checkbox" id="pomodoro-stop-time">
                     <label for="pomodoro-stop-time">Stop time tracking when pomodoro time ends</label>
                   </p>
+                  <p>
+                    <input type="checkbox" id="pomodoro-focus-mode">
+                    <label for="pomodoro-focus-mode">Enable focus mode while a pomodoro interval is active</label>
+                  </p>
                   <div class="pomodoro-sound">
                     <input type="checkbox" id="enable-sound-signal">
                     <label for="enable-sound-signal">Enable sound notification at the end of an interval</label>

--- a/src/scripts/@toggl/time-format-utils/format-duration.ts
+++ b/src/scripts/@toggl/time-format-utils/format-duration.ts
@@ -1,0 +1,20 @@
+import {
+  differenceInHours,
+  differenceInMinutes,
+  differenceInSeconds,
+  subHours,
+  subMinutes
+} from 'date-fns';
+
+/**
+ * Returns the elapsed time since `since` as a duration in the format hh:mm:ss.
+ */
+export const formatDuration = (start: string | number, stop?: string | number | Date) => {
+  const now = stop || Date.now();
+  const hours = differenceInHours(now, start);
+  const minutes = differenceInMinutes(subHours(now, hours), start);
+  const seconds = differenceInSeconds(subMinutes(subHours(now, hours), minutes), start);
+  const timeValue = (value: number) => value.toString().padStart(2, '0');
+
+  return `${hours}:${timeValue(minutes)}:${timeValue(seconds)}`;
+}

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -1,11 +1,12 @@
+import browser from 'webextension-polyfill';
+
 import bugsnagClient from './lib/bugsnag';
 import { escapeHtml, isTogglURL, report, secToHHMM } from './lib/utils';
-
+import { renderTimeEntries } from './lib/actions';
 import Db from './lib/db';
 import Ga from './lib/ga';
 import Sound from './lib/sound';
 
-const browser = require('webextension-polyfill');
 const FIVE_MINUTES = 5 * 60;
 const ONE_HOUR = 60 * 60;
 const RETRY_INTERVAL = 15;
@@ -709,6 +710,7 @@ window.TogglButton = {
         updateProgress,
         pomodoroInterval / steps
       );
+      browser.runtime.sendMessage(renderTimeEntries());
       updateProgress();
     }
   },

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -82,6 +82,8 @@ window.TogglButton = {
   pomodoroAlarm: null,
   pomodoroProgressTimer: null,
   $ticker: null,
+  pomodoroInterval: null,
+  pomodoroFocusMode: null,
   localEntry: null,
   $userState: 'active',
   $fullVersion: `TogglButton/${process.env.VERSION}`,
@@ -670,9 +672,11 @@ window.TogglButton = {
   },
 
   checkPomodoroAlarm: async function (entry) {
+    console.log('checking pomo alarm');
     const duration = new Date() - new Date(entry.start);
-    const pomodoroInterval = await db.get('pomodoroInterval');
-    const interval = parseInt(pomodoroInterval, 10) * 60000;
+    TogglButton.pomodoroInterval = await db.get('pomodoroInterval');
+    TogglButton.pomodoroFocusMode = await db.get('pomodoroFocusMode');
+    const interval = parseInt(TogglButton.pomodoroInterval, 10) * 60000;
     if (duration < interval) {
       TogglButton.triggerPomodoroAlarm(interval - duration);
     }
@@ -1893,6 +1897,8 @@ window.TogglButton = {
           );
         } else if (request.type === 'toggle-pomodoro') {
           db.set('pomodoroModeEnabled', request.state);
+        } else if (request.type === 'toggle-pomodoro-focus-mode') {
+          db.set('pomodoroFocusMode', request.state);
         } else if (request.type === 'toggle-pomodoro-sound') {
           db.set('pomodoroSoundEnabled', request.state);
         } else if (request.type === 'toggle-pomodoro-interval') {

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -673,7 +673,6 @@ window.TogglButton = {
   },
 
   checkPomodoroAlarm: async function (entry) {
-    console.log('checking pomo alarm');
     const duration = new Date() - new Date(entry.start);
     TogglButton.pomodoroInterval = await db.get('pomodoroInterval');
     TogglButton.pomodoroFocusMode = await db.get('pomodoroFocusMode');

--- a/src/scripts/components/Pomodoro.tsx
+++ b/src/scripts/components/Pomodoro.tsx
@@ -1,0 +1,104 @@
+import * as React from "react";
+import { differenceInSeconds } from "date-fns";
+import styled from "@emotion/styled";
+
+function formatDuration(seconds: number) {
+  const m = Math.floor(seconds / 60);
+  const s = seconds - m * 60;
+  return m + ":" + (s < 10 ? "0" : "") + s;
+}
+
+function getCountdown(start: string, interval: number) {
+  const intervalSeconds = interval * 60;
+  const elapsed = differenceInSeconds(new Date(), start);
+  return intervalSeconds - elapsed;
+}
+
+const ringProps = {
+  r: "142",
+  cx: "150",
+  cy: "150",
+  strokeWidth: 3,
+  fill: "transparent",
+  transform: "rotate(-90, 150, 150)"
+};
+
+interface PomodoroProps {
+  entry: Toggl.TimeEntry;
+  interval: number;
+}
+export default function Pomodoro(props: PomodoroProps) {
+  const [countdown, setCountdown] = React.useState(
+    getCountdown(props.entry.start, props.interval)
+  );
+
+  React.useEffect(() => {
+    if (!countdown) return;
+    const intervalId = setInterval(() => {
+      setCountdown(countdown - 1);
+    }, 1000);
+    return () => clearInterval(intervalId);
+  }, [countdown]);
+
+  const strokeDashoffset = (countdown / (props.interval * 60)) * 892;
+
+  const stopTimer = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    window.PopUp.sendMessage({ type: 'stop', service: 'dropdown', respond: true });
+  };
+
+  return (
+    <Container>
+      <Clock>
+        <Countdown x="50%" y="50%">
+          {formatDuration(countdown)}
+        </Countdown>
+        <circle stroke="#eee" {...ringProps} />
+        <ActiveRing {...ringProps} style={{ strokeDashoffset }} />
+        <Stop width="60" height="60" rx="2" x="120" y="120" onClick={stopTimer} />
+      </Clock>
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  min-height: 410px;
+`;
+
+const Clock = styled.svg`
+  cursor: pointer;
+  width: 300px;
+  height: 300px;
+  &:hover text {
+    opacity: 0%;
+  }
+  &:hover rect {
+    opacity: 100%;
+  }
+`;
+
+const ActiveRing = styled.circle`
+  stroke: #e20505;
+  stroke-dasharray: 892 892;
+  animation-iteration-count: 1;
+`;
+
+const Stop = styled.rect`
+  fill: #f41d1d;
+  opacity: 0;
+  transition: 0.2s opacity ease-in;
+`;
+
+const Countdown = styled.text`
+  font-size: 55px;
+  color: #333;
+  opacity: 100%;
+  dominant-baseline: middle;
+  text-anchor: middle;
+  transition: 0.2s opacity ease-in;
+`;

--- a/src/scripts/components/Pomodoro.tsx
+++ b/src/scripts/components/Pomodoro.tsx
@@ -1,17 +1,14 @@
 import * as React from "react";
-import { differenceInSeconds } from "date-fns";
 import styled from "@emotion/styled";
 
-function formatDuration(seconds: number) {
-  const m = Math.floor(seconds / 60);
-  const s = seconds - m * 60;
-  return m + ":" + (s < 10 ? "0" : "") + s;
-}
+import useCountdown from '../shared/use-countdown';
 
-function getCountdown(start: string, interval: number) {
-  const intervalSeconds = interval * 60;
-  const elapsed = differenceInSeconds(new Date(), start);
-  return intervalSeconds - elapsed;
+function formatCountdown (seconds: number) {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  const mm = m.toString().padStart(2, '0');
+  const ss = s.toString().padStart(2, '0');
+  return mm + ':' + ss;
 }
 
 function stopTimer (e: React.MouseEvent) {
@@ -34,25 +31,14 @@ interface PomodoroProps {
   interval: number;
 }
 export default function Pomodoro(props: PomodoroProps) {
-  const [countdown, setCountdown] = React.useState(
-    getCountdown(props.entry.start, props.interval)
-  );
-
-  React.useEffect(() => {
-    if (!countdown) return;
-    const intervalId = setInterval(() => {
-      setCountdown(countdown - 1);
-    }, 1000);
-    return () => clearInterval(intervalId);
-  }, [countdown]);
-
+  const countdown = useCountdown(props.entry.start, props.interval);
   const strokeDashoffset = (countdown / (props.interval * 60)) * 892;
 
   return (
     <Container>
       <Clock>
         <Countdown x="50%" y="50%">
-          {formatDuration(countdown)}
+          {formatCountdown(countdown)}
         </Countdown>
         <circle stroke="#eee" {...ringProps} />
         <ActiveRing {...ringProps} style={{ strokeDashoffset }} />

--- a/src/scripts/components/Pomodoro.tsx
+++ b/src/scripts/components/Pomodoro.tsx
@@ -14,6 +14,12 @@ function getCountdown(start: string, interval: number) {
   return intervalSeconds - elapsed;
 }
 
+function stopTimer (e: React.MouseEvent) {
+  e.preventDefault();
+  e.stopPropagation();
+  window.PopUp.sendMessage({ type: 'stop', service: 'dropdown', respond: true });
+}
+
 const ringProps = {
   r: "142",
   cx: "150",
@@ -42,21 +48,15 @@ export default function Pomodoro(props: PomodoroProps) {
 
   const strokeDashoffset = (countdown / (props.interval * 60)) * 892;
 
-  const stopTimer = (e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    window.PopUp.sendMessage({ type: 'stop', service: 'dropdown', respond: true });
-  };
-
   return (
     <Container>
-      <Clock onClick={stopTimer} >
+      <Clock>
         <Countdown x="50%" y="50%">
           {formatDuration(countdown)}
         </Countdown>
         <circle stroke="#eee" {...ringProps} />
         <ActiveRing {...ringProps} style={{ strokeDashoffset }} />
-        <Stop width="72" height="72" rx="2" x="114" y="114" />
+        <Stop width="72" height="72" rx="2" x="114" y="114" onClick={stopTimer} />
       </Clock>
     </Container>
   );
@@ -71,7 +71,6 @@ const Container = styled.div`
 `;
 
 const Clock = styled.svg`
-  cursor: pointer;
   width: 300px;
   height: 300px;
   &:hover text {
@@ -92,6 +91,7 @@ const Stop = styled.rect`
   fill: #f41d1d;
   opacity: 0;
   transition: 0.2s opacity ease-in;
+  cursor: pointer;
 `;
 
 const Countdown = styled.text`

--- a/src/scripts/components/Pomodoro.tsx
+++ b/src/scripts/components/Pomodoro.tsx
@@ -50,13 +50,13 @@ export default function Pomodoro(props: PomodoroProps) {
 
   return (
     <Container>
-      <Clock>
+      <Clock onClick={stopTimer} >
         <Countdown x="50%" y="50%">
           {formatDuration(countdown)}
         </Countdown>
         <circle stroke="#eee" {...ringProps} />
         <ActiveRing {...ringProps} style={{ strokeDashoffset }} />
-        <Stop width="60" height="60" rx="2" x="120" y="120" onClick={stopTimer} />
+        <Stop width="72" height="72" rx="2" x="114" y="114" />
       </Clock>
     </Container>
   );

--- a/src/scripts/components/Summary.tsx
+++ b/src/scripts/components/Summary.tsx
@@ -1,13 +1,17 @@
 import * as React from 'react';
 import styled from '@emotion/styled';
-import browser from 'webextension-polyfill';
 
 import * as color from '../@toggl/style/lib/color';
 import * as text from '../@toggl/style/lib/text';
 
-function Summary () {
-  const totals = browser.extension.getBackgroundPage().TogglButton.calculateSums();
-
+function Summary ({
+  totals
+}: {
+  totals: {
+    today: string,
+    week: string
+  }
+}) {
   return (
     <SummaryRow>
       <div>Today: {totals.today}</div>

--- a/src/scripts/components/TimeEntriesList.tsx
+++ b/src/scripts/components/TimeEntriesList.tsx
@@ -11,8 +11,8 @@ import { Button } from '../@toggl/ui/buttons';
 import * as color from '../@toggl/style/lib/color';
 import * as text from '../@toggl/style/lib/text';
 import { borderRadius } from '../@toggl/style/lib/variables';
+import { formatDuration } from '../@toggl/time-format-utils/format-duration';
 
-import { formatDuration } from './Timer';
 import play from '../icons/play.svg';
 
 const NO_DESCRIPTION = '(no description)';

--- a/src/scripts/components/Timer.tsx
+++ b/src/scripts/components/Timer.tsx
@@ -1,33 +1,17 @@
 import * as React from 'react';
 import styled from '@emotion/styled';
-import {
-  differenceInHours,
-  differenceInMinutes,
-  differenceInSeconds,
-  subHours,
-  subMinutes
-} from 'date-fns';
+import { addSeconds } from 'date-fns';
 import * as keycode from 'keycode';
+
+import { formatDuration } from '../@toggl/time-format-utils/format-duration';
 
 import { TimeEntryDescription, TimeEntryProject } from './TimeEntriesList';
 import TagsIcon from './TagsIcon';
 import start from '../icons/start.svg';
 import stop from '../icons/stop.svg';
+import { useDuration } from '../shared/use-duration';
 
 const NO_DESCRIPTION = '(no description)';
-
-/**
- * Returns the elapsed time since `since` as a duration in the format hh:mm:ss.
- */
-export const formatDuration = (start: string | number, stop?: string | number) => {
-  const now = stop || Date.now();
-  const hours = differenceInHours(now, start);
-  const minutes = differenceInMinutes(subHours(now, hours), start);
-  const seconds = differenceInSeconds(subMinutes(subHours(now, hours), minutes), start);
-  const timeValue = (value) => value > 9 ? value : (value > 0 ? '0' + value : '00');
-
-  return `${hours}:${timeValue(minutes)}:${timeValue(seconds)}`;
-}
 
 type TimerProps = {
   entry: Toggl.TimeEntry | null;
@@ -68,18 +52,10 @@ function RunningTimer(props: { entry: Toggl.TimeEntry, project: Toggl.Project | 
 }
 
 function TimerDuration ({ start }: { start: string }) {
-  const [ duration, setDuration ] = React.useState(formatDuration(start));
-
-  React.useEffect(() => {
-    const timeoutId = setTimeout(() => {
-      setDuration(formatDuration(start));
-    }, 1000);
-    return () => clearTimeout(timeoutId);
-  })
-
+  const duration = useDuration(start);
   return (
     <Duration>
-      {duration}
+      {formatDuration(start, addSeconds(start, duration))}
     </Duration>
   )
 }

--- a/src/scripts/components/Timer.tsx
+++ b/src/scripts/components/Timer.tsx
@@ -47,11 +47,6 @@ function RunningTimer(props: { entry: Toggl.TimeEntry, project: Toggl.Project | 
   const editEntry = () => {
     window.PopUp.renderEditForm(entry);
   };
-  const stopTimer = (e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    window.PopUp.sendMessage({ type: 'stop', service: 'dropdown', respond: true });
-  };
 
   return (
     <TimerContainer onClick={editEntry}>
@@ -111,6 +106,12 @@ function TimerForm () {
     </TimerContainer>
   );
 }
+
+const stopTimer = (e: React.MouseEvent) => {
+  e.preventDefault();
+  e.stopPropagation();
+  window.PopUp.sendMessage({ type: 'stop', service: 'dropdown', respond: true });
+};
 
 const TimerContainer = styled.div`
   box-sizing: border-box;

--- a/src/scripts/lib/actions.ts
+++ b/src/scripts/lib/actions.ts
@@ -1,0 +1,6 @@
+/**
+ * Re-render time-entries list action
+ */
+export function renderTimeEntries () {
+  return { type: 'bg/render-entries-list' as const };
+}

--- a/src/scripts/lib/timerUtils.js
+++ b/src/scripts/lib/timerUtils.js
@@ -1,41 +1,41 @@
-import map from 'lodash.map'
-import reduce from 'lodash.reduce'
-import moment from 'moment'
-import { secToHhmmImproved } from '../@toggl/time-format-utils/index'
+import map from 'lodash.map';
+import reduce from 'lodash.reduce';
+import moment from 'moment';
+import { secToHhmmImproved } from '../@toggl/time-format-utils/index';
 
 const _ = {
   map,
   reduce
-}
+};
 
-const MAX_DURATION = 3596400000 // 999 hours in milliseconds
-const HHMMSS_DURATION_REGEX = /^\s*(\d+)?[ :;_/-]?([\d,.]+)?:?([[ :;_/-]+[\d,.]+)?\s*$/
-const HUMAN_DURATION_REGEX = /^\s*((\d+(?:\.|,)?\d*|\d*(?:\.|,)?\d+)\s*(((m|min|mins|minute|minutes)?)|((h|hr|hrs|hour|hours)?)|((s|sec|secs|second|seconds)?)|((d|ds|day|days)?)|((w|wk|wks|week|weeks)?))?\s*)+$/i
+const MAX_DURATION = 3596400000; // 999 hours in milliseconds
+const HHMMSS_DURATION_REGEX = /^\s*(\d+)?[ :;_/-]?([\d,.]+)?:?([[ :;_/-]+[\d,.]+)?\s*$/;
+const HUMAN_DURATION_REGEX = /^\s*((\d+(?:\.|,)?\d*|\d*(?:\.|,)?\d+)\s*(((m|min|mins|minute|minutes)?)|((h|hr|hrs|hour|hours)?)|((s|sec|secs|second|seconds)?)|((d|ds|day|days)?)|((w|wk|wks|week|weeks)?))?\s*)+$/i;
 
 /**
  * Returns stop date of given time entry, handling duronly entries.
  * @param  {object} timeEntry Time entry
  * @return {string}
  */
-export function getStopDate(timeEntry) {
+export function getStopDate (timeEntry) {
   return (
     timeEntry.stop ||
     moment(timeEntry.start)
       .add(getDuration(timeEntry), 'seconds')
       .format()
-  )
+  );
 }
 
-export function getStartDateSeconds(timeEntry) {
-  return moment(timeEntry.start).unix()
+export function getStartDateSeconds (timeEntry) {
+  return moment(timeEntry.start).unix();
 }
 /**
  * Returns stop date of given time entry as a unix timestamp (seconds)
  * @param  {object} timeEntry Time entry
  * @return {number}
  */
-export function getStopDateSeconds(timeEntry) {
-  return moment(getStopDate(timeEntry)).unix()
+export function getStopDateSeconds (timeEntry) {
+  return moment(getStopDate(timeEntry)).unix();
 }
 
 /**
@@ -43,14 +43,14 @@ export function getStopDateSeconds(timeEntry) {
  * @param  {object} timeEntry Time entry
  * @return {number} duration in seconds
  */
-export function getDuration(timeEntry) {
+export function getDuration (timeEntry) {
   if (timeEntry.duration >= 0) {
-    return timeEntry.duration
+    return timeEntry.duration;
   }
   if (timeEntry.duronly) {
-    return moment().unix() + timeEntry.duration
+    return moment().unix() + timeEntry.duration;
   }
-  return moment().diff(timeEntry.start, 'seconds')
+  return moment().diff(timeEntry.start, 'seconds');
 }
 
 /**
@@ -60,10 +60,10 @@ export function getDuration(timeEntry) {
  * @param {Date} stop time (optional)
  * @return {number} duration in seconds
  */
-export function calculateDuration(start, stop) {
-  const startValue = start.valueOf()
-  const stopValue = stop ? stop.valueOf() : 0
-  return Math.round((stopValue - startValue) / 1000)
+export function calculateDuration (start, stop) {
+  const startValue = start.valueOf();
+  const stopValue = stop ? stop.valueOf() : 0;
+  return Math.round((stopValue - startValue) / 1000);
 }
 
 /**
@@ -73,12 +73,12 @@ export function calculateDuration(start, stop) {
  * @param {number} duration in seconds
  * @return {Date} stop date
  */
-export function calculateStopDate(start, duration) {
-  if (duration < 0) return null
+export function calculateStopDate (start, duration) {
+  if (duration < 0) return null;
 
-  const startValue = start.valueOf()
-  const stopValue = startValue + duration * 1000
-  return moment(stopValue).toDate()
+  const startValue = start.valueOf();
+  const stopValue = startValue + duration * 1000;
+  return moment(stopValue).toDate();
 }
 
 /**
@@ -86,11 +86,11 @@ export function calculateStopDate(start, duration) {
  * @param  {Object|Array} timeEntries Time entries
  * @return {string}
  */
-export function getGroupStartDate(timeEntries) {
+export function getGroupStartDate (timeEntries) {
   const firstTE = _(timeEntries.slice())
     .sortBy(getStartDateSeconds)
-    .head()
-  return firstTE.start
+    .head();
+  return firstTE.start;
 }
 
 /**
@@ -98,11 +98,11 @@ export function getGroupStartDate(timeEntries) {
  * @param  {Object|Array} timeEntries Time entries
  * @return {string}
  */
-export function getGroupStopDate(timeEntries) {
+export function getGroupStopDate (timeEntries) {
   const firstTE = _(timeEntries.slice())
     .sortBy(getStopDateSeconds)
-    .last()
-  return getStopDate(firstTE)
+    .last();
+  return getStopDate(firstTE);
 }
 
 /**
@@ -110,18 +110,18 @@ export function getGroupStopDate(timeEntries) {
  * @param  {Object|Array} timeEntries Time entries to sum
  * @return {number}             Total duration in seconds
  */
-export function getGroupDuration(timeEntries) {
+export function getGroupDuration (timeEntries) {
   return _.reduce(
     timeEntries,
     (sum, te) => {
-      if (!te.duration) return sum
+      if (!te.duration) return sum;
 
-      const duration = getDuration(te)
-      sum += duration
-      return sum
+      const duration = getDuration(te);
+      sum += duration;
+      return sum;
     },
     0
-  )
+  );
 }
 
 /**
@@ -129,8 +129,8 @@ export function getGroupDuration(timeEntries) {
  * @param  {string}  duration Duration
  * @return {Boolean}
  */
-export function isValidDuration(duration) {
-  return isValidTimeDuration(duration) || isValidHumanDuration(duration)
+export function isValidDuration (duration) {
+  return isValidTimeDuration(duration) || isValidHumanDuration(duration);
 }
 
 /**
@@ -138,8 +138,8 @@ export function isValidDuration(duration) {
  * @param  {string}  duration Duration
  * @return {Boolean}
  */
-export function isValidTimeDuration(duration) {
-  return HHMMSS_DURATION_REGEX.test(duration)
+export function isValidTimeDuration (duration) {
+  return HHMMSS_DURATION_REGEX.test(duration);
 }
 
 /**
@@ -147,8 +147,8 @@ export function isValidTimeDuration(duration) {
  * @param  {string}  duration Duration
  * @return {Boolean}
  */
-export function isValidHumanDuration(duration) {
-  return HUMAN_DURATION_REGEX.test(duration)
+export function isValidHumanDuration (duration) {
+  return HUMAN_DURATION_REGEX.test(duration);
 }
 
 /**
@@ -156,10 +156,10 @@ export function isValidHumanDuration(duration) {
  * @param  {object} Duration
  * @return {object} Duration
  */
-export function forceMaxDuration(duration) {
+export function forceMaxDuration (duration) {
   return duration.asMilliseconds() > MAX_DURATION
     ? moment.duration(MAX_DURATION)
-    : duration
+    : duration;
 }
 
 /**
@@ -168,11 +168,11 @@ export function forceMaxDuration(duration) {
  * @param  {string} str Duration string to parse
  * @return {object} Duration in milliseconds
  */
-export function parseDuration(str) {
+export function parseDuration (str) {
   const duration = isValidHumanDuration(str)
     ? parseHumanDuration(str)
-    : parseTimeDuration(str)
-  return forceMaxDuration(duration)
+    : parseTimeDuration(str);
+  return forceMaxDuration(duration);
 }
 
 /**
@@ -190,20 +190,20 @@ export function parseDuration(str) {
  * @param  {string}  str Duration
  * @return {Duration} the momentjs duration object, always positive
  */
-export function parseTimeDuration(str) {
-  str = str.replace(/[,.]+/g, '.').replace(/[ :;_/-]+/g, ':') // 2,5;5 => 2.5:5
-  let hms = _.map(str.split(':'), part => parseFloat(part || 0))
+export function parseTimeDuration (str) {
+  str = str.replace(/[,.]+/g, '.').replace(/[ :;_/-]+/g, ':'); // 2,5;5 => 2.5:5
+  let hms = _.map(str.split(':'), part => parseFloat(part || 0));
 
   if (hms.length === 1) {
-    if (hms[0] > 99) hms = [Math.floor(hms[0] / 100), hms[0] % 100, void 0]
-    else hms = [void 0, hms[0], void 0]
+    if (hms[0] > 99) hms = [Math.floor(hms[0] / 100), hms[0] % 100, void 0];
+    else hms = [void 0, hms[0], void 0];
   }
 
-  if (hms.length >= 2) hms = [hms[0], hms[1], hms[2] || void 0]
+  if (hms.length >= 2) hms = [hms[0], hms[1], hms[2] || void 0];
 
   return moment.duration({
     seconds: (hms[0] || 0) * 60 * 60 + (hms[1] || 0) * 60 + (hms[2] || 0)
-  })
+  });
 }
 
 /**
@@ -219,72 +219,72 @@ export function parseTimeDuration(str) {
  * @param {string} [options.defaultUnit] The unit to default to, pluralized
  * @return {moment|null}
  */
-export function parseHumanDuration(inputDuration, options = {}) {
-  let input = inputDuration
-  let match = HHMMSS_DURATION_REGEX.exec(input)
+export function parseHumanDuration (inputDuration, options = {}) {
+  let input = inputDuration;
+  let match = HHMMSS_DURATION_REGEX.exec(input);
   if (match) {
-    return parseTimeDuration(input)
+    return parseTimeDuration(input);
   }
 
-  let accumulated = null
-  let value
-  let valueDuration
-  input = input.replace(/[,.]+/g, '.')
-  match = HUMAN_DURATION_REGEX.exec(input)
+  let accumulated = null;
+  let value;
+  let valueDuration;
+  input = input.replace(/[,.]+/g, '.');
+  match = HUMAN_DURATION_REGEX.exec(input);
 
   // Go through regex matches and accumulate a duration
   while (match) {
-    value = +match[2]
+    value = +match[2];
 
     // Parse the value according to the group
     // If there was no group defined then parse the values as minutes
     // If `,` or `.` is used then parse as hours
-    const hasUnitMinutes = match[5] != null
-    const hasUnitHours = match[7] != null
-    const hasUnitSeconds = match[9] != null
-    const hasUnitDays = match[11] != null
-    const hasUnitWeeks = match[13] != null
-    const isDecimalNoUnit = /^\d*\.\d*$/.exec(match[1])
+    const hasUnitMinutes = match[5] != null;
+    const hasUnitHours = match[7] != null;
+    const hasUnitSeconds = match[9] != null;
+    const hasUnitDays = match[11] != null;
+    const hasUnitWeeks = match[13] != null;
+    const isDecimalNoUnit = /^\d*\.\d*$/.exec(match[1]);
 
     if (hasUnitHours) {
-      valueDuration = { hours: value }
+      valueDuration = { hours: value };
     } else if (hasUnitSeconds) {
-      valueDuration = { seconds: value }
+      valueDuration = { seconds: value };
     } else if (hasUnitMinutes) {
-      valueDuration = { minutes: value }
+      valueDuration = { minutes: value };
     } else if (hasUnitDays) {
-      valueDuration = { days: value }
+      valueDuration = { days: value };
     } else if (hasUnitWeeks) {
-      valueDuration = { weeks: value }
+      valueDuration = { weeks: value };
     } else if (options.defaultUnit) {
       valueDuration = {
         [options.defaultUnit]: value
-      }
+      };
     } else if (isDecimalNoUnit && !options.defaultDecimal) {
-      valueDuration = { hours: value }
+      valueDuration = { hours: value };
     } else {
-      valueDuration = { minutes: value }
+      valueDuration = { minutes: value };
     }
 
-    if (!accumulated) accumulated = moment.duration(0)
-    accumulated = accumulated.add(valueDuration)
+    if (!accumulated) accumulated = moment.duration(0);
+    accumulated = accumulated.add(valueDuration);
 
     // We could just re-run `exec` on the string and it should work, but we'd
     // have to take the beginning of the line constraint and mess up validation.
-    input = input.replace(match[1], '')
-    match = HUMAN_DURATION_REGEX.exec(input)
+    input = input.replace(match[1], '');
+    match = HUMAN_DURATION_REGEX.exec(input);
     if (match && input) {
-      if (isDecimalNoUnit) return null
+      if (isDecimalNoUnit) return null;
     } else {
-      return accumulated
+      return accumulated;
     }
   }
 
-  return accumulated
+  return accumulated;
 }
 
-export function formatDuration(duration, options) {
-  return secToHhmmImproved(duration, options)
+export function formatDuration (duration, options) {
+  return secToHhmmImproved(duration, options);
 }
 
 /**
@@ -293,7 +293,7 @@ export function formatDuration(duration, options) {
  * @param  {string}  time the input string
  * @return {Boolean}
  */
-export function isValidTime(time) {
+export function isValidTime (time) {
   return [
     'H',
     'HA',
@@ -331,7 +331,7 @@ export function isValidTime(time) {
     'HH;mm',
     'HH;mmA',
     'HH;mm A'
-  ].some(format => moment(time, format, true).isValid())
+  ].some(format => moment(time, format, true).isValid());
 }
 
 /**
@@ -344,11 +344,11 @@ export function isValidTime(time) {
  * @param  {Date} prevDate    if no am/pm specified in string, compare both to this date and use whatever is closest.
  * @return {object}              {hours: ..., minutes: ...}
  */
-export function parseTime(str, use24hClock, prevDate = null) {
+export function parseTime (str, use24hClock, prevDate = null) {
   str = str
     .toLowerCase()
     .replace(/[,.:;]+/, ':')
-    .trim()
+    .trim();
 
   /**
    * Parse hours and minutes from the time string and return the hours minute components
@@ -356,17 +356,17 @@ export function parseTime(str, use24hClock, prevDate = null) {
    * @param  {string} str The input string such as '100', '1:00', '1200', '12:00'
    * @return {array}      [hh, mm]
    */
-  function getHoursMinutes(str) {
+  function getHoursMinutes (str) {
     if (str.indexOf(':') > -1) {
-      return _.map(str.split(':'), part => parseInt(part, 10) || 0)
+      return _.map(str.split(':'), part => parseInt(part, 10) || 0);
     } else {
-      str = str.replace(/[^0-9]/g, '')
+      str = str.replace(/[^0-9]/g, '');
       if (str.length <= 2) {
-        return [parseInt(str, 10), 0] // h and hh
+        return [parseInt(str, 10), 0]; // h and hh
       } else if (str.length <= 3) {
-        return [parseInt(str[0], 10), parseInt(str.substr(1), 10)] // hmm
+        return [parseInt(str[0], 10), parseInt(str.substr(1), 10)]; // hmm
       } else {
-        return [parseInt(str.substr(0, 2), 10), parseInt(str.substr(2), 10)] // hhmm and hhmmmmmm..
+        return [parseInt(str.substr(0, 2), 10), parseInt(str.substr(2), 10)]; // hhmm and hhmmmmmm..
       }
     }
   }
@@ -376,31 +376,31 @@ export function parseTime(str, use24hClock, prevDate = null) {
    * @param  {array} hm [hh, mm]
    * @return {array}    [hh, mm]
    */
-  function overflowMinutes(hm) {
-    hm = hm.slice()
-    hm[0] += Math.floor(hm[1] / 60)
-    hm[1] = hm[1] % 60
-    return hm
+  function overflowMinutes (hm) {
+    hm = hm.slice();
+    hm[0] += Math.floor(hm[1] / 60);
+    hm[1] = hm[1] % 60;
+    return hm;
   }
 
-  let hm = getHoursMinutes(str)
-  hm[0] = hm[0] % 24 // Lose extra days
-  hm = overflowMinutes(hm)
+  let hm = getHoursMinutes(str);
+  hm[0] = hm[0] % 24; // Lose extra days
+  hm = overflowMinutes(hm);
 
   // If we're in 24h mode or the user inputs more than 12 hours, there's no need to add any more magic
   if (use24hClock || hm[0] >= 13) {
-    return { hours: hm[0], minutes: hm[1] }
+    return { hours: hm[0], minutes: hm[1] };
   }
 
-  const isPM = _isPm(str, hm, use24hClock, prevDate)
+  const isPM = _isPm(str, hm, use24hClock, prevDate);
 
-  if (hm[0] === 12) hm[0] = 0 // twelvehouranians say 12:00 when they mean 0:00. We need to normalize that
+  if (hm[0] === 12) hm[0] = 0; // twelvehouranians say 12:00 when they mean 0:00. We need to normalize that
 
   if (isPM === true) {
-    hm[0] += 12
+    hm[0] += 12;
   }
 
-  return { hours: hm[0], minutes: hm[1] }
+  return { hours: hm[0], minutes: hm[1] };
 }
 
 /**
@@ -410,49 +410,49 @@ export function parseTime(str, use24hClock, prevDate = null) {
  * @param  {string} str The time string like '11:22a', assumed to be in 12h format
  * @return {boolean}    true if PM
  */
-export function _isPm(str, hm, use24hClock, prevDate) {
-  let isPM = null // null represents "we don't know"
-  const ampmMatch = str.toLowerCase().match(/(a|p)m?$/)
+export function _isPm (str, hm, use24hClock, prevDate) {
+  let isPM = null; // null represents "we don't know"
+  const ampmMatch = str.toLowerCase().match(/(a|p)m?$/);
 
   if (ampmMatch) {
-    str = str.substr(0, str.length - ampmMatch[0].length)
-    isPM = ampmMatch[0] === 'p' || ampmMatch[0] === 'pm'
+    str = str.substr(0, str.length - ampmMatch[0].length);
+    isPM = ampmMatch[0] === 'p' || ampmMatch[0] === 'pm';
   } else if (!use24hClock && prevDate) {
     // No am/pm found in string but we need *something* => take the closest value to prevDate
-    if (hm[0] === 12) hm = [0, hm[1]] // twelvehouranians say 12:00 when they mean 0:00. We need to normalize that
-    const date = moment().set({ hours: hm[0], minutes: hm[1] })
+    if (hm[0] === 12) hm = [0, hm[1]]; // twelvehouranians say 12:00 when they mean 0:00. We need to normalize that
+    const date = moment().set({ hours: hm[0], minutes: hm[1] });
     const prevTimeInPrevDay = moment()
       .subtract(1, 'day')
-      .set({ hours: prevDate.getHours(), minutes: prevDate.getMinutes() })
+      .set({ hours: prevDate.getHours(), minutes: prevDate.getMinutes() });
     const prevTimeInCurrentDay = moment().set({
       hours: prevDate.getHours(),
       minutes: prevDate.getMinutes()
-    })
+    });
     const prevTimeInNextDay = moment()
       .add(1, 'day')
-      .set({ hours: prevDate.getHours(), minutes: prevDate.getMinutes() })
-    const diffPrevDay = Math.abs(date.valueOf() - prevTimeInPrevDay.valueOf())
+      .set({ hours: prevDate.getHours(), minutes: prevDate.getMinutes() });
+    const diffPrevDay = Math.abs(date.valueOf() - prevTimeInPrevDay.valueOf());
     const diffCurrentDayAM = Math.abs(
       date.valueOf() - prevTimeInCurrentDay.valueOf()
-    )
+    );
     const diffCurrentDayPM = Math.abs(
       date.valueOf() + 12 * 60 * 60 * 1000 - prevTimeInCurrentDay.valueOf()
-    )
+    );
     const diffNextDay = Math.abs(
       date.valueOf() + 12 * 60 * 60 * 1000 - prevTimeInNextDay.valueOf()
-    )
+    );
     const smallest = Math.min(
       diffPrevDay,
       diffCurrentDayAM,
       diffCurrentDayPM,
       diffNextDay
-    )
+    );
 
-    if (smallest === diffPrevDay) isPM = false
-    else if (smallest === diffCurrentDayAM) isPM = false
-    else if (smallest === diffCurrentDayPM) isPM = true
-    else if (smallest === diffNextDay) isPM = true
+    if (smallest === diffPrevDay) isPM = false;
+    else if (smallest === diffCurrentDayAM) isPM = false;
+    else if (smallest === diffCurrentDayPM) isPM = true;
+    else if (smallest === diffNextDay) isPM = true;
   }
 
-  return isPM
+  return isPM;
 }

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -6,10 +6,11 @@ import ReactDOM from 'react-dom';
 import { addSeconds, differenceInSeconds, isSameDay } from 'date-fns';
 
 import { secToHhmmImproved } from './@toggl/time-format-utils';
+import { formatDuration } from './@toggl/time-format-utils/format-duration';
 import Summary from './components/Summary';
 import TimeEntriesList from './components/TimeEntriesList';
 import Pomodoro from './components/Pomodoro';
-import Timer, { formatDuration } from './components/Timer';
+import Timer from './components/Timer';
 import { ProjectAutoComplete, TagAutoComplete } from './lib/autocomplete';
 import { parseDuration } from './lib/timerUtils';
 import renderLogin from './initializers/login';

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -7,6 +7,7 @@ import { addSeconds, differenceInSeconds, isSameDay } from 'date-fns';
 import { secToHhmmImproved } from './@toggl/time-format-utils';
 import Summary from './components/Summary';
 import TimeEntriesList from './components/TimeEntriesList';
+import Pomodoro from './components/Pomodoro';
 import Timer, { formatDuration } from './components/Timer';
 import { ProjectAutoComplete, TagAutoComplete } from './lib/autocomplete';
 import { parseDuration } from './lib/timerUtils';
@@ -165,6 +166,10 @@ window.PopUp = {
   },
 
   renderEntriesList: function () {
+    if (TogglButton.pomodoroFocusMode && TogglButton.pomodoroAlarm) {
+      ReactDOM.render(<Pomodoro entry={TogglButton.$curEntry} interval={TogglButton.pomodoroInterval} />, document.getElementById('root-time-entries-list'));
+      return;
+    }
     const entries = TogglButton.$user.time_entries;
     if (!entries || entries.length < 1) {
       ReactDOM.render(<TimeEntriesList />, document.getElementById('root-time-entries-list'));

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -1,5 +1,6 @@
 /// <reference path="./index.d.ts" />
 
+import browser from 'webextension-polyfill';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { addSeconds, differenceInSeconds, isSameDay } from 'date-fns';
@@ -13,8 +14,6 @@ import { ProjectAutoComplete, TagAutoComplete } from './lib/autocomplete';
 import { parseDuration } from './lib/timerUtils';
 import renderLogin from './initializers/login';
 
-const browser = require('webextension-polyfill');
-
 let TogglButton = browser.extension.getBackgroundPage().TogglButton;
 const FF = navigator.userAgent.indexOf('Chrome') === -1;
 
@@ -24,7 +23,7 @@ if (FF) {
   document.querySelector('body').classList.add('ff');
 }
 
-window.PopUp = {
+const Popup = {
   $postStartText: ' post-start popup',
   $popUpButton: null,
   $errorLabel: document.querySelector('.error'),
@@ -509,8 +508,20 @@ window.PopUp = {
         e.preventDefault();
       }
     });
+  },
+
+  handleBackgroundMessage: function (request) {
+    if (process.env.DEBUG) {
+      console.log('Popup:handleBackgroundMessage', request);
+    }
+    switch (request.type) {
+      case 'bg/render-entries-list':
+        Popup.renderEntriesList();
+        break;
+    }
   }
 };
+window.PopUp = Popup;
 
 document.addEventListener('DOMContentLoaded', function () {
   const req = {
@@ -599,4 +610,6 @@ document.addEventListener('DOMContentLoaded', function () {
       category: 'Popup'
     });
   }
+
+  browser.runtime.onMessage.addListener(Popup.handleBackgroundMessage);
 });

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -71,9 +71,7 @@ const Popup = {
           PopUp.switchView(PopUp.$menuView);
         }
 
-        PopUp.renderTimer();
-        PopUp.renderEntriesList();
-        PopUp.renderSummary();
+        Popup.renderApp();
       } else {
         localStorage.setItem('latestStoppedEntry', '');
         PopUp.switchView(PopUp.$loginView);
@@ -87,10 +85,17 @@ const Popup = {
     }
   },
 
+  renderApp: function () {
+    PopUp.renderTimer();
+    PopUp.renderEntriesList();
+    PopUp.renderSummary();
+  },
+
   renderSummary: function () {
     const rootElement = document.getElementById('root-summary');
+    const totals = TogglButton.calculateSums();
     ReactDOM.unmountComponentAtNode(rootElement);
-    ReactDOM.render(<Summary />, rootElement);
+    ReactDOM.render(<Summary totals={totals} />, rootElement);
   },
 
   renderTimer: function () {
@@ -130,16 +135,12 @@ const Popup = {
             // Edit form update
             TogglButton = browser.extension.getBackgroundPage().TogglButton;
             // Current TE update
-            PopUp.renderTimer();
-            PopUp.renderEntriesList();
-            PopUp.renderSummary();
+            PopUp.renderApp();
           } else if (response.type === 'update') {
             // Current TE update
             PopUp.renderTimer();
           } else if (response.type === 'Stop') {
-            PopUp.renderTimer();
-            PopUp.renderEntriesList();
-            PopUp.renderSummary();
+            PopUp.renderApp();
           } else if (response.type === 'list-continue' || response.type === 'New Entry') {
             PopUp.renderTimer();
             PopUp.renderEntriesList();

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -47,6 +47,7 @@ const Settings = {
   $stopAtDayEnd: null,
   $defaultProject: null,
   $defaultProjectContainer: null,
+  $pomodoroFocusMode: null,
   $pomodoroVolume: null,
   $pomodoroVolumeLabel: null,
 
@@ -81,6 +82,7 @@ const Settings = {
       const nannyCheckEnabled = await db.get('nannyCheckEnabled');
       const pomodoroModeEnabled = await db.get('pomodoroModeEnabled');
       const pomodoroInterval = await db.get('pomodoroInterval');
+      const pomodoroFocusMode = await db.get('pomodoroFocusMode');
       const pomodoroSoundEnabled = await db.get('pomodoroSoundEnabled');
       const pomodoroStopTimeTrackingWhenTimerEnds = await db.get('pomodoroStopTimeTrackingWhenTimerEnds');
       const sendUsageStatistics = await db.get('sendUsageStatistics');
@@ -133,6 +135,10 @@ const Settings = {
         pomodoroModeEnabled
       );
       document.querySelector('.field.pomodoro-mode').classList.toggle('field--showDetails', pomodoroModeEnabled);
+      Settings.toggleState(
+        Settings.$pomodoroFocusMode,
+        pomodoroFocusMode
+      );
       Settings.toggleState(
         Settings.$pomodoroSound,
         pomodoroSoundEnabled
@@ -644,6 +650,7 @@ document.addEventListener('DOMContentLoaded', async function (e) {
     Settings.$nanny = document.querySelector('#nag-nanny');
     Settings.$idleDetection = document.querySelector('#idle-detection');
     Settings.$pomodoroMode = document.querySelector('#pomodoro-mode');
+    Settings.$pomodoroFocusMode = document.querySelector('#pomodoro-focus-mode');
     Settings.$pomodoroSound = document.querySelector('#enable-sound-signal');
     Settings.$pomodoroStopTimeTracking = document.querySelector(
       '#pomodoro-stop-time'
@@ -763,6 +770,10 @@ document.addEventListener('DOMContentLoaded', async function (e) {
       const pomodoroModeEnabled = await db.get('pomodoroModeEnabled');
       Settings.toggleSetting(e.target, !pomodoroModeEnabled, 'toggle-pomodoro');
       document.querySelector('.field.pomodoro-mode').classList.toggle('field--showDetails', !pomodoroModeEnabled);
+    });
+    Settings.$pomodoroFocusMode.addEventListener('click', async function (e) {
+      const pomodoroFocusMode = await db.get('pomodoroFocusMode');
+      Settings.toggleSetting(e.target, !pomodoroFocusMode, 'toggle-pomodoro-focus-mode');
     });
     Settings.$pomodoroSound.addEventListener('click', async function (e) {
       const pomodoroSoundEnabled = await db.get('pomodoroSoundEnabled');

--- a/src/scripts/shared/use-countdown.ts
+++ b/src/scripts/shared/use-countdown.ts
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { differenceInSeconds } from 'date-fns';
+import useInterval from './use-interval';
+
+const ONE_SECOND = 1000;
+
+export default function useCountdown (start: string, delta: number) {
+  const [countdown, setCountdown] = React.useState(
+    getCountdown(start, delta)
+  );
+
+  const updateCountdown = React.useCallback(() => {
+    setCountdown(countdown - 1);
+  }, [setCountdown, countdown]);
+
+  useInterval(updateCountdown, ONE_SECOND);
+
+  return countdown;
+}
+
+function getCountdown (start: string, interval: number) {
+  const intervalSeconds = interval * 60;
+  const elapsed = differenceInSeconds(new Date(), start);
+  return intervalSeconds - elapsed;
+}

--- a/src/scripts/shared/use-duration.ts
+++ b/src/scripts/shared/use-duration.ts
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { differenceInSeconds } from 'date-fns';
+import useInterval from './use-interval';
+
+const ONE_SECOND = 1000;
+
+/**
+ * Returns the duration since the startDate
+ */
+export const useDuration = (start: string) => {
+  const [duration, setDuration] = React.useState(timeElapsed(start));
+
+  const updateDuration = React.useCallback(() => {
+    setDuration(timeElapsed(start));
+  }, [setDuration]);
+
+  useInterval(updateDuration, ONE_SECOND);
+
+  return duration;
+}
+
+function timeElapsed (start: string) {
+  const elapsed = differenceInSeconds(new Date(), start);
+  return elapsed;
+}

--- a/src/scripts/shared/use-interval.ts
+++ b/src/scripts/shared/use-interval.ts
@@ -1,0 +1,28 @@
+import * as React from 'react';
+
+/**
+ * Executes the passed callback at specifed delay
+ */
+export function useInterval (callback: () => void, delay: number) {
+  const savedCallback = React.useRef<typeof callback>();
+
+  // Remember the latest function.
+  React.useEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+
+  // Set up the interval.
+  React.useEffect(() => {
+    function tick () {
+      if (savedCallback.current) {
+        requestAnimationFrame(savedCallback.current);
+      }
+    }
+    if (delay !== null) {
+      const id = setInterval(tick, delay);
+      return () => clearInterval(id);
+    }
+  }, [delay]);
+}
+
+export default useInterval;


### PR DESCRIPTION
## :star2: What does this PR do?

Adds an optional focus mode while a pomodoro timer is running - shows a countdown timer instead of the usual entries list.

Current issues:
- The countdown doesn't update at the exact same time as the duration :(
- It works in the extension popup, but not when the popup is opened as a separate page

## :bug: Recommendations for testing

Turn the focus mode option on and start a timer.
Click on the countdown to stop it early.
Open the popup during a working 

## :memo: Links to relevant issues or information

Closes #1567 
