### PR TITLE
feat: Add option to integrate with private projects

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -50,6 +50,26 @@ Please consider the following with your pull request:
 * Make sure we're not leaking styles or breaking the layout of the UI.
 * The text used as timer description should be tailored to the majority of users. E.g. if ticket ID is an important piece of information, it should be included. If it's not important information (e.g. never actually shown in the UI, only in URLs) it should not be included.
 
+### Private integration
+
+If you want to integrate `Toggl Button` with your private project on your custom domain you can
+assign the domain to `Generic Toggl` integration in settings "Permissions" tab.
+
+Your site needs to contain some variation of the following HTML element, where the Toggl Button will
+be created as its child:
+
+```html
+<div
+  class="toggl-root"
+  data-class-name="name-of-the-integration"
+  data-description="Description of a new entry"
+  data-project-id="ID of a project that the entry should be assigned to"
+  data-project-name="Name of a project that the entry should be assigned to"
+  data-tags="list,of,tags"
+  data-type="minimal"
+></div>
+```
+
 ## Making changes to the core extension code
 
 Please consider future maintainers and the "generic" nature of the extension in mind when writing new features. All changes should be tested across both Chrome and Firefox.

--- a/src/scripts/content/generic-toggl.js
+++ b/src/scripts/content/generic-toggl.js
@@ -1,0 +1,24 @@
+'use strict';
+
+togglbutton.render('.toggl-root:not(.toggl)', { observe: true }, function (
+  elem
+) {
+  console.log(elem);
+  const integrationClassName = elem.getAttribute('data-class-name');
+  const description = elem.getAttribute('data-description');
+  const projectName = elem.getAttribute('data-project-name');
+  const projectId = elem.getAttribute('data-project-id');
+  const tags = elem.getAttribute('data-tags');
+  const type = elem.getAttribute('data-type');
+
+  const link = togglbutton.createTimerLink({
+    className: integrationClassName || 'generic-toggl',
+    description: description,
+    projectName: projectName,
+    projectId: parseInt(projectId, 10),
+    tags: tags !== null ? tags.split(',') : [],
+    buttonType: type
+  });
+
+  elem.appendChild(link);
+});

--- a/src/scripts/origins.js
+++ b/src/scripts/origins.js
@@ -184,6 +184,10 @@ export default {
     url: '*://*.freshdesk.com/*',
     name: 'Freshdesk'
   },
+  'generic-toggl': {
+    url: '*://*/*',
+    name: 'Generic Toggl'
+  },
   'getflow.com': {
     url: '*://*.getflow.com/*',
     name: 'Getflow'


### PR DESCRIPTION
- Create `Generic Toggl` integration

Close #1524

## :star2: What does this PR do?

Adds a new type of integration (`Generic Toggl`) that enables custom private projects to implement
a defined interface for toggl-button to latch onto.

## :bug: Recommendations for testing

Add the following element to your site and assign its domain under `Generic Toggl` in settings "Permissions" tab.

```html
<div
  class="toggl-root"
  data-description="Description of a new entry"
></div>
```
