### PR TITLE
feat(edit-popup): Close popup edit form when user clicks outside

### DIFF
--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -419,6 +419,14 @@ window.togglbutton = {
       return false;
     });
 
+    document.addEventListener('click', function (e) {
+      const editFormPopup = document.getElementById('toggl-button-edit-form');
+      if (!editFormPopup.contains(e.target)) {
+        closeForm();
+        return false;
+      }
+    });
+
     /* prevent certain host webapps from processing key commands */
     $('form', editForm).addEventListener('keydown', function (e) {
       e.stopPropagation();

--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -420,11 +420,12 @@ window.togglbutton = {
     });
 
     function closeOnClickOutside (e) {
-      const editFormPopup = document.getElementById('toggl-button-edit-form');
-      if (!editFormPopup.contains(e.target)) {
-        document.removeEventListener('click', closeOnClickOutside);
-        closeForm();
-        return false;
+      if (editForm.style.display !== 'none') {
+        const editFormPopup = document.getElementById('toggl-button-edit-form');
+        if (!editFormPopup.contains(e.target)) {
+          closeForm();
+          return false;
+        }
       }
     }
 

--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -419,13 +419,16 @@ window.togglbutton = {
       return false;
     });
 
-    document.addEventListener('click', function (e) {
+    function closeOnClickOutside (e) {
       const editFormPopup = document.getElementById('toggl-button-edit-form');
       if (!editFormPopup.contains(e.target)) {
+        document.removeEventListener('click', closeOnClickOutside);
         closeForm();
         return false;
       }
-    });
+    }
+
+    document.addEventListener('click', closeOnClickOutside);
 
     /* prevent certain host webapps from processing key commands */
     $('form', editForm).addEventListener('keydown', function (e) {


### PR DESCRIPTION
## :star2: What does this PR do?

The popup edit form is closed when there's a click outside it.

## :bug: Recommendations for testing

1. Start a timer in any integration
2. Click inside the popup (it should stay open)
3. Click outside the popup (it should close)

## :memo: Links to relevant issues or information

Closes #1585 
