### PR TITLE
Fix autocomplete height to be calculated based on window's innerHeight

### DIFF
--- a/src/scripts/lib/autocomplete.js
+++ b/src/scripts/lib/autocomplete.js
@@ -139,14 +139,14 @@ AutoComplete.prototype.closeDropdown = function (t) {
 };
 
 AutoComplete.prototype.updateHeight = function () {
-  const bodyRect = document.body.getBoundingClientRect();
+  const windowHeight = window.innerHeight;
   const elRect = this.el.getBoundingClientRect();
   let popdownStyle = '';
   let listStyle = 'max-height:auto;';
   let calc;
 
-  if (bodyRect.bottom > 0 && elRect.bottom + 25 >= bodyRect.bottom) {
-    calc = window.scrollY + bodyRect.bottom - elRect.top - 10;
+  if (windowHeight > 0 && elRect.bottom + 25 >= windowHeight) {
+    calc = window.scrollY + windowHeight - elRect.top - 10;
     if (calc < 55) {
       calc = 55;
     }


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?
Fixes autocomplete popdown height to be based on `window.innerHeight` instead of `body` element

## :bug: Recommendations for testing
Check main integrations with different window sizes, all should render good.

Rebase it on top of https://github.com/toggl/toggl-button/pull/1604 and check if it works well for Worksection too 

## :memo: Links to relevant issues or information
Closes #1606