### PR TITLE
fix(salesforce): Fix Salesforce Lightning buttons being temperemental

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -854,19 +854,15 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
   padding-right: 5px;
   margin-bottom: -6px;
 }
-
 .toggl-button.salesforce-legacy:not(.minimal) {
   margin-left: 5px;
   font-size: 12px;
   text-decoration: none;
   font-weight: normal;
 }
-
-.toggl-button:not(.toggl-button-edit-form-button).salesforce {
-  margin-top: 0;
-  position: relative;
-  top: 2px;
-  left: 5px;
+/* Lightning UI */
+.toggl-button-salesforce-wrapper {
+  margin-left: auto;
 }
 .custom-truncate .toggl-button.salesforce {
   /* avoid button image being truncated */


### PR DESCRIPTION

Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

<!-- Concise description of what this PR achieves, including any context. -->

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

I've moved the button to the "Utility bar" at the bottom of the page. It is not feasible to place it in the header anymore IMO, there are so many edge cases and the layout can't really be relied on in my experience. May need to review further in the future - or redo it from scratch with much more time spent on it.

![Screenshot 2020-05-21 at 15 12 45](https://user-images.githubusercontent.com/6432028/82568624-01b0d100-9b77-11ea-9ca0-2a62ab24270b.png)

We'll need to communicate with our friends in support that this will probably generate feedback / questions, since the button has moved.

More screenshots at the end of the PR showing what values it picks up.

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

Sorry, but you've got to give it a good thrashing. Things were breaking depending on what order you viewed pages, or even when going back and forward to the same page.

Views I verified:
* Accounts
* Contacts
* Leads
* Opportunities
* Tasks

Description should be picked up from page "title", and on most views the ""Project"" should be identified as well if it matches a project in Toggl (it kind of depends).

Use the test account credentials for Salesforce, and the usual test account for logging into button as well.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->

Fixes #1724 

![Screenshot 2020-05-21 at 15 12 06](https://user-images.githubusercontent.com/6432028/82568583-f3fb4b80-9b76-11ea-8a74-71d7f12e98f3.png)

![Screenshot 2020-05-21 at 15 12 18](https://user-images.githubusercontent.com/6432028/82568587-f6f63c00-9b76-11ea-9312-e52aaa05d3da.png)

![Screenshot 2020-05-21 at 15 12 34](https://user-images.githubusercontent.com/6432028/82568594-f9f12c80-9b76-11ea-99f8-216a76d0661e.png)

![Screenshot 2020-05-21 at 15 12 56](https://user-images.githubusercontent.com/6432028/82568611-fd84b380-9b76-11ea-8528-d51a3b58a5b9.png)
(Acme doesn't exist so it isn't picked up by the button)

