### PR TITLE
fix(toggl-plan): Extract Description & Project from the Plan event

### DIFF
--- a/src/scripts/content/toggl-plan.js
+++ b/src/scripts/content/toggl-plan.js
@@ -27,9 +27,6 @@ togglbutton.render('.task-form:not(.toggl)',
       projectName: getProjectText
     });
 
-    link.style.marginTop = '-1px';
-    link.style.marginLeft = '16px';
-
     container.parentNode.insertBefore(link, container);
   }
 );

--- a/src/scripts/content/toggl-plan.js
+++ b/src/scripts/content/toggl-plan.js
@@ -1,24 +1,35 @@
 'use strict';
 
-togglbutton.render('.task-form:not(.toggl)', { observe: true }, elem => {
-  const container = $('[data-hook=actions-menu]', elem);
+// Changed from teamweek to Toggl-Plan
+// Version active on July 2020
+togglbutton.render('.task-form:not(.toggl)',
+  { observe: true },
+  element => {
+    const container = element.querySelector('[data-hook=actions-menu]');
 
-  const getDescriptionText = () => {
-    const titleElement = $('[data-hook=name-input]', elem);
-    return titleElement ? titleElement.textContent.trim() : '';
-  };
+    const getDescriptionText = () => {
+      const titleElement = element.querySelector('[data-hook=name-editor] textarea');
+      return titleElement ? titleElement.textContent.trim() : '';
+    };
 
-  const getProjectText = () => {
-    const projectElement = $('[data-hook=project-select] [data-hook=input-label]', elem);
-    return projectElement ? projectElement.textContent.trim() : null;
-  };
+    const getProjectText = () => {
+      const planElement = element.querySelector('[data-hook=plan-editor] [data-hook=input-value]');
 
-  const link = togglbutton.createTimerLink({
-    className: 'teamweek-new',
-    buttonType: 'minimal',
-    description: getDescriptionText,
-    projectName: getProjectText
-  });
+      return planElement
+        ? planElement.textContent.trim()
+        : '';
+    };
 
-  container.parentNode.insertBefore(link, container);
-});
+    const link = togglbutton.createTimerLink({
+      className: 'toggl-plan',
+      buttonType: 'minimal',
+      description: getDescriptionText,
+      projectName: getProjectText
+    });
+
+    link.style.marginTop = '-1px';
+    link.style.marginLeft = '16px';
+
+    container.parentNode.insertBefore(link, container);
+  }
+);

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -364,14 +364,10 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
   opacity: 0 !important;
 }
 
-/********* TEAMWEEK *********/
-.toggl-button.teamweek-new {
-  color: rgba(47, 47, 47, 0.8);
-  margin-right: 10px;
-}
-
-#toggl-button-edit-form .toggl-button.teamweek-new {
-  position: static;
+/********* TOGGL-PLAN *********/
+a.toggl-button.toggl-plan {
+  margin-top: -1px;
+  margin-left: 16px;
 }
 
 /********* Produck *********/


### PR DESCRIPTION
## :star2: What does this PR do?
Fills in the description (from the Event name) and the project (from the Plan name, if available) fields in Toggl Plan TB integration.

## :bug: Recommendations for testing

* Open any Toggl Plan event
* Start a TB timer and check that the description matches the event description
* Make yourself a project that would match the plan name.
* Start a TB timer again and check that the project was automatically selected as well.
* If no project exists or a plan is not selected, the project field should be empty (no selection).

## :memo: Links to relevant issues or information

Closes #1793