### PR TITLE
fix(common): Hide text in minimal button type

### DIFF
--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -509,7 +509,10 @@ window.togglbutton = {
     }
 
     link.innerHTML = togglButtonSVG;
-    setLinkText(link, 'Start Timer');
+
+    if (params.buttonType !== 'minimal') {
+      setLinkText(link, 'Start Timer');
+    }
 
     link.addEventListener('click', function (e) {
       let opts;


### PR DESCRIPTION
## :star2: What does this PR do?
We've recently reworked button to use svg and we apparently forgot to hide `Start Timer` text from it.
In few integrations like Toggl Plan it worked by an accident but it screwed Trello checklist for example.

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

Check Trello checklists.

Before:
![image](https://user-images.githubusercontent.com/10184544/88921043-1fcd3880-d26e-11ea-9438-e2b4101d5e38.png)

After:
![image](https://user-images.githubusercontent.com/10184544/88921079-2e1b5480-d26e-11ea-981f-71c0f479cbe1.png)

Now matches our [style guide](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md#toggl-button-style-guide)

## :memo: Links to relevant issues or information

https://toggl.slack.com/archives/C9LMUPD9T/p1596045257219300
