### PR TITLE
Add DOM integration option

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -50,6 +50,26 @@ Please consider the following with your pull request:
 * Make sure we're not leaking styles or breaking the layout of the UI.
 * The text used as timer description should be tailored to the majority of users. E.g. if ticket ID is an important piece of information, it should be included. If it's not important information (e.g. never actually shown in the UI, only in URLs) it should not be included.
 
+### Private integration
+
+If you want to integrate `Toggl Button` with your private project on your custom domain you can
+assign the domain to `Generic Toggl` integration in settings "Permissions" tab.
+
+Your site needs to contain some variation of the following HTML element, where the Toggl Button will
+be created as its child:
+
+```html
+<div
+  class="toggl-root"
+  data-class-name="name-of-the-integration"
+  data-description="Description of a new entry"
+  data-project-id="ID of a project that the entry should be assigned to"
+  data-project-name="Name of a project that the entry should be assigned to"
+  data-tags="list,of,tags"
+  data-type="minimal"
+></div>
+```
+
 ## Making changes to the core extension code
 
 Please consider future maintainers and the "generic" nature of the extension in mind when writing new features. All changes should be tested across both Chrome and Firefox.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -50,25 +50,44 @@ Please consider the following with your pull request:
 * Make sure we're not leaking styles or breaking the layout of the UI.
 * The text used as timer description should be tailored to the majority of users. E.g. if ticket ID is an important piece of information, it should be included. If it's not important information (e.g. never actually shown in the UI, only in URLs) it should not be included.
 
-### Private integration
+### DOM integration
 
-If you want to integrate `Toggl Button` with your private project on your custom domain you can
-assign the domain to `Generic Toggl` integration in settings "Permissions" tab.
+If you want to quickly integrate **Toggl Button** with your website.
+You can enable the *DOM Integration* in the **Custom Integrations** section for your domain
 
-Your site needs to contain some variation of the following HTML element, where the Toggl Button will
-be created as its child:
+![enable-dom-integration](https://user-images.githubusercontent.com/1716853/70514207-34cb4f00-1b59-11ea-894a-538f94f4d1f5.png)
+
+You will have to add one or more `div` in your DOM with the class name `toggl-root`, containing the metadata for the time-entry you want to start, Toggl Button will render a button link as a child of these `divs`.
+
+The schema for the time-entry metadata is
+
+```typescript
+interface TogglMetadata {
+  'class': 'toggl-root'
+  'data-description': string
+  'data-project-name': string
+  'data-project-id'?: number
+  'data-tags'?: string // comma separated tag names
+  'data-type'?: 'minimal'
+  'data-class-name'?: string
+}
+```
+
+The actual DOM node would resemble
 
 ```html
 <div
   class="toggl-root"
-  data-class-name="name-of-the-integration"
-  data-description="Description of a new entry"
-  data-project-id="ID of a project that the entry should be assigned to"
+  data-description="Description of the time-entry"
   data-project-name="Name of a project that the entry should be assigned to"
+  data-project-id="Optionally the id of the project that the entry should be assigned to"
   data-tags="list,of,tags"
   data-type="minimal"
+  data-class-name="name-of-the-integration"
 ></div>
 ```
+
+See [toggl-button-dom-demo.now.sh](https://toggl-button-dom-demo.now.sh/) for reference.
 
 ## Making changes to the core extension code
 

--- a/src/scripts/content/dom-integration.js
+++ b/src/scripts/content/dom-integration.js
@@ -3,7 +3,6 @@
 togglbutton.render('.toggl-root:not(.toggl)', { observe: true }, function (
   elem
 ) {
-  console.log(elem);
   const integrationClassName = elem.getAttribute('data-class-name');
   const description = elem.getAttribute('data-description');
   const projectName = elem.getAttribute('data-project-name');
@@ -12,7 +11,7 @@ togglbutton.render('.toggl-root:not(.toggl)', { observe: true }, function (
   const type = elem.getAttribute('data-type');
 
   const link = togglbutton.createTimerLink({
-    className: integrationClassName || 'generic-toggl',
+    className: integrationClassName || 'dom-integration',
     description: description,
     projectName: projectName,
     projectId: parseInt(projectId, 10),

--- a/src/scripts/content/generic-toggl.js
+++ b/src/scripts/content/generic-toggl.js
@@ -1,0 +1,24 @@
+'use strict';
+
+togglbutton.render('.toggl-root:not(.toggl)', { observe: true }, function (
+  elem
+) {
+  console.log(elem);
+  const integrationClassName = elem.getAttribute('data-class-name');
+  const description = elem.getAttribute('data-description');
+  const projectName = elem.getAttribute('data-project-name');
+  const projectId = elem.getAttribute('data-project-id');
+  const tags = elem.getAttribute('data-tags');
+  const type = elem.getAttribute('data-type');
+
+  const link = togglbutton.createTimerLink({
+    className: integrationClassName || 'generic-toggl',
+    description: description,
+    projectName: projectName,
+    projectId: parseInt(projectId, 10),
+    tags: tags !== null ? tags.split(',') : [],
+    buttonType: type
+  });
+
+  elem.appendChild(link);
+});

--- a/src/scripts/origins.js
+++ b/src/scripts/origins.js
@@ -184,6 +184,10 @@ export default {
     url: '*://*.freshdesk.com/*',
     name: 'Freshdesk'
   },
+  'generic-toggl': {
+    url: '*://*/*',
+    name: 'Generic Toggl'
+  },
   'getflow.com': {
     url: '*://*.getflow.com/*',
     name: 'Getflow'

--- a/src/scripts/origins.js
+++ b/src/scripts/origins.js
@@ -128,6 +128,10 @@ export default {
     name: 'DokuWiki',
     file: 'dokuwiki.js'
   },
+  'dom-integration': {
+    url: '*://*/*',
+    name: 'DOM Integration'
+  },
   'draftin.com': {
     url: '*://*.draftin.com/*',
     name: 'Draftin'
@@ -183,10 +187,6 @@ export default {
   'freshdesk.com': {
     url: '*://*.freshdesk.com/*',
     name: 'Freshdesk'
-  },
-  'generic-toggl': {
-    url: '*://*/*',
-    name: 'Generic Toggl'
   },
   'getflow.com': {
     url: '*://*.getflow.com/*',

--- a/src/scripts/origins.js
+++ b/src/scripts/origins.js
@@ -129,7 +129,7 @@ export default {
     file: 'dokuwiki.js'
   },
   'dom-integration': {
-    url: '*://*/*',
+    url: '*://toggl-button-dom-demo.now.sh/*',
     name: 'DOM Integration'
   },
   'draftin.com': {


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

- Adds generic DOM integraiton option
- Updates contirbuting doc to add a note about new option
- Add demo website to showcase the integration

Built on top of #1599 from @mskrip 

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

## :bug: Recommendations for testing

- Enable `DOM Integration` for a page with the specified schema
- It should render a usable toggl button

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

Closes #1599 
Closes #1524 
