### PR TITLE
fix(todoist): Fix duplicated button on todoist

### DIFF
--- a/src/scripts/content/todoist.js
+++ b/src/scripts/content/todoist.js
@@ -68,8 +68,14 @@ togglbutton.render('[data-item-detail-root] [data-item-actions-root]:not(.toggl)
 // task view - subtasks
 togglbutton.render(
   '.task_list_item .task_list_item__actions:not(.toggl)',
-  { observe: true, observeTarget: todoistEditor, debounceInterval: 100 },
+  { observe: true, observeTarget: todoistEditor, debounceInterval: 300 },
   elem => {
+    const isButtonAdded = elem.querySelector('.toggl-button') !== null;
+
+    if (isButtonAdded) {
+      return;
+    }
+
     const rootEl = elem.closest('.task_list_item');
     const content = rootEl.querySelector('.task_list_item__content');
 


### PR DESCRIPTION
## :star2: What does this PR do?

- 3c60e97 - **fix(todoist): Fix duplicated button on todoist** 
For some reason there is an intermediary state when opening/closing the task's schedule popdown, where the `.toggl` class is removed and re-added.
This commit fixes it by checking if the toggl button is already present, before adding it.

## :bug: Recommendations for testing
- Check if everything looks fine on todoist integration 👌 

## :memo: Links to relevant issues or information
Related #1752
