### PR TITLE
chore(azure): Fix dropdowns on board view

### DIFF
--- a/src/scripts/content/visualstudio.js
+++ b/src/scripts/content/visualstudio.js
@@ -49,7 +49,8 @@ togglbutton.render(
     const link = togglbutton.createTimerLink({
       className: 'visual-studio-online',
       description: descriptionSelectorFactory(activeHeaderContainer),
-      projectName: projectSelector
+      projectName: projectSelector,
+      container: '.work-item-form-main-header'
     });
 
     // For new layout vs_activeClassElem is not longer required, we can skip it


### PR DESCRIPTION
## :star2: What does this PR do?

Move Toggl Button form inside the azure task popup, so the project and tag dropdowns will open.

## :bug: Recommendations for testing

1. Open a task from board view (or [click here](https://dev.azure.com/togglbutton/Toggl%20Button%20Project/_boards/board/t/Toggl%20Button%20Project%20Team/Stories/?workitem=2))
2. Start timer
3. Open the project and tag dropdowns (which don't open on master)

## :memo: Links to relevant issues or information

Closes #1709
