### PR TITLE
feat(intercom): Add button to KB article edit page

### DIFF
--- a/src/scripts/content/intercom.js
+++ b/src/scripts/content/intercom.js
@@ -31,3 +31,21 @@ togglbutton.render('.conversation__card__content-expanded__controls .inbox__conv
 
     elem.appendChild(link);
   });
+
+togglbutton.render('.articles__editor__header-text:not(.toggl)',
+  { observe: true },
+  function (elem) {
+    const descriptionSelector = () => {
+      const description = elem.textContent;
+      return description ? description.trim() : '';
+    };
+
+    const link = togglbutton.createTimerLink({
+      className: 'intercom',
+      description: descriptionSelector,
+      buttonType: 'minimal'
+    });
+    link.style.margin = '3px 15px';
+
+    elem.appendChild(link);
+  });


### PR DESCRIPTION
## :star2: What does this PR do?

Adds a button to intercom's article edit page:
![image](https://user-images.githubusercontent.com/50156618/70969052-10d6b300-20ef-11ea-86eb-5706668fdcd4.png)

## :bug: Recommendations for testing

Go to intercom's articles section, open an article and look for the button.

## :memo: Links to relevant issues or information

Requested internally
