### PR TITLE
Add notification when trying to stop entry with unmet constraints

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -874,6 +874,9 @@ window.TogglButton = {
                   browser.tabs.sendMessage(tabs[0].id, { type: 'stop-entry', user: TogglButton.$user });
                 }));
             }
+            if (xhr.status === 400 && xhr.response && xhr.response.includes('please add a')) {
+              TogglButton.showUnmetConstraintsNotification(xhr.response);
+            }
           },
           onError: function (xhr) {
             resolve({
@@ -920,6 +923,9 @@ window.TogglButton = {
                   browser.tabs.sendMessage(tabs[0].id, { type: 'stop-entry', user: TogglButton.$user });
                 }));
             }
+            if (xhr.status === 400 && xhr.response && xhr.response.includes('please add a')) {
+              TogglButton.showUnmetConstraintsNotification(xhr.response);
+            }
           },
           onError: function (xhr) {
             resolve({
@@ -930,6 +936,20 @@ window.TogglButton = {
         }
       );
     });
+  },
+
+  showUnmetConstraintsNotification: function (message) {
+    const notificationId = 'unmet-constraints';
+    const options = {
+      type: 'basic',
+      iconUrl: 'images/icon-128.png',
+      title: 'Toggl Button',
+      message,
+      priority: 2
+    };
+
+    TogglButton.hideNotification(notificationId);
+    browser.notifications.create(notificationId, options);
   },
 
   pomodoroStopTimeTracking: async function () {


### PR DESCRIPTION
## :star2: What does this PR do?

For now it only prints error from backend, which is descriptive enough, imho. We might actually add some actions pointing to ws settings, or something.

## :bug: Recommendations for testing

⚠️ All changes should be tested across Chrome and Firefox. ⚠️ 

* Set some constraints in ws settings
* Try to stop Time Entry in button without ☝️ fields filled in
*  There should be a notification 

Try pomodoro with "stop time entry" option set too

## :memo: Links to relevant issues or information
Closes #1430