### PR TITLE
[WIP] Use iframe for popup edit form

### DIFF
--- a/src/chrome-manifest.json
+++ b/src/chrome-manifest.json
@@ -54,5 +54,5 @@
   },
   "content_security_policy":
     "script-src 'self'; object-src 'self';",
-  "web_accessible_resources": ["html/login.html"]
+  "web_accessible_resources": ["html/login.html", "html/popup.html"]
 }

--- a/src/firefox-manifest.json
+++ b/src/firefox-manifest.json
@@ -50,5 +50,5 @@
   ],
   "content_security_policy":
     "script-src 'self'; object-src 'self';",
-  "web_accessible_resources": ["html/login.html"]
+  "web_accessible_resources": ["html/login.html", "html/popup.html"]
 }

--- a/src/html/popup.html
+++ b/src/html/popup.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="../styles/popup.css"/>
     <link rel="stylesheet" href="../styles/autocomplete.css"/>
   </head>
-  <body style="overflow-y: scroll;">
+  <body>
     <ul class="header">
       <li class="icon">
         <svg xmlns="http://www.w3.org/2000/svg" width="75" height="23" viewBox="0 0 75 23">
@@ -72,7 +72,7 @@
         </form>
       </div>
 
-      <div id="toggl-button-entry-form" class="view" style="min-height: calc(100vh - 40px);">
+      <div id="toggl-button-entry-form" class="view">
       </div>
 
     </div>

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -147,11 +147,11 @@ window.TogglButton = {
     '</div>' +
     '</div>' +
     `
-      <div id="tb-actions-button-group">
+      <div class="tb-actions-button-group">
         <button type="button" id="tb-edit-form-cancel" tabindex="0" class="TB__Secondary__button">Cancel</button>
         <div id="toggl-button-update" tabindex="0" class="TB__Button__button">Done</div>
       </div>
-      <div id="tb-actions-button-group">
+      <div class="tb-actions-button-group">
         <div id="toggl-button-delete" tabindex="0" class="TB__Button__button danger">Delete</div>
       </div>
     ` +

--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -294,7 +294,7 @@ window.togglbutton = {
     const editFormWidth = 360;
     const position = togglbutton.topPosition(elemRect, editFormWidth, editFormHeight);
 
-    const frameWrapperStyle = 'z-index: 200000; position: absolute; background: white; border-radius: 8px; overflow: hidden; ' +
+    const frameWrapperStyle = 'z-index: 200000; position: absolute; background: white; border-radius: 6px; overflow: hidden; ' +
       `top: ${position.top}px; left: ${position.left}px; height: ${editFormHeight}px; width: ${editFormWidth}px;`;
     frameWrapper.setAttribute('id', 'toggl-button-frame-wrapper');
     frameWrapper.setAttribute('style', frameWrapperStyle);

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -26,7 +26,6 @@ if (FF) {
 const Popup = {
   $postStartText: ' post-start popup',
   $popUpButton: null,
-  $isIntegrationPopup: false,
   $errorLabel: document.querySelector('.error'),
   $projectAutocomplete: null,
   $tagAutocomplete: null,
@@ -89,7 +88,7 @@ const Popup = {
   renderApp: function () {
     const view = new URL(window.location.href).searchParams.get('view');
     if (view && view === 'integration-popup') {
-      Popup.$isIntegrationPopup = true;
+      document.documentElement.classList.add('integration-popup');
       Popup.renderEditForm(TogglButton.$curEntry);
       return;
     }

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -26,6 +26,7 @@ if (FF) {
 const Popup = {
   $postStartText: ' post-start popup',
   $popUpButton: null,
+  $isIntegrationPopup: false,
   $errorLabel: document.querySelector('.error'),
   $projectAutocomplete: null,
   $tagAutocomplete: null,
@@ -86,6 +87,13 @@ const Popup = {
   },
 
   renderApp: function () {
+    const view = new URL(window.location.href).searchParams.get('view');
+    if (view && view === 'integration-popup') {
+      Popup.$isIntegrationPopup = true;
+      Popup.renderEditForm(TogglButton.$curEntry);
+      return;
+    }
+
     PopUp.renderTimer();
     PopUp.renderEntriesList();
     PopUp.renderSummary();

--- a/src/styles/edit-form.css
+++ b/src/styles/edit-form.css
@@ -308,7 +308,7 @@
   background: rgb(243, 243, 243);
 }
 
-#tb-actions-button-group {
+.tb-actions-button-group {
   display: flex;
   width: 100%;
 }

--- a/src/styles/popup.css
+++ b/src/styles/popup.css
@@ -6,8 +6,12 @@ html, body {
 }
 
 body {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
   font-size: 14px;
   overflow: hidden;
+  overflow-y: scroll;
   margin: 0px;
   padding: 0px;
   background: white;
@@ -209,6 +213,13 @@ p.form-row.first {
   height: 24px;
 }
 
+.views {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
 .views > div,
 .views > ul {
   display: none;
@@ -216,8 +227,7 @@ p.form-row.first {
 
 .header[data-view='menu'] ~ .views #menu,
 .header[data-view='login-view'] ~ .views #login-view,
-.header[data-view='revoked-workspace'] ~ .views #revoked-workspace,
-.header[data-view='toggl-button-entry-form'] ~ .views #toggl-button-entry-form {
+.header[data-view='revoked-workspace'] ~ .views #revoked-workspace {
   display: block !important;
 }
 
@@ -226,10 +236,10 @@ p.form-row.first {
 }
 
 .header[data-view='toggl-button-entry-form'] ~ .views #toggl-button-entry-form {
-  display: flex !important;
-  align-items: flex-start;
+  flex: 1;
+  display: flex;
   justify-content: center;
-  padding-top: 5rem;
+  align-items: center;
 }
 
 .running,
@@ -284,23 +294,6 @@ hr {
   max-height: 100px;
 }
 
-/* Entry form styles */
-
-.views #toggl-button-entry-form {
-  /* Bigger width in the toolbar popup. It'll be changed completely in "Timer popup" issue. */
-  width: 100%;
-  height: 100%;
-}
-
-.views #toggl-button-edit-form {
-  /* Bigger width in the toolbar popup. It'll be changed completely in "Timer popup" issue. */
-  position: relative;
-  margin: 0 auto;
-  width: auto !important;
-}
-
-
-
 /** FIREFOX **/
 .ff #toggl-button-update:focus {
   box-shadow: 1px 1px 5px #83bffc;
@@ -341,4 +334,19 @@ hr {
 
 #revoked-workspace .primary-btn {
   width: 100%;
+}
+
+/** Integration Popup **/
+html.integration-popup, html.integration-popup body {
+  width: 360px;
+  min-height: 300px;
+  overflow-x: hidden;
+  overflow-y: hidden;
+}
+
+.integration-popup .header,
+.integration-popup #toggl-button-duration-row,
+.integration-popup #tb-edit-form-cancel,
+.integration-popup .tb-actions-button-group {
+  display: none;
 }


### PR DESCRIPTION
## :star2: What does this PR do?

Uses an iframe to display the popup edit form, to avoid weird interactions with underlying page.

Currently working:
- Creates an iframe when a timer is started
- Frame reuses edit view from the normal browser popup
- Frame is deleted on click outside

Not working:
- Firefox
- Frame should be deleted on pressing "Enter" inside the popup
- Autocomplete boxes should be a little taller

## :bug: Recommendations for testing

:grimacing: 

## :memo: Links to relevant issues or information

If this works it would fix a bunch of issues, e.g. #1623, #1622, #1448, and hopefully be more hardy in general :wrench: 
