### PR TITLE
Fix Trello card closing when opening project/tag dropdown

### DIFF
--- a/src/scripts/content/trello.js
+++ b/src/scripts/content/trello.js
@@ -29,7 +29,8 @@ togglbutton.render(
     const link = togglbutton.createTimerLink({
       className: 'trello',
       description: getDescription,
-      projectName: getProject
+      projectName: getProject,
+      container: '.window-wrapper'
     });
 
     // Pass through click on Trello button to the timer link
@@ -67,7 +68,8 @@ togglbutton.render(
       className: 'trello-list',
       buttonType: 'minimal',
       projectName: getProject,
-      description: getDescription
+      description: getDescription,
+      container: '.window-wrapper'
     });
 
     link.classList.add('checklist-item-menu');


### PR DESCRIPTION
## :star2: What does this PR do?

Fixes Trello card closing when you click on the edit popup's project or tag dropdowns.

## :bug: Recommendations for testing

1. Open a Trello card
2. Click the "Start timer" link
3. On the edit popup, open the project or tag dropdown

The Trello card should no longer close in the background.

## :memo: Links to relevant issues or information

First two commits are from #1625 which should be merged first.

Closes #1622.
