### PR TITLE
fix(redmine) Prevent positioning in sidebar

### DIFF
--- a/src/scripts/content/redmine.js
+++ b/src/scripts/content/redmine.js
@@ -1,10 +1,10 @@
 'use strict';
 
 togglbutton.render(
-  'body.controller-issues.action-show h2:not(.toggl)',
+  'body.controller-issues.action-show #content h2:not(.toggl)',
   {},
   function (elem) {
-    const numElem = $('h2');
+    const numElem = $('#content h2');
     const titleElem = $('.subject h3') || '';
     const projectElem = $('h1');
     let description;
@@ -30,6 +30,6 @@ togglbutton.render(
       projectName: projectElem && projectElem.textContent
     });
 
-    $('h2').appendChild(link);
+    $('#content h2').appendChild(link);
   }
 );


### PR DESCRIPTION
## :star2: What does this PR do?

Currently the button is rendered in the first `h2` tag found. Depending on installed plugins in Redmine there are multiple `h2` tags present. This leads to having the button rendered at the wrong position and using the wrong title.

This PR makes the selectors more specific by using `#content h2` to detect `numElem` and button position.

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

## :bug: Recommendations for testing

Use Redmine with Plugins installed. e.g. [Helpdesk](https://www.redmineup.com/pages/de/plugins/helpdesk)