### PR TITLE
fix(asana): Update project selector for My Tasks page

### DIFF
--- a/src/scripts/content/asana.js
+++ b/src/scripts/content/asana.js
@@ -70,30 +70,49 @@ togglbutton.render('.SpreadsheetRow .SpreadsheetTaskName:not(.toggl)', { observe
   }
 );
 
-// 2019 My Tasks view, possibly other similar views.
+// 2020 My Tasks view, possibly other similar views.
 togglbutton.render('.MyTasksTaskRow:not(.toggl)', { observe: true },
   function (elem) {
     if (elem.querySelector('.toggl-button')) {
       // Due to the way this UI is rendered, we must check for existence of old buttons manually.
       return;
     }
-    const container = elem.querySelector('.ItemRowTwoColumnStructure-left');
     const descriptionSelector = () => elem.querySelector('.TaskName textarea').textContent;
 
-    const projectSelector = () => {
-      const projectElement = elem.querySelector('.TaskRow-pots .Pill');
+    // attempt at separating projects and tags, which are not differentiated in the dom
+    // assume first pill is a project and any others are tags
+    // misses tags which are in the "..." overflow, and if there is a tag without a project
+    const pillSelector = (type) => {
+      const pills = [...elem.querySelectorAll('.NavigationLink')]
+        .map(pill => pill.textContent.trim());
+      if (type === 'project') {
+        return pills.length ? pills[0] : '';
+      } else if (type === 'tags') {
+        return pills.length > 1 ? pills.slice(1) : [];
+      }
+    };
 
-      return projectElement ? projectElement.textContent : '';
+    const projectSelector = () => {
+      return pillSelector('project');
+    };
+
+    const tagsSelector = () => {
+      return pillSelector('tags');
     };
 
     const link = togglbutton.createTimerLink({
       className: 'asana-new-ui',
       description: descriptionSelector,
       projectName: projectSelector,
+      tags: tagsSelector,
       buttonType: 'minimal'
     });
 
-    container.appendChild(link);
+    const wrapper = document.createElement('div');
+    wrapper.style.margin = '3px 0 0 4px';
+    wrapper.appendChild(link);
+
+    elem.appendChild(wrapper);
   }
 );
 

--- a/src/styles/colours.css
+++ b/src/styles/colours.css
@@ -1,0 +1,15 @@
+:root {
+  --white: #fff;
+  --extra-light-grey: #f3f3f3;
+  --lighter-grey: #e3e4e4;
+  --greyish: #a3a3a3;
+  --grey: #363636;
+  --mineshaft: #323232;
+  --dark-grey: #303030;
+  --another-black: #222;
+  --darker-black: #1e1e1e;
+
+  --red: #d92b2b;
+  --red-on-dark: #ff5050;
+  --green: #4bc800;
+}


### PR DESCRIPTION
## :star2: What does this PR do?

- Project names will be picked up again on the My Tasks page
- Move button to far right so they align if a project is present

## :bug: Recommendations for testing

1. Go to My Tasks page
2. Time a task with a project
3. Project is now picked up
4. Icons no longer do this
![image](https://user-images.githubusercontent.com/50156618/85359176-e6135e80-b558-11ea-9701-6e5370856003.png)

## :memo: Links to relevant issues or information

Closes #1757
