### PR TITLE
Fix tasks sometimes not showing in the Project dropdown when searching

### DIFF
--- a/src/styles/autocomplete.css
+++ b/src/styles/autocomplete.css
@@ -113,6 +113,10 @@
   display: block !important;
 }
 
+.client-list.filter-match .project-row {
+  display: flex !important;
+}
+
 .item-name {
   padding-left: 5px;
   overflow: hidden;


### PR DESCRIPTION


Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

<!-- A Concise description of what this PR achieves, including any context. -->

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

Fixes issue where the "X tasks" label next to projects could vanish after you perform a search.

The latest layout for the projects + tasks uses `flex`, but the olden autocomplete CSS classes were overriding it to `block`. This broke the display of the task list label.

Change to specifically handle project rows and ensure they are flex.

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

See the linked case in the issue for a helpful video demonstrating the original problem

1. Search for a **client name**, where this client has a project with tasks assigned to it
2. You see the project filtered, and you can still see `X tasks` next to it _(this is the fix)_
3. Remove your search value from the input
4. Scroll to find the same project as 2️⃣ , you should still see `X tasks` next to it _(this is the fix)_
5. No other regressions introduced 😇 

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->


Fixes #1737.
