### PR TITLE
style: Make continue button easier to click

### DIFF
--- a/src/scripts/components/ContinueIcon.tsx
+++ b/src/scripts/components/ContinueIcon.tsx
@@ -15,6 +15,7 @@ export default function ContinueIcon (props: { title: string }) {
 const Wrapper = styled.span`
   line-height: 0;
   padding-left: 1px;
+  position: relative;
 
   & path {
     fill: var(--font-color);
@@ -29,6 +30,8 @@ const Wrapper = styled.span`
 
 const Target = styled.div`
   position: absolute;
-  width: 12px;
-  height: 16px;
+  width: 22px;
+  left: -5px;
+  height: 26px;
+  top: -5px;
 `


### PR DESCRIPTION
This PR makes the clickable area for the continue button a little larger and fixes the mis-positioned "target" element due to the missing `position: relative;` on the parent.

Before, only the triangle of the play button was clickable. 

Now, a square area with ~5px paddings around the button is clickable. 

This doesn't interfere with the tags or billable icons that appear nearby. 