### PR TITLE
add(Placker):Placker integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ out of the way and focus on real work.
 - [Phacility](http://phacility.com/)
 - [Pivotal](https://www.pivotaltracker.com/)
 - [Planbox](http://www.planbox.com/)
+- [Placker](http://placker.com/)
 - [Podio](https://podio.com/)
 - [ProcessWire](http://processwire.com/)
 - [Producteev](https://www.producteev.com/)

--- a/src/scripts/content/placker.js
+++ b/src/scripts/content/placker.js
@@ -1,0 +1,46 @@
+'use strict';
+/* global createTag */
+
+togglbutton.render(
+  '.plackerModal:not(.toggl)',
+  { observe: true },
+  (elem) => {
+    const interval = setInterval(function () {
+      const actionButton = $('.dialogCardHeaderOverviewComponent__bottomRight');
+
+      if (!actionButton) {
+        return;
+      }
+
+      clearInterval(interval);
+
+      const getProject = () => {
+        const project = $('.breadcrumbComponent .breadcrumbComponent__item:first-child .breadcrumbComponent__itemLink', elem);
+        return project ? project.textContent.trim() : '';
+      };
+
+      const getDescription = () => {
+        const description = $('.dialogCardHeaderOverviewComponent__titleInput', elem);
+        return description ? description.textContent.trim() : '';
+      };
+
+      const container = createTag('div', 'button-link placker-tb-wrapper');
+      const link = togglbutton.createTimerLink({
+        className: 'placker',
+        description: getDescription,
+        projectName: getProject,
+        container: '.plackerModal'
+      });
+
+      // Pass through click on placker button to the timer link
+      container.addEventListener('click', (e) => {
+        e.preventDefault();
+        link.click();
+      });
+
+      container.appendChild(link);
+      actionButton.prepend(container);
+    }, 100);
+  },
+  '.plackerModal'
+);

--- a/src/scripts/origins.js
+++ b/src/scripts/origins.js
@@ -388,6 +388,11 @@ export default {
     url: '*://*.pivotaltracker.com/*',
     name: 'PivotalTracker'
   },
+  'placker.com': {
+    url: '*://*.placker.com/*',
+    name: 'Placker',
+    file: 'placker.js'
+  },
   'planbox.com': {
     url: '*://*.planbox.com/*',
     name: 'Planbox'

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1533,8 +1533,18 @@ body.notion-body.dark .toggl-button.notion {
 }
 
 /********* LiveAgent *********/
-.toggl-button.liveagent{
+.toggl-button.liveagent {
   cursor: pointer;
   margin: 1em;
   text-Align :center;
 }
+
+/********* PLACKER *********/
+.toggl-button.placker {
+  color: rgb(115, 125, 140);
+  left: -5px;
+  font-size: 14px;
+  font-family: "Proxima Nova", sans-serif;
+  font-weight: bold;
+  position: relative;
+  top: -3px;


### PR DESCRIPTION
 - Added Toggl button to Placker card

## :star2: What does this PR do?

Added a Toggl button to the card view in Placker. Automatically assigns the name of the card as the task and matches the board name to a project if one exists.

## :bug: Recommendations for testing

Open a board in Placker, double click a card to open card view, click the Placker button.

## :memo: Links to relevant issues or information

N/A
