### PR TITLE
Fix Integration filter not working with upper-case text

### DIFF
--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -696,9 +696,10 @@ document.addEventListener('DOMContentLoaded', async function (e) {
         Settings.$permissionFilterClear.style.opacity = '0';
       }
 
+      val = val.toLowerCase();
       const permissionItems = document.querySelectorAll('#permissions-list li');
       permissionItems.forEach((item) => {
-        if (item.textContent.toLowerCase().indexOf(val) !== -1) {
+        if (item.textContent.toLowerCase().includes(val)) {
           item.classList.add('filter');
         } else if (item.classList) {
           item.classList.remove('filter');


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

- Normalizes the input to lower-case before comparing it to lower-case integration names

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

## :bug: Recommendations for testing

- Try the integration filter with upper, lower, mixed case input
- It should filter correctly in all cases

All changes should be tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
Closes #1628