### PR TITLE
fix(jira): Fix "copy link" text being included in time entry descriptions

### DIFF
--- a/src/scripts/content/atlassian.js
+++ b/src/scripts/content/atlassian.js
@@ -70,7 +70,12 @@ const getDescription = (issueNumberElement) => () => {
   const titleElement = document.querySelector('h1 ~ button[aria-label]');
 
   if (issueNumberElement) {
-    description += issueNumberElement.textContent.trim();
+    // Inspect deeper to avoid other hidden elements which can contain text
+    // https://github.com/toggl/toggl-button/issues/1644
+    const issueLink = issueNumberElement.querySelector('a');
+    if (issueLink) {
+      description += issueLink.textContent.trim();
+    }
   }
 
   if (titleElement && titleElement.previousSibling) {


### PR DESCRIPTION


Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

<!-- Concise description of what this PR achieves, including any context. -->

Attempts to dodge all other elements when picking the time entry description, by focusing on the issue link itself. This only contains the issue ID.

This seemed simplest and works in all pages at the moment.

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

## :bug: Recommendations for testing

Ensure that timer buttons work as expected with the correct descriptions in all of our test projects

- "Toggl button project"
- "Toggl button Scrum project"
- "Next generation scrum project" ( this is where the issue could be reproduced) 

All changes should be tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->

Fixes #1644.
