### PR TITLE
Fix capitalization of "GitHub" in integrations

### DIFF
--- a/src/scripts/origins.js
+++ b/src/scripts/origins.js
@@ -202,7 +202,7 @@ export default {
   },
   'github.com': {
     url: '*://github.com/*',
-    name: 'Github'
+    name: 'GitHub'
   },
   'gitlab.com': {
     url: '*://*.gitlab.com/*',


### PR DESCRIPTION
## :star2: What does this PR do?

Fixes the capitalization of "GitHub" in the integration list

## :bug: Recommendations for testing

Visually confirm in the integration list in settings.