### PR TITLE
fix(autocomplete): Fix long task names overlapping in project dropdown

### DIFF
--- a/src/styles/autocomplete.css
+++ b/src/styles/autocomplete.css
@@ -254,6 +254,11 @@
   color: #000;
   height: 30px;
   line-height: 30px;
+
+  /* Truncate task names. Full name will be in title attribute */
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 #project-autocomplete .task-item:hover {
   background-color: hsla(0,0%,69.4%,.07);


### PR DESCRIPTION


Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

<!-- Concise description of what this PR achieves, including any context. -->

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

Stop long task names from wrapping and overlapping other content in the projects dropdown

## :bug: Recommendations for testing

Have some tasks with *very* long names, check that they don't overlap each other anymore in the projects dropdown.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
Fixes #1667.
