### PR TITLE
fix(visualstudio): Prevent duplicate buttons

### DIFF
--- a/src/scripts/content/visualstudio.js
+++ b/src/scripts/content/visualstudio.js
@@ -45,6 +45,11 @@ togglbutton.render(
     const activeButtonContainer = getContainer('.work-item-form-header-controls-container');
     const activeHeaderContainer = getContainer('.work-item-form-main-header');
     const vsActiveClassElem = $('.commandbar.header-bottom > .commandbar-item > .displayed');
+    const isAlreadyAdded = getContainer('.work-item-form-header-controls-container .toggl-button').length>0;
+
+    if (isAlreadyAdded) {
+      return;
+    }
 
     const link = togglbutton.createTimerLink({
       className: 'visual-studio-online',


### PR DESCRIPTION
- Add check for already added button

## :star2: Prevent duplicates

When navigating within a parent/child structure an extra button might be added when closing the child.

## :bug: Recommendations for testing

- In the backlog view
- Open User Story or Product Backlog Item
- Add a new link to related work (eg. a new Task
- Save & Close
- Two buttons visible