### PR TITLE
Add Fallback login

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -1170,6 +1170,18 @@ window.TogglButton = {
     browser.browserAction.setIcon({ path: imagePath });
   },
 
+  setupToken: function (response) {
+    try {
+      const parsedResponse = JSON.parse(response);
+      const { api_token: apiToken } = parsedResponse.data;
+      localStorage.setItem('userToken', apiToken);
+    } catch (err) {
+      bugsnagClient.notify(new Error('Login token-parse failed'), {
+        metaData: { response }
+      });
+    }
+  },
+
   loginUser: function (request) {
     let error;
     return new Promise((resolve, reject) => {
@@ -1177,6 +1189,7 @@ window.TogglButton = {
         method: 'POST',
         onLoad: function (xhr) {
           if (xhr.status === 200) {
+            TogglButton.setupToken(xhr.responseText);
             TogglButton.queue.push(TogglButton.checkPermissions);
             TogglButton.fetchUser()
               .then((response) => {

--- a/src/scripts/components/LoginForm.tsx
+++ b/src/scripts/components/LoginForm.tsx
@@ -27,7 +27,10 @@ export default function LoginForm ({ onSubmit, onSuccess, onError }: LoginFormPr
       const response = await onSubmit(email, password);
       setLoading(false);
 
-      if (!response) return;
+      if (!response) {
+        onError('Unknown Error');
+        return;
+      }
 
       if (response.success) {
         onSuccess();

--- a/src/scripts/components/LoginForm.tsx
+++ b/src/scripts/components/LoginForm.tsx
@@ -1,0 +1,124 @@
+import * as React from 'react';
+import styled from '@emotion/styled';
+
+import { Button } from '../@toggl/ui/components';
+import Spinner from './Spinner';
+
+interface LoginFormProps {
+  onSubmit: (email: string, password: string) => Promise<ButtonResponse | null>;
+  onSuccess: () => void;
+  onError: (error: string) => void;
+}
+
+export default function LoginForm ({ onSubmit, onSuccess, onError }: LoginFormProps) {
+  const [loading, setLoading] = React.useState(false);
+  const emailRef = React.useRef<HTMLInputElement>(null);
+  const passwordRef = React.useRef<HTMLInputElement>(null);
+
+  const handleSubmit = React.useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      const email = emailRef.current && emailRef.current.value;
+      const password = passwordRef.current && passwordRef.current.value;
+
+      if (!email || !password) return;
+
+      setLoading(true);
+      const response = await onSubmit(email, password);
+      setLoading(false);
+
+      if (!response) return;
+
+      if (response.success) {
+        onSuccess();
+      } else {
+        onError(response.error);
+      }
+    },
+    [emailRef, passwordRef, onSubmit, setLoading]
+  );
+
+  return (
+    <Form onSubmit={handleSubmit}>
+      <Field>
+        <Label htmlFor="login-email">Email Address</Label>
+        <Input
+          ref={emailRef}
+          id="login-email"
+          name="email"
+          type="email"
+          autoCorrect="off"
+          autoCapitalize="off"
+          autoComplete="username"
+          spellCheck={false}
+          pattern=".+@.+\..+$"
+          autoFocus
+          disabled={loading}
+          required
+        />
+      </Field>
+      <Field>
+        <Label htmlFor="login-password">Password</Label>
+        <Input
+          ref={passwordRef}
+          id="login-password"
+          name="password"
+          type="password"
+          autoComplete="current-password"
+          disabled={loading}
+          required
+        />
+      </Field>
+      <Button>
+        {loading && <Spinner />}
+        {!loading && 'Log in'}
+      </Button>
+    </Form>
+  )
+}
+
+const Form = styled.form`
+  display: flex;
+  width: 512px;
+  padding: 96px 102px;
+  background: white;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  flex-direction: column;
+  & input:focus {
+    border-color: #88cf8f;
+  }
+`;
+
+const Input = styled.input`
+  height: 72px;
+  font-size: 21px;
+  padding: 0 20px;
+
+  background-color: #e3e8eb;
+  border: .2rem solid #e3e8eb;
+  border-radius: .4rem;
+  box-shadow: none;
+  color: #282a2d;
+  display: block;
+  outline: none;
+  resize: none;
+  transition: border-color .3s;
+`;
+
+const Label = styled.label`
+  display: block;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.55px;
+  line-height: 1.45;
+  text-transform: uppercase;
+  text-align: left;
+  margin-bottom: 10px
+`;
+
+const Field = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 42px
+`;

--- a/src/scripts/components/LoginPage.tsx
+++ b/src/scripts/components/LoginPage.tsx
@@ -34,12 +34,21 @@ interface LoginState {
 async function login (setState: React.Dispatch<React.SetStateAction<LoginState>>) {
   setState({ loading: true, error: null, loggedIn: false });
 
-  const { error, success: loggedIn } = await browser.runtime.sendMessage({
+  const response = await sendMessage({
     type: 'sync',
     respond: true
   });
 
-  setState({ loading: false, error, loggedIn });
+  if (!response) {
+    setState({ loading: false, loggedIn: false, error: 'Unknown Error' });
+    return;
+  }
+
+  setState({
+    loading: false,
+    error: (response as FailureResponse).error,
+    loggedIn: response.success
+  });
 }
 
 export default function LoginPage ({ source, isLoggedIn, isPopup }: LoginProps) {

--- a/src/scripts/components/LoginPage.tsx
+++ b/src/scripts/components/LoginPage.tsx
@@ -122,7 +122,7 @@ export default function LoginPage ({ source, isLoggedIn, isPopup }: LoginProps) 
             <a href="login.html?source=install" style={{ marginBottom: 21 }}>
               <Button>Try again</Button>
             </a>
-            <Subheading>or login directly</Subheading>
+            <Subheading>or log in directly</Subheading>
             <LoginForm
               onSubmit={performLogin}
               onSuccess={onLoginSuccess}

--- a/src/scripts/index.d.ts
+++ b/src/scripts/index.d.ts
@@ -193,3 +193,22 @@ type TogglButton = {
 type TogglDB = {
   get<T>(key: string): Promise<T | null>;
 }
+
+interface LoginRequest {
+  type: 'login';
+  username: string;
+  password: string;
+}
+
+type ButtonRequest = LoginRequest;
+
+interface SuccessResponse {
+  success: true;
+}
+
+interface FailureResponse {
+  success: false;
+  error: string;
+}
+
+type ButtonResponse = SuccessResponse | FailureResponse;

--- a/src/scripts/index.d.ts
+++ b/src/scripts/index.d.ts
@@ -200,7 +200,12 @@ interface LoginRequest {
   password: string;
 }
 
-type ButtonRequest = LoginRequest;
+interface SyncRequest {
+  type: 'sync';
+  respond: true;
+}
+
+type ButtonRequest = LoginRequest | SyncRequest;
 
 interface SuccessResponse {
   success: true;

--- a/src/scripts/lib/messaging.ts
+++ b/src/scripts/lib/messaging.ts
@@ -1,0 +1,22 @@
+import browser from 'webextension-polyfill';
+
+export async function sendMessage (request: ButtonRequest) {
+  if (process.env.DEBUG) {
+    console.info('Extension:sendMessage', request);
+  }
+  const response = await browser.runtime
+    .sendMessage(request)
+    .catch(error => {
+      if (process.env.DEBUG) {
+        console.error('Extension:sendMessageResponse', request, error);
+      }
+    });
+
+  if (!response) {
+    return null;
+  }
+  if (process.env.DEBUG) {
+    console.info('Extension:sendMessageResponse', request, response);
+  }
+  return response as ButtonResponse;
+}

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -25,7 +25,7 @@ if (FF) {
 }
 
 document.querySelector('#version').textContent = process.env.VERSION;
-document.querySelector('#review-prompt a').href = getStoreLink();
+document.querySelector('#review-prompt a').href = getStoreLink(FF);
 document.querySelector('#review-prompt a').addEventListener('click', dismissReviewPrompt);
 document.querySelector('#close-review-prompt').addEventListener('click', dismissReviewPrompt);
 


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

<!-- Concise description of what this PR achieves, including any context. -->

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

- Adds fallback login option in case regular login fails

## :bug: Recommendations for testing

- Log out from button and webapp completely
- Fallback login will only show up in case regular login fails
- Use attached diff to force login view navigate to `chrome-extension://EXT_ID/html/login.html?source=quick-start`
- Try logging in using fallback form button should still work

```diff
diff --git a/src/scripts/components/LoginPage.tsx b/src/scripts/components/LoginPage.tsx
index 40858f0..bf8143e 100644
--- a/src/scripts/components/LoginPage.tsx
+++ b/src/scripts/components/LoginPage.tsx
@@ -52,7 +52,7 @@ async function login (setState: React.Dispatch<React.SetStateAction<LoginState>>
 }
 
 export default function LoginPage ({ source, isLoggedIn, isPopup }: LoginProps) {
-  const [ state, setState ] = React.useState<LoginState>({ loading: false, error: null, loggedIn: isLoggedIn });
+  const [ state, setState ] = React.useState<LoginState>({ loading: false, error: 'Random error', loggedIn: isLoggedIn });
   const { loading, error, loggedIn } = state;
 
   React.useEffect(() => {
```


All changes should be tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->

Closes #1618 