### PR TITLE
fix(autocomplete): Fix escaping of tag names in html title attribute

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -1418,8 +1418,8 @@ window.TogglButton = {
       .map(t => `
         <li
           class="tag-item"
-          data-wid=${escapeHtml(t.wid)}
-          title=${escapeHtml(t.name)}
+          data-wid="${escapeHtml(t.wid)}"
+          title="${escapeHtml(t.name)}"
         >
         ${escapeHtml(t.name)}
         </li>

--- a/src/scripts/lib/autocomplete.js
+++ b/src/scripts/lib/autocomplete.js
@@ -708,17 +708,31 @@ TagAutoComplete.prototype.selectTag = function (e) {
 };
 
 TagAutoComplete.prototype.setSelected = function (tags) {
-  let i; let item;
-
   this.clearSelectedTags();
 
+  /**
+   * Create map of elements keyed to element .title attribute value.
+   * @param {NodeList} elements
+   */
+  const mapByTitle = function (elements) {
+    let i;
+    let title;
+    const result = {};
+
+    for (i = 0; i < elements.length; i += 1) {
+      title = elements[i].getAttribute('title');
+      result[title] = elements[i];
+    }
+
+    return result;
+  };
+
   if (tags) {
+    const current = mapByTitle(this.el.querySelectorAll('li[title]'));
+    let i; let item;
+
     for (i = 0; i < tags.length; i += 1) {
-      // must escape colon, as it has special meaning for querySelector
-      const escapedFilter = tags[i].replace(/[ :\\]/g, function (char) {
-        return '\\' + char;
-      });
-      item = this.el.querySelector("li[title='" + escapedFilter + "']");
+      item = current[tags[i]];
       if (!item) {
         this.addNew(tags[i]);
       } else {

--- a/src/scripts/lib/autocomplete.js
+++ b/src/scripts/lib/autocomplete.js
@@ -715,8 +715,8 @@ TagAutoComplete.prototype.setSelected = function (tags) {
   if (tags) {
     for (i = 0; i < tags.length; i += 1) {
       // must escape colon, as it has special meaning for querySelector
-      const escapedFilter = tags[i].replace(/:/g, function (tag) {
-        return '\\' + tag;
+      const escapedFilter = tags[i].replace(/[ :\\]/g, function (char) {
+        return '\\' + char;
       });
       item = this.el.querySelector("li[title='" + escapedFilter + "']");
       if (!item) {

--- a/src/scripts/lib/autocomplete.js
+++ b/src/scripts/lib/autocomplete.js
@@ -714,7 +714,11 @@ TagAutoComplete.prototype.setSelected = function (tags) {
 
   if (tags) {
     for (i = 0; i < tags.length; i += 1) {
-      item = this.el.querySelector("li[title='" + tags[i] + "']");
+      // must escape colon, as it has special meaning for querySelector
+      const escapedFilter = tags[i].replace(/:/g, function (tag) {
+        return '\\' + tag;
+      });
+      item = this.el.querySelector("li[title='" + escapedFilter + "']");
       if (!item) {
         this.addNew(tags[i]);
       } else {


### PR DESCRIPTION
There's bug if tag containing `::` is added, autocomplete code gets fatal error because `::` indicates DOM selector, not verbatim text.

This was extracted out of https://github.com/toggl/toggl-button/pull/1639

Docs:
- https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector
