### PR TITLE
fix(autocomplete): Fix autocomplete dropdowns being too long

### DIFF
--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -40,20 +40,6 @@ function invokeIfFunction (trial) {
   return trial;
 }
 
-function getFullPageHeight () {
-  const body = document.body;
-
-  const html = document.documentElement;
-
-  return Math.max(
-    body.scrollHeight,
-    body.offsetHeight,
-    html.clientHeight,
-    html.scrollHeight,
-    html.offsetHeight
-  );
-}
-
 function setCursorAtBeginning (elem) {
   elem.focus();
   elem.setSelectionRange(0, 0);
@@ -203,9 +189,10 @@ window.togglbutton = {
     if (left + editFormWidth > window.innerWidth) {
       left = window.innerWidth - 10 - editFormWidth;
     }
-    if (top + editFormHeight > getFullPageHeight()) {
+    if (top + editFormHeight > window.innerHeight) {
       top = window.innerHeight + document.body.scrollTop - 10 - editFormHeight;
     }
+
     return { left: left, top: top };
   },
 

--- a/src/scripts/lib/autocomplete.js
+++ b/src/scripts/lib/autocomplete.js
@@ -142,25 +142,19 @@ AutoComplete.prototype.updateHeight = function () {
   const windowHeight = window.innerHeight;
   const elRect = this.el.getBoundingClientRect();
   let popdownStyle = '';
-  let listStyle = 'max-height:auto;';
   let calc;
 
   if (windowHeight > 0 && elRect.bottom + 25 >= windowHeight) {
-    calc = window.scrollY + windowHeight - elRect.top - 10;
+    calc = windowHeight - elRect.top + 45;
     if (calc < 55) {
       calc = 55;
     }
     popdownStyle = 'max-height: ' + calc + 'px;';
-    // Not sure, but probably: 55=filter, 25=??, 24=clear-tags
-    listStyle = 'max-height: ' + (calc - 55 - 25 - 24) + 'px;';
   } else {
     return;
   }
 
   this.el.closest('.TB__Popdown__content').style = popdownStyle;
-  if (this.type === 'tag') {
-    document.querySelector('.tag-list').style = listStyle;
-  }
 };
 
 //* Project autocomplete *//


### PR DESCRIPTION
## :star2: What does this PR do?

Update the way the project and tag dropdowns' max height is calculated. It should stretch out and end just before the bottom of the page (assuming there are that many entries), e.g.:
Long list when near top of page:
![image](https://user-images.githubusercontent.com/50156618/73241223-8ad18000-41f5-11ea-9a5e-b61ccdd04e5b.png)
Short list near bottom of page:
![image](https://user-images.githubusercontent.com/50156618/73241239-94f37e80-41f5-11ea-972d-b816c27e41d1.png)

## :bug: Recommendations for testing

Open the dropdowns in a few integrations, and also the popup.

The dropdown should not stretch outside of the viewport.

## :memo: Links to relevant issues or information

Closes #1659 
