### PR TITLE
fix(asana): Get task description when button is clicked

### DIFF
--- a/src/scripts/content/asana.js
+++ b/src/scripts/content/asana.js
@@ -50,7 +50,7 @@ togglbutton.render('.MyTasksTaskRow:not(.toggl)', { observe: true },
       return;
     }
     const container = elem.querySelector('.ItemRowTwoColumnStructure-left');
-    const description = elem.querySelector('.TaskName textarea').textContent;
+    const descriptionSelector = () => elem.querySelector('.TaskName textarea').textContent;
 
     const projectSelector = () => {
       const projectElement = elem.querySelector('.TaskRow-pots .Pill');
@@ -60,7 +60,7 @@ togglbutton.render('.MyTasksTaskRow:not(.toggl)', { observe: true },
 
     const link = togglbutton.createTimerLink({
       className: 'asana-new-ui',
-      description: description,
+      description: descriptionSelector,
       projectName: projectSelector,
       buttonType: 'minimal'
     });


### PR DESCRIPTION
## :star2: What does this PR do?

Change description to a selector function, to get the latest description when button is clicked

Note: button doesn't turn red on click, see issue #1650 

## :bug: Recommendations for testing

On master:
1. Go to Asana's My Tasks page
2. Add a new task
3. Type in a name
4. Click the Button
5. There is no description <- fixed on this branch

## :memo: Links to relevant issues or information

Closes #1646 