### PR TITLE
fix(popup): Stop time cleared when opening running entry

### DIFF
--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -249,7 +249,7 @@ const Popup = {
       editView.dataset.timeEntryId = timeEntry.id;
       editView.dataset.workspaceId = timeEntry.wid;
       editView.dataset.startTime = timeEntry.start;
-      timeEntry.stop && (editView.dataset.stopTime = timeEntry.stop);
+      editView.dataset.stopTime = timeEntry.stop || '';
     }
 
     const duration = differenceInSeconds(

--- a/src/scripts/shared/use-duration.ts
+++ b/src/scripts/shared/use-duration.ts
@@ -12,7 +12,7 @@ export const useDuration = (start: string) => {
 
   const updateDuration = React.useCallback(() => {
     setDuration(timeElapsed(start));
-  }, [setDuration]);
+  }, [start, setDuration]);
 
   useInterval(updateDuration, ONE_SECOND);
 


### PR DESCRIPTION
#1539  :star2: What does this PR do?

Fixes a bug where editing the running entry also stops it, if a completed entry has been opened previously. 

Steps to reproduce:
- Open edit view for any past entry
  - `dataset.stopTime` is set to that entry's stop time
- Open edit view for the currently running entry
  - `dataset.stopTime` is still set to the previous stop time
  - Submitting the form stops the entry

This change clears `dataset.stopTime` when opening the currently running entry.

## :bug: Recommendations for testing

- Follow the instructions above to verify the bug in master
- Try the same again in this branch

## :memo: Links to relevant issues or information

