### PR TITLE
fix(form): Add no focus lock attribute to form

### DIFF
--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -316,6 +316,11 @@ window.togglbutton = {
     editForm.style.top = position.top + 'px';
     editForm.style.position = 'fixed';
     editForm.classList.add('toggl-integration');
+
+    // Some integrations uses trap zones which prevents from focus everything inside this element
+    // See: https://github.com/theKashey/focus-lock
+    editForm.setAttribute('data-no-focus-lock', true);
+
     // if a container was provided to createTimerlink, append editForm to that container
     // for avoiding unwanted interactions with some services' events
     const container = response.container ? document.querySelector(response.container) : document.body;


### PR DESCRIPTION

Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

Sets `data-no-focus-lock` attribute on form which prevents [this library](https://github.com/theKashey/focus-lock) to trap button's focus events


## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.
See #1704 it should work nicely now

## :memo: Links to relevant issues or information
Closes #1704

