### PR TITLE
Fix issues with integration checkboxes

### DIFF
--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -351,9 +351,7 @@ const Settings = {
               .replace('*://*.', '')
               .replace('*://', '')
               .replace('/*', '');
-            if (url.split('.').length > 2) {
-              name = url.substr(url.indexOf('.') + 1);
-            }
+
             Settings.origins[name] = {
               id: i,
               origin: origins[i],


### PR DESCRIPTION


Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

<!-- A Concise description of what this PR achieves, including any context. -->

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->


Integrations sharing the same host could be shown as enabled even if they are not. (The prime case here being Google products).

The permission is requested on the full domain, but the list of origins in the UI would ignore the subdomains and show things as checked even if they aren't enabled. I think at one point this was a convenience feature for services that had many subdomains for the same app.. but it doesn't really hold up elsewhere.

I made a small tweak to the integration list to respect subdomain when creating the list of origins (`Settings.origins`)

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

* ⚠️ This integration origin list is 🍝  and we'll have to test to QA everything we can.
* Specific Google steps:
1. Enable a google integration
2. Refresh the page - only that integration shows as selected ✅ 
3. The integration works
4. Enable additional Google integrations, check again after refreshing ✅ 
5. The integrations work

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->

Closes #1728.
