### PR TITLE
Restore support for Trello check-lists

### DIFF
--- a/src/scripts/content/trello.js
+++ b/src/scripts/content/trello.js
@@ -71,9 +71,13 @@ togglbutton.render(
       description: getDescription,
       container: '.window-wrapper'
     });
-
-    link.classList.add('checklist-item-menu');
-    elem.querySelector('.checklist-item-menu-wrapper').appendChild(link);
+    const wrapper = document.createElement('span');
+    wrapper.classList.add('checklist-item-menu');
+    wrapper.style.display = 'flex';
+    wrapper.style.alignItems = 'center';
+    wrapper.style.marginRight = '4px';
+    wrapper.appendChild(link);
+    elem.querySelector('.checklist-item-controls').appendChild(wrapper);
   },
   '.checklist-items-list, .window-wrapper'
 );

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -248,9 +248,8 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
 .checklist-item-details:hover .toggl-button.trello-list, .toggl-button.trello-list.active:not(.toggl-button-edit-form-button) {
   visibility: visible;
   pointer-events: all;
-  position: absolute;
-  top: 0;
-  right: 32px;
+  height: 100%;
+  width: 100%;
   background-position: center !important;
 }
 .trello-tb-wrapper .toggl-button {


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

<!-- Concise description of what this PR achieves, including any context. -->

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

- Updates insertion selector
- Fixes positioning code

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

- Open a Trello card with a checklist
- Button should be visible on hovering over a checklist item

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
Closes #1672