### PR TITLE
fix(gitlab): Fix Gitlab MR showing two Toggl buttons

### DIFF
--- a/src/scripts/content/gitlab.js
+++ b/src/scripts/content/gitlab.js
@@ -30,7 +30,7 @@ togglbutton.render(
 );
 
 togglbutton.render(
-  '.merge-request-details .detail-page-description:not(.toggl)',
+  '.merge-request-details > .detail-page-description:not(.toggl)',
   { observe: true },
   function (elem) {
     const breadcrumbsSubTitle = getBreadcrumbsSubTitle();


### PR DESCRIPTION
If Gitlab merge request had a description, the button was shown two
times since the redender selector found two matching elements.

## :star2: What does this PR do?

Fixes that behavior to only generate a single button from Gitlab MR name.
