### PR TITLE
fix(popup): Restore current day total, inc running timer, to summary

### DIFF
--- a/src/scripts/components/Summary.tsx
+++ b/src/scripts/components/Summary.tsx
@@ -14,6 +14,7 @@ function Summary ({
 }) {
   return (
     <SummaryRow>
+      <div>Today: {totals.today}</div>
       <div>This week: {totals.week}</div>
     </SummaryRow>
   )
@@ -21,7 +22,7 @@ function Summary ({
 
 const SummaryRow = styled.div`
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
   align-items: center;
   padding: 15px 30px;
 


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

Restores the "Today" total in the popup. Unlike the total given at the top right of each day block, this total includes the current running timer - note difference between the two numbers:
![image](https://user-images.githubusercontent.com/50156618/70888842-546ce680-2035-11ea-8e66-0fe7a7fe807c.png)

## :bug: Recommendations for testing

Check it's there and the number is correct

## :memo: Links to relevant issues or information

Closes #1619 
