### PR TITLE
fix: Workflowy styles

### DIFF
--- a/src/scripts/content/workflowy.js
+++ b/src/scripts/content/workflowy.js
@@ -3,8 +3,7 @@
 
 /* Hover on Bullet Popup */
 togglbutton.render(
-  // TODO: Change selector if the popup ever gets a constant class.
-  '.name:not(.toggl) > div:not(.content)',
+  '.name:not(.toggl) > .flyout.menu',
   { observe: true },
   $container => {
     const $bulletInfo = $('.content', $container.parentElement);
@@ -29,13 +28,35 @@ togglbutton.render(
 
 /* More Options Menu Popup */
 togglbutton.render(
-  // TODO: Change selector if the popup ever gets a constant class.
-  '.selected:not(.mainTreeRoot) ~ .pageControls > .pageMenu:not(.toggl) >' +
-  ' div:nth-child(2)',
+  '.pageMenu:not(.toggl) > .flyout.menu',
   { observe: true },
   $container => {
     // Get the content of the top bullet.
     const $bulletInfo = $('.content');
+
+    const descriptionSelector = () => {
+      return getDescription($bulletInfo);
+    };
+
+    const tagsSelector = () => {
+      return getTags($bulletInfo);
+    };
+
+    const link = togglbutton.createTimerLink({
+      className: 'workflowy',
+      description: descriptionSelector,
+      tags: tagsSelector
+    });
+
+    insertLink($container, link);
+  }
+);
+
+togglbutton.render(
+  '.menu.itemMenu:not(.toggl) > .flyout.menu',
+  { observe: true },
+  $container => {
+    const $bulletInfo = $('.content', $container.parentElement.parentElement);
 
     const descriptionSelector = () => {
       return getDescription($bulletInfo);
@@ -122,22 +143,25 @@ function getTags (bulletInfo) {
 function insertLink (popup, link) {
   const INSERT_POSITION = 3;
 
-  /* Massage the DOM */
-  const wrapper = document.createElement('div');
-  wrapper.classList.add('workflowy-toggl-wrapper');
-  // This makes sure the 'Start timer' link matches the style of the other
-  // options (even when the theme is changed).
-  wrapper.classList.add(popup.children[0].classList[0]);
-  wrapper.appendChild(link);
-  popup.insertBefore(wrapper, popup.children[INSERT_POSITION]);
+  const templateMenuItem = popup.children[0];
+  const templateSpan = templateMenuItem.children[0];
+  const templateLink = templateSpan.children[0];
+
+  link.className += ' ' + templateLink.className;
+  const span = document.createElement('span');
+  span.className += ' ' + templateSpan.className;
+  span.appendChild(link);
+  const menuItem = document.createElement('div');
+  menuItem.className += ' ' + templateMenuItem.className;
+  menuItem.appendChild(span);
+  popup.insertBefore(menuItem, popup.children[INSERT_POSITION]);
 
   // We have to add the toggl class to the parent of the popup,
   // because the popup's classes get overwritten by workflowy.
   const parent = popup.parentElement;
   parent.classList.add('toggl');
 
-  // And remove the class when the parent element's children change (meaning
-  // the popup is deleted).
+  // And remove the class when the popup is deleted.
   const observer = new MutationObserver(function (mutationsList, observer) {
     parent.classList.remove('toggl');
     observer.disconnect();

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1391,24 +1391,17 @@ li .toggl-button.heflo {
 }
 
 /****** WORKFLOWY ******/
-.workflowy-toggl-wrapper {
-  display: flex !important;
-}
-
 .toggl-button.workflowy:not(.toggl-button-edit-form-button) {
   background-position-x: right;
   background-position-y: center;
-  background-size: 14px 14px;
-  line-height: 24px;
-  height: 24px;
-  font-size: 100%;
-  padding-left: 0;
-  padding-right: 23px;
-  flex-grow: 1;
-  -webkit-box-flex: 1;
+  background-size: 16px 16px;
+  line-height: inherit;
+  height: inherit;
+  font-size: inherit;
+  padding: inherit;
+  cursor: inherit;
+  text-decoration: inherit;
   color: inherit !important;
-  cursor: default !important;
-  text-decoration: none !important;
 }
 
 /********* Microsoft To-Do *********/


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

<!-- Concise description of what this PR achieves, including any context. -->
Workflowy styles had gone a bit out of date. This fixes them! Original workflowy integration PR: #1335

![Toggl1](https://user-images.githubusercontent.com/25440652/69487290-18ff4380-0e0c-11ea-9c7a-44bf44a281c2.png)
![Toggl2](https://user-images.githubusercontent.com/25440652/69487291-1a307080-0e0c-11ea-8cd0-817431720af7.png)

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

## :bug: Recommendations for testing

Copied from the original PR

### Finding the Hover Button:
1. Navigated to [workflowy.com](https://workflowy.com/).
2. Created a bullet.
3. Hovered over the bullet (the circle part).
4. Observed how the toggl button appeared. (pass)

### Finding the More Options Button:
1. Navigated to [workflowy.com](https://workflowy.com/).
2. Created a bullet.
3. Clicked on the bullet (the circle part). This makes it so that that bullet is now the top bullet.
4. Clicked the more options menu on the right.
5. Observed how the toggl button appeared. (pass).

### And it Works in All the Styles
![Toggl3](https://user-images.githubusercontent.com/25440652/69487293-1ef52480-0e0c-11ea-8dc9-2fabecd45df5.png)
![Toggl4](https://user-images.githubusercontent.com/25440652/69487294-2288ab80-0e0c-11ea-8849-4e7f20c61384.png)

## :memo: Links to relevant issues or information

Original integration PR: #1335 
