### PR TITLE
Add additional toggl button to timetracking block

### DIFF
--- a/src/scripts/content/gitlab.js
+++ b/src/scripts/content/gitlab.js
@@ -88,17 +88,14 @@ function tagsSelector () {
 
   const tagItems = $tagList.children;
   const tags = [];
-  let index;
 
-  for (index in tagItems) {
-    if (tagItems.hasOwnProperty(index)) {
-      const tagName = tagItems[index].textContent.trim();
-      // Skip no labels: <span className="no-value">None</span>
-      if (tagName === 'None') {
-        continue;
-      }
-      tags.push(tagName);
+  for (const node of Object.values(tagItems)) {
+    const tagName = node.textContent.trim();
+    // Skip no labels: <span className="no-value">None</span>
+    if (tagName === 'None') {
+      continue;
     }
+    tags.push(tagName);
   }
 
   return tags;

--- a/src/scripts/content/gitlab.js
+++ b/src/scripts/content/gitlab.js
@@ -5,7 +5,6 @@ togglbutton.render(
   { observe: true },
   function (elem) {
     const breadcrumbsSubTitle = getBreadcrumbsSubTitle();
-    const actionsElem = $('.time_tracker');
 
     let description = getTitle(elem);
     if (breadcrumbsSubTitle) {
@@ -18,14 +17,7 @@ togglbutton.render(
         description;
     }
 
-    const link = togglbutton.createTimerLink({
-      className: 'gitlab',
-      description: description,
-      tags: tagsSelector,
-      projectName: getProjectSelector
-    });
-
-    actionsElem.parentElement.appendChild(link, actionsElem);
+    insertButton(description);
   }
 );
 
@@ -34,7 +26,6 @@ togglbutton.render(
   { observe: true },
   function (elem) {
     const breadcrumbsSubTitle = getBreadcrumbsSubTitle();
-    const actionsElem = $('.time_tracker');
 
     let description = getTitle(elem);
     if (breadcrumbsSubTitle) {
@@ -49,16 +40,21 @@ togglbutton.render(
         description;
     }
 
-    const link = togglbutton.createTimerLink({
-      className: 'gitlab',
-      description: description,
-      tags: tagsSelector,
-      projectName: getProjectSelector
-    });
-
-    actionsElem.parentElement.appendChild(link, actionsElem);
+    insertButton(description);
   }
 );
+
+function insertButton (description) {
+  const el = $('.time_tracker');
+  const link = togglbutton.createTimerLink({
+    className: 'gitlab',
+    description: description,
+    tags: tagsSelector,
+    projectName: getProjectSelector
+  });
+
+  el.parentElement.appendChild(link, el);
+}
 
 function getTitle (parent) {
   const $el = $('.title', parent);

--- a/src/scripts/content/gitlab.js
+++ b/src/scripts/content/gitlab.js
@@ -17,7 +17,8 @@ togglbutton.render(
         description;
     }
 
-    insertButton(description);
+    insertButton($('.detail-page-header-actions'), description, true);
+    insertButton($('.time_tracker'), description);
   }
 );
 
@@ -40,12 +41,17 @@ togglbutton.render(
         description;
     }
 
-    insertButton(description);
+    insertButton($('.detail-page-header-actions'), description, true);
+    insertButton($('.time_tracker'), description);
   }
 );
 
-function insertButton (description) {
-  const el = $('.time_tracker');
+/**
+ * @param $el
+ * @param {String} description
+ * @param {boolean} prepend
+ */
+function insertButton ($el, description, prepend = false) {
   const link = togglbutton.createTimerLink({
     className: 'gitlab',
     description: description,
@@ -53,7 +59,11 @@ function insertButton (description) {
     projectName: getProjectSelector
   });
 
-  el.parentElement.appendChild(link, el);
+  if (prepend) {
+    $el.parentElement.insertBefore(link, $el);
+  } else {
+    $el.parentElement.appendChild(link, $el);
+  }
 }
 
 function getTitle (parent) {

--- a/src/scripts/content/gitlab.js
+++ b/src/scripts/content/gitlab.js
@@ -5,7 +5,7 @@ togglbutton.render(
   { observe: true },
   function (elem) {
     const breadcrumbsSubTitle = getBreadcrumbsSubTitle();
-    const actionsElem = $('.detail-page-header-actions');
+    const actionsElem = $('.time_tracker');
 
     let description = getTitle(elem);
     if (breadcrumbsSubTitle) {
@@ -25,7 +25,7 @@ togglbutton.render(
       projectName: getProjectSelector
     });
 
-    actionsElem.parentElement.insertBefore(link, actionsElem);
+    actionsElem.parentElement.appendChild(link, actionsElem);
   }
 );
 
@@ -34,7 +34,7 @@ togglbutton.render(
   { observe: true },
   function (elem) {
     const breadcrumbsSubTitle = getBreadcrumbsSubTitle();
-    const actionsElem = $('.detail-page-header-actions');
+    const actionsElem = $('.time_tracker');
 
     let description = getTitle(elem);
     if (breadcrumbsSubTitle) {
@@ -56,7 +56,7 @@ togglbutton.render(
       projectName: getProjectSelector
     });
 
-    actionsElem.parentElement.insertBefore(link, actionsElem);
+    actionsElem.parentElement.appendChild(link, actionsElem);
   }
 );
 


### PR DESCRIPTION
## :star2: What does this PR do?

GitLab has it's own time tracking and block in sidebar, add the Toggl button there.

The major benefit is that the button is now at a fixed location, I do not have to scroll up on the page to find the button and start the tracker.

![image](https://user-images.githubusercontent.com/199095/73940201-b1797000-48f3-11ea-957e-adc3f37a803c.png)

This also synchronizes with GitHub integration where the button is also at sidebar:

![image](https://user-images.githubusercontent.com/199095/73940227-bfc78c00-48f3-11ea-96d0-25325d7d9db0.png)

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
