### PR TITLE
Add integration for board layout

### DIFF
--- a/src/scripts/content/asana.js
+++ b/src/scripts/content/asana.js
@@ -1,5 +1,31 @@
 'use strict';
 
+// Board view, 2020. Inserts button next to assignee/due date.
+togglbutton.render('.BoardCard .BoardCard-contents:not(.toggl)', { observe: true },
+  boadCardElem => {
+    const descriptionSelector = () => boadCardElem.querySelector('.BoardCard-name').textContent.trim();
+
+    const projectSelector = () => {
+      const projectElement = document.querySelector('.TopbarPageHeaderStructure-titleRow > h1');
+      if (!projectElement) return '';
+
+      return projectElement.textContent.trim();
+    };
+
+    const link = togglbutton.createTimerLink({
+      className: 'asana-board-view',
+      description: descriptionSelector,
+      projectName: projectSelector,
+      buttonType: 'minimal'
+    });
+
+    const injectContainer = boadCardElem.querySelector('.BoardCard-rightMetadata');
+    if (injectContainer) {
+      injectContainer.insertAdjacentElement('afterbegin', link);
+    }
+  }
+);
+
 // Spreadsheet view, 2019. Inserts button next to to the task name.
 togglbutton.render('.SpreadsheetRow .SpreadsheetTaskName:not(.toggl)', { observe: true },
   function (taskNameCell) {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -182,6 +182,14 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
   margin-right: 5px; /* Ensure any additional controls are spaced  */
 }
 
+.toggl-button.asana-board-view {
+  opacity: 0;
+}
+
+.BoardCard--hover .toggl-button.asana-board-view {
+  opacity: 1;
+}
+
 /********* PODIO *********/
 .toggl-button.podio {
   width: 65px;


### PR DESCRIPTION
## :star2: What does this PR do?

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

It is visible on card item when you hover it. I decided to display it on the right because the size of button didn't really align well with items on the left:
![image](https://user-images.githubusercontent.com/10184544/79231032-c0d1e800-7e65-11ea-8bf8-ccbcbc9daf8e.png)


## :memo: Links to relevant issues or information

Closes #1706