### PR TITLE
Move workflowy to minimal button

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1435,17 +1435,12 @@ body.notion-body.dark .toggl-button.notion {
 }
 
 /****** WORKFLOWY ******/
-.toggl-button.workflowy:not(.toggl-button-edit-form-button) {
-  background-position-x: right;
-  background-position-y: center;
-  background-size: 16px 16px;
-  line-height: inherit;
-  height: inherit;
-  font-size: inherit;
-  padding: inherit;
-  cursor: inherit;
-  text-decoration: inherit;
-  color: inherit !important;
+.toggl-button.min.workflowy {
+  width: 36px;
+  height: 36px;
+  padding-left: 0;
+  margin-right: 6px;
+  background-position: center;
 }
 
 /********* Microsoft To-Do *********/


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

<!-- Concise description of what this PR achieves, including any context. -->
Fixes the workflowy integration by removing the old context menu functionality. It now uses a permanent minimal button attached to the header.


Here is what the integration looks like now:
![NewUI](https://user-images.githubusercontent.com/25440652/80011956-6c3ff580-8481-11ea-8249-3cb77ba1e2c7.png)
When you click it it starts a timer for the bullet you last interacted with. If you haven't interacted with a bullet yet, it starts the timer for the top bullet on the page. You can also see the timer it will start when you hover over it:
![HoverTip](https://user-images.githubusercontent.com/25440652/80011966-7104a980-8481-11ea-8fd6-c74aa3f0b369.gif)

## :bug: Recommendations for testing

### Top Bullet Test
1. Open workflowy.
2. Click the timer immediately.
3. Observe how it starts a "home" timer. (home is the name of the invisible top bullet)

### Bullet Test 1
1. Open Workflowy.
2. Create some bullets.
3. Click around on them.
4. Observe how the timer starts for the latest bullet you interacted with.

### Bullet Test 2
1. Open workflowy.
2. Create some bullets with sub-bullets.
3. Open and close some of the bullet drop-downs.
4. Observe how the timer starts for the latest bullet you interacted with.

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
Closes #1711