### PR TITLE
fix(teamwork): Reposition Toggl Button after UI redesign

### DIFF
--- a/src/scripts/content/teamwork.js
+++ b/src/scripts/content/teamwork.js
@@ -132,8 +132,41 @@ togglbutton.render(
       description: descFunc
     });
 
-    link.style.margin = "3px 0 0 7px";
+    link.style.margin = '3px 0 0 7px';
 
     container.appendChild(link);
+  }
+);
+
+// Teamwork (July 2020)
+togglbutton.render(
+  '.task-groupHold-wrapper .task-row .row-content-holder:not(.toggl), .s-project-task__tasklist .row-content-holder:not(.toggl)',
+  { observe: true },
+  function (root) {
+    const getNameHolder = () => root.querySelector('.w-task-row__name > a');
+
+    if (!getNameHolder()) { return; }
+
+    const link = togglbutton.createTimerLink({
+      className: 'teamwork',
+      buttonType: 'minimal',
+      description: () => getNameHolder().textContent.trim()
+    });
+
+    Object.assign(link.style, {
+      backgroundSize: '16px',
+      marginTop: '7px',
+      marginLeft: '2px'
+    });
+
+    link.setAttribute('data-content', 'Toggl Button');
+
+    link.classList.add(
+      'w-task-row__option',
+      'integration--hide',
+      'tipped-delegate',
+      'show-on-mouseenter');
+
+    root.appendChild(link);
   }
 );


### PR DESCRIPTION
## :star2: What does this PR do?

There was a UI change in the Teamwork app. 
This PR fixes the integration.

The Toggl Button is visible at:

* Task list
* Single task view in side-view
* Single-page task view

## :bug: Recommendations for testing

Make sure it's visible and working in both browsers: 
![image](https://user-images.githubusercontent.com/7033216/87968824-4d252400-cac1-11ea-8531-cb74b1b5e809.png)

## :memo: Links to relevant issues or information

Closes #1716 
