### PR TITLE
style(brokerengine): Update hover styles for toggl buttons on task queue

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1500,13 +1500,11 @@ body.notion-body.dark .toggl-button.notion {
 }
 
 [data-toggl="taskRow"] .toggl-button.brokerengine:not(.active) {
-  opacity: 0;
-  visibility: hidden;
+  opacity: 0.4;
 }
 
 [data-toggl="taskRow"]:hover .toggl-button.brokerengine {
   opacity: 1;
-  visibility: visible;
 }
 
 [data-toggl="loanDrawer"] .toggl-button.brokerengine {


### PR DESCRIPTION
## :star2: What does this PR do?

This PR updates the hover styling for toggl buttons on BrokerEngine's task queue view.

Lowered opacity on buttons that are neither being hovered nor active.

Hover:
<img width="478" alt="Screen Shot 2020-01-28 at 5 03 39 PM" src="https://user-images.githubusercontent.com/2377217/73250421-d71ac100-41f1-11ea-9ab2-6f5511a54862.png">

Active:
<img width="404" alt="Screen Shot 2020-01-28 at 5 04 15 PM" src="https://user-images.githubusercontent.com/2377217/73250427-d97d1b00-41f1-11ea-8423-517398e1b352.png">

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.
