### PR TITLE
Restore Toggl Button for Asana's old task detail view

### DIFF
--- a/src/scripts/content/asana.js
+++ b/src/scripts/content/asana.js
@@ -100,3 +100,45 @@ togglbutton.render(
     firstButton.parentNode.insertBefore(link, firstButton);
   }
 );
+
+// Old and Beta UI - detail view
+togglbutton.render(
+  '.SingleTaskPane-titleRow:not(.toggl)',
+  { observe: true },
+  function (elem) {
+    if ($('.toggl-button', elem)) {
+      return;
+    }
+    const container = $('.SingleTaskPaneToolbar');
+
+    const descriptionSelector = () => {
+      return $(
+        '.SingleTaskPane-titleRow .simpleTextarea',
+        elem.parentNode
+      ).textContent;
+    };
+
+    const projectSelector = () => {
+      const projectElement = $(
+        '.SingleTaskPane-projects .TaskProjectPill-projectName',
+        elem.parentNode
+      );
+
+      return projectElement ? projectElement.textContent : '';
+    };
+
+    const link = togglbutton.createTimerLink({
+      className: 'asana-board',
+      description: descriptionSelector,
+      projectName: projectSelector,
+      buttonType: 'minimal'
+    });
+
+    link.style.marginRight = '5px';
+
+    if (container) {
+      const closeButton = container.lastElementChild;
+      container.insertBefore(link, closeButton);
+    }
+  }
+);


### PR DESCRIPTION
## :star2: What does this PR do?

Re-adds the button that was changed in #1636, as the new Asana detail view isn't available to 100% of existing users right now. It should be live for everyone soon (https://github.com/toggl/toggl-button/pull/1636#issuecomment-572724899) but putting this PR here in case anyone has time to review and release beforehand, or the rollout gets delayed.

## :bug: Recommendations for testing

Unfortunately we don't have access to any accounts still on the old system, but this is just the [old code](https://github.com/toggl/toggl-button/blob/309f0e92d042a46f2d8183306a79e2ef6bebf02f/src/scripts/content/asana.js#L72) added back in and it worked fine before :see_no_evil: 

## :memo: Links to relevant issues or information

[Slack notice](https://toggl.slack.com/archives/C8H3UCQ9W/p1578547062009100)
