### PR TITLE
Fix tags not being included when using discard + continue option

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -590,7 +590,12 @@ window.TogglButton = {
         });
       });
     }
-    const shouldIncludeTags = (enableAutoTagging || type === 'list-continue' || type === 'resume');
+    const shouldIncludeTags = (
+      enableAutoTagging || // Auto-add tags found in integration script
+      type === 'list-continue' || // Include tags when using Continue in the UI
+      type === 'resume' || // Include tags when continuing latest entry in reminder notification
+      type === 'idle-detection-notification-continue' // Include tags when using Continue-and-discard in idle detection
+    );
 
     entry = {
       start: start.toISOString(),
@@ -1737,6 +1742,7 @@ window.TogglButton = {
         }).then(() => {
           // discard idle time and continue
           if (buttonID === 1) {
+            timeEntry.type = 'idle-detection-notification-continue';
             TogglButton.createTimeEntry(timeEntry);
             buttonName = 'discard_continue';
           }


### PR DESCRIPTION



Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

<!-- Concise description of what this PR achieves, including any context. -->

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

When using "Discard and continue" option in the idle-detection notification, ensure that the tags from the running entry are copied to the new entry.

Prior to this PR, they did not get included if the "Automatic tagging" option was not enabled. The automatic tagging option is only describing the process of extracting tags/labels from within an integration, and should not affect the idle detection features.

## :bug: Recommendations for testing

This only affects Chrome, because this feature is not supported in Firefox.

Test locally:

1. "Idle detection" should be enabled,
2. "Enable automatic tagging" should be **disabled**
3. Apply this patch to speed up time. N.B. you should fully refresh the extension in `chrome://extensions` to ensure the latest bundle is loaded 

```diff
diff --git a/src/scripts/background.js b/src/scripts/background.js
index ef289e1..6209dce 100644
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -17,8 +17,8 @@ const FF = navigator.userAgent.indexOf('Chrome') === -1;
 
 const shouldTriggerNotification = (state, seconds) => {
   return (
-    state === 'active' && seconds > FIVE_MINUTES ||
-    state === 'idle' && seconds > 0 && (seconds % FIVE_MINUTES) === 0
+    state === 'active' && seconds > 5 ||
+    state === 'idle' && seconds > 0 && (seconds % 5) === 0
   );
 };
```

4. Start a timer via the UI which has some tags on it
5. Leave your computer idle for some ~10 seconds to ensure the notification will be triggered (don't even move your mouse at all)
6. Interact with the browser again and receive notification
7. Click "more" and then "Discard and continue"
8. Observe new TE includes the tags from the TE you previously started 🎉 

With the same settings, it would not copy the tags on `master`.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->

Closes #1717.
