### PR TITLE
Rearrange edit form buttons

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -147,11 +147,11 @@ window.TogglButton = {
     '</div>' +
     '</div>' +
     `
-      <div id="tb-actions-button-group">
-        <button type="button" id="tb-edit-form-cancel" tabindex="0" class="TB__Secondary__button">Cancel</button>
+      <div class="tb-actions-button-group">
         <div id="toggl-button-update" tabindex="0" class="TB__Button__button">Done</div>
       </div>
-      <div id="tb-actions-button-group">
+      <div class="tb-actions-button-group">
+        <button type="button" id="tb-edit-form-cancel" tabindex="0" class="TB__Secondary__button">Cancel</button>
         <div id="toggl-button-delete" tabindex="0" class="TB__Button__button danger">Delete</div>
       </div>
     ` +

--- a/src/styles/edit-form.css
+++ b/src/styles/edit-form.css
@@ -296,8 +296,7 @@
 }
 
 .TB__Button__button.danger {
-  width: 100%;
-  margin-top: 12px;
+  flex: 1;
   background: none;
   color: rgb(226, 5, 5);
   font-weight: 400;
@@ -308,9 +307,17 @@
   background: rgb(243, 243, 243);
 }
 
-#tb-actions-button-group {
+.tb-actions-button-group {
   display: flex;
   width: 100%;
+}
+
+.tb-actions-button-group ~ .tb-actions-button-group {
+  margin-top: 12px;
+}
+
+.toggl-integration .tb-actions-button-group ~ .tb-actions-button-group {
+  display: none;
 }
 
 #tb-edit-form-cancel,
@@ -320,13 +327,6 @@
 
 #tb-edit-form-cancel {
   margin-right: 10px;
-}
-#toggl-button-edit-form.toggl-integration #tb-edit-form-cancel {
-  display: none;
-  visibility: hidden;
-}
-#toggl-button-edit-form.toggl-integration #toggl-button-delete {
-  display: none;
 }
 
 #toggl-button-edit-form #toggl-button-update {


### PR DESCRIPTION
## :star2: What does this PR do?

- Make the "Done" button 100% wide
- Move the "Cancel" button next to the "Delete" button

This makes the popup's edit form look more like the integration popup (where "Done" is 100% wide) and groups the less commonly used "Cancel" and "Delete" options together.

![image](https://user-images.githubusercontent.com/50156618/72409165-17714c80-37b9-11ea-99e3-3505ff1108fc.png)

## :bug: Recommendations for testing

Buttons should still work as before.

## :memo: Links to relevant issues or information

Closes #1632
