### PR TITLE
[Firefox] Fix settings navigation

### DIFF
--- a/src/scripts/settings-theme.js
+++ b/src/scripts/settings-theme.js
@@ -2,5 +2,5 @@ let darkMode = JSON.parse(localStorage.getItem('darkMode'));
 if (darkMode === null) darkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
 if (darkMode) {
   document.documentElement.classList.add('dark');
-  document.body.classList.add('dark');
+  document.body && document.body.classList.add('dark');
 }

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -1007,7 +1007,7 @@ document.addEventListener('DOMContentLoaded', async function (e) {
 });
 
 function changeActiveTab (tab) {
-  const elem = tab.target ? tab.path.find(e => e.dataset.tab) : undefined;
+  const elem = tab.target ? tab.target.closest('[data-tab]') : undefined;
 
   const name = elem ? elem.dataset.tab : tab;
 


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

-  Replace event path usage with [element.closest](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest)
- `event.path` is not-standard, recommended standard is [event.composedPath()](https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath)
- But this usage can be simplified by using `element.closest(selector)`

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

- Open TB settings page
- Click the links in the sidebar under the `Settings` header they should work as expected

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
Closes #1776 