### PR TITLE
Remove "checkPermissions" logic on load/login

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -1192,7 +1192,6 @@ window.TogglButton = {
         onLoad: function (xhr) {
           if (xhr.status === 200) {
             TogglButton.setupToken(xhr.responseText);
-            TogglButton.queue.push(TogglButton.checkPermissions);
             TogglButton.fetchUser()
               .then((response) => {
                 TogglButton.refreshPage();
@@ -2254,22 +2253,6 @@ window.TogglButton = {
     }
   },
 
-  checkPermissions: async function (show) {
-    const dontShowPermissions = await db.get('dont-show-permissions');
-    if (!dontShowPermissions && !FF) {
-      browser.permissions.getAll().then(function (results) {
-        if (show != null || results.origins.length === 2) {
-          show = show != null ? show : 2;
-          db.set('settings-active-tab', 2);
-          db.set('show-permissions-info', show);
-          if (TogglButton.$user) {
-            browser.runtime.openOptionsPage();
-          }
-        }
-      });
-    }
-  },
-
   hasWorkspaceBeenRevoked: function (workspaces) {
     return workspaces.length === 0;
   },
@@ -2383,17 +2366,11 @@ window.onbeforeunload = function () {
     });
 };
 
-if (!FF) {
-  TogglButton.checkPermissions();
-}
-
 // Check whether new version is installed
 browser.runtime.onInstalled.addListener(function (details) {
   if (details.reason === 'install') {
     if (!TogglButton.$user) {
       browser.tabs.create({ url: 'html/login.html?source=install' });
-    } else if (!FF) {
-      TogglButton.checkPermissions(0);
     }
   } else if (details.reason === 'update') {
     console.info(`Updated from ${details.previousVersion} to ${process.env.VERSION}.`);

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -1990,11 +1990,6 @@ window.TogglButton = {
           db.updateSetting('rememberProjectPer', request.state);
           db.resetDefaultProjects();
         } else if (
-          request.type === 'update-dont-show-permissions' ||
-          request.type === 'update-settings-active-tab'
-        ) {
-          db.updateSetting(request.type.substr(7), request.state);
-        } else if (
           request.type === 'update-send-usage-statistics'
         ) {
           db.updateSetting('sendUsageStatistics', request.state);

--- a/src/scripts/lib/db.js
+++ b/src/scripts/lib/db.js
@@ -31,9 +31,6 @@ const DEFAULT_SETTINGS = {
   rememberProjectPer: 'false',
   enableAutoTagging: false,
 
-  'dont-show-permissions': false,
-  'show-permissions-info': 0,
-  'settings-active-tab': 0,
   sendErrorReports: true,
   sendUsageStatistics: true
 };


### PR DESCRIPTION

Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

<!-- Concise description of what this PR achieves, including any context. -->

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

Remove some `checkPermissions` logic that would automatically open the login page if it thinks you don't have any permissions enabled, on load/login (with login meaning, any time user is fetched, I think).

Do not think this is needed any more with the new onboarding page(s).

## :bug: Recommendations for testing

Everything seems sound, and we're not missing out on anything as a result of this change.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->

 Closes #1663.
