### PR TITLE
Truncate long time entry descriptions in Pomodoro notification

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -977,12 +977,14 @@ window.TogglButton = {
 
     let notificationId = 'pomodoro-time-is-up';
     let stopSound;
-    const latestDescription =
+    const description =
         TogglButton.$curEntry && TogglButton.$curEntry.description
-          ? ' (' + TogglButton.$curEntry.description + ')'
+          ? TogglButton.$curEntry.description
           : '';
+    let truncatedDescription = description.slice(0, 30);
+    if (truncatedDescription.length < description.length) truncatedDescription += '.. ';
 
-    let topButtonTitle = 'Continue Latest' + latestDescription;
+    let topButtonTitle = `Continue Latest ${description && `(${truncatedDescription})`}`;
     let bottomButtonTitle = 'Start New';
 
     TogglButton.pomodoroStopTimeTracking();


### PR DESCRIPTION

Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

<!-- A Concise description of what this PR achieves, including any context. -->

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

Truncates the time entry description in the Pomodoro "time's up" notification.

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

* With Pomodoro enabled and "stop timer at end" setting:
  * The notification is shown, long entry is truncated
  * if there's no description, the button should simply be `Continue Latest`

Other Pomodoro variations should not be affected.

<img width="309" alt="Screenshot 2020-06-09 at 16 36 30" src="https://user-images.githubusercontent.com/6432028/84169733-e0098200-aa70-11ea-9556-f4689316f818.png">


<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->

Fixes #1746.
