### PR TITLE
Fix Workflowy integration

### DIFF
--- a/src/scripts/content/workflowy.js
+++ b/src/scripts/content/workflowy.js
@@ -1,12 +1,12 @@
 'use strict';
 /* global togglbutton, $ */
 
-/* Hover on Bullet Popup */
+/* Task more menu (formerly bullet hover) */
 togglbutton.render(
-  '.name:not(.toggl) > .flyout.menu',
+  '.name:not(.toggl) div:not(.toggl) > .flyout.menu',
   { observe: true },
   $container => {
-    const $bulletInfo = $('.content', $container.parentElement);
+    const $bulletInfo = $('.content', $container.closest('.name'));
 
     const descriptionSelector = () => {
       return getDescription($bulletInfo);


### PR DESCRIPTION


Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

<!-- Concise description of what this PR achieves, including any context. -->

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

Fix workflowy following UI changes. The "more menu" markup changed a little bit and the nesting broke things. It is tricky as the DOM is updated whilst using these menus and it can overwrite the classes we depend on when checking if we should inject a button.. but it seems to work again for now.

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

* Using the 'more menu' next to individual task works fine
* Using the 'more menu' next to the title works fine

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->

Closes #1662.
