### PR TITLE
Add declarative integrations support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6206,7 +6206,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6227,12 +6228,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6247,17 +6250,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6374,7 +6380,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6386,6 +6393,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6400,6 +6408,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6407,12 +6416,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6431,6 +6442,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6518,7 +6530,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6530,6 +6543,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6615,7 +6629,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6651,6 +6666,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6670,6 +6686,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6713,12 +6730,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -8822,6 +8841,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
+    },
+    "mustache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.0.1.tgz",
+      "integrity": "sha512-yL5VE97+OXn4+Er3THSmTdCFCtx5hHWzrolvH+JObZnUYwuaG7XV+Ch4fR2cIrcYI0tFHxS7iyFYl14bW8y2sA=="
     },
     "mute-stream": {
       "version": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "lodash.map": "4.6.0",
     "lodash.reduce": "4.6.0",
     "moment": "2.24.0",
+    "mustache": "4.0.1",
     "nanoid": "1.2.6",
     "prop-types": "15.7.2",
     "raw-loader": "4.0.1",

--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -1,6 +1,7 @@
 import { ProjectAutoComplete, TagAutoComplete } from './lib/autocomplete';
 /* eslint-disable-next-line import/no-webpack-loader-syntax */
 import togglButtonSVG from '!!raw-loader!./icons/toggl-button.svg';
+import Mustache from 'mustache';
 const browser = require('webextension-polyfill');
 
 let projectAutocomplete; let tagAutocomplete;
@@ -164,6 +165,41 @@ window.togglbutton = {
           category: 'Content'
         });
       });
+  },
+
+  declare: function ({ elements, link }) {
+    togglbutton.render(link.observe, { observe: true }, function (elem) {
+      const keys = Object.keys(elements);
+      const vars = {};
+      keys.forEach((key) => {
+        const element = $(elements[key]);
+        if (element) {
+          vars[key] = ('' || element.textContent).trim();
+        }
+      });
+
+      let button = togglbutton.createTimerLink({
+        className: link.className,
+        buttonType: link.largeButton ? null : 'minimal',
+        description: Mustache.render(link.description, vars),
+        projectName: Mustache.render(link.projectName, vars)
+      });
+
+      if (link.linkWrapper) {
+        const wrapper = createTag(...link.linkWrapper);
+        wrapper.appendChild(button);
+        button = wrapper;
+      }
+
+      const target = $(link.target);
+      if (link.targetInsertion === 'before') {
+        target.parentNode.insertBefore(button, target);
+      } else if (link.targetInsertion === 'after') {
+        target.parentNode.insertBefore(button, target.nextSibling);
+      } else {
+        target.appendChild(button);
+      }
+    });
   },
 
   renderTo: function (selector, renderer) {

--- a/src/scripts/content/github.js
+++ b/src/scripts/content/github.js
@@ -1,65 +1,39 @@
 'use strict';
 
 // Issue and Pull Request Page
-togglbutton.render('#partial-discussion-sidebar', { observe: true }, function (
-  elem
-) {
-  const numElem = $('.gh-header-number');
-  const titleElem = $('.js-issue-title');
-  const projectElem = $('h1.public strong a, h1.private strong a');
-  const existingTag = $('.discussion-sidebar-item.toggl');
-
-  // Check for existing tag, create a new one if one doesn't exist or is not the first one
-  // We want button to be the first one because it looks different from the other sidebar items
-  // and looks very weird between them.
-
-  if (existingTag) {
-    if (existingTag.parentNode.firstChild.classList.contains('toggl')) {
-      return;
-    }
-    existingTag.parentNode.removeChild(existingTag);
-  }
-
-  let description = titleElem.textContent;
-  if (numElem !== null) {
-    description = numElem.textContent + ' ' + description.trim();
-  }
-
-  const div = document.createElement('div');
-  div.classList.add('discussion-sidebar-item', 'toggl');
-
-  const link = togglbutton.createTimerLink({
+togglbutton.declare({
+  elements: {
+    title: '.js-issue-title',
+    num: '.gh-header-number',
+    project: 'h1 strong a'
+  },
+  link: {
+    observe: '#partial-discussion-sidebar:not(.toggl)',
+    target: '.discussion-sidebar-item',
+    targetInsertion: 'before',
+    linkWrapper: ['div', 'discussion-sidebar-item toggl'],
     className: 'github',
-    description: description,
-    projectName: projectElem && projectElem.textContent
-  });
-
-  div.appendChild(link);
-  elem.prepend(div);
+    largeButton: true,
+    description: '{{#num}}{{num}} {{/num}}{{title}}',
+    projectName: '{{project}}'
+  }
 });
 
 // Project Page
-togglbutton.render('.js-project-card-details .js-comment:not(.toggl)', { observe: true }, function (
-  elem
-) {
-  const titleElem = $('.js-issue-title');
-  const numElem = $('.js-project-card-details .project-comment-title-hover span.text-gray-light');
-  const projectElem = $('h1.public strong a, h1.private strong a');
-
-  let description = titleElem.textContent;
-  if (numElem !== null) {
-    description = numElem.textContent + ' ' + description.trim();
-  }
-
-  const link = togglbutton.createTimerLink({
+togglbutton.declare({
+  elements: {
+    title: '.js-issue-title',
+    num: '.js-project-card-details .project-comment-title-hover span.text-gray-light',
+    project: 'h1 strong a'
+  },
+  link: {
+    observe: '.js-project-card-details .js-comment:not(.toggl)',
+    target: '.discussion-sidebar-item',
+    targetInsertion: 'before',
+    linkWrapper: ['div', 'discussion-sidebar-item js-discussion-sidebar-item'],
     className: 'github',
-    description: description,
-    projectName: projectElem && projectElem.textContent
-  });
-
-  const wrapper = createTag('div', 'discussion-sidebar-item js-discussion-sidebar-item');
-  wrapper.appendChild(link);
-
-  const target = $('.discussion-sidebar-item');
-  target.parentNode.insertBefore(wrapper, target);
+    largeButton: true,
+    description: '{{#num}}{{num}} {{/num}}{{title}}',
+    projectName: '{{project}}'
+  }
 });

--- a/src/scripts/content/toggl-plan.js
+++ b/src/scripts/content/toggl-plan.js
@@ -2,31 +2,17 @@
 
 // Changed from teamweek to Toggl-Plan
 // Version active on July 2020
-togglbutton.render('.task-form:not(.toggl)',
-  { observe: true },
-  element => {
-    const container = element.querySelector('[data-hook=actions-menu]');
-
-    const getDescriptionText = () => {
-      const titleElement = element.querySelector('[data-hook=name-editor] textarea');
-      return titleElement ? titleElement.textContent.trim() : '';
-    };
-
-    const getProjectText = () => {
-      const planElement = element.querySelector('[data-hook=plan-editor] [data-hook=input-value]');
-
-      return planElement
-        ? planElement.textContent.trim()
-        : '';
-    };
-
-    const link = togglbutton.createTimerLink({
-      className: 'toggl-plan',
-      buttonType: 'minimal',
-      description: getDescriptionText,
-      projectName: getProjectText
-    });
-
-    container.parentNode.insertBefore(link, container);
+togglbutton.declare({
+  elements: {
+    title: '[data-hook=name-editor] textarea',
+    plan: '[data-hook=plan-editor] [data-hook=input-value]'
+  },
+  link: {
+    observe: '.task-form:not(.toggl)',
+    target: '[data-hook=actions-menu]',
+    targetInsertion: 'before',
+    className: 'toggl-plan',
+    description: '{{title}}',
+    projectName: '{{plan}}'
   }
-);
+});


### PR DESCRIPTION
## :star2: What does this PR do?

🚀  Adds declarative integrations support
:octocat: Refactors the Github integration to use the declarative style.
👼 Refactors the Toggl Plan integration to use the declarative style.
🌈  As a bonus, it'll also fix the automatic project selection in Github.
⚠️ There's no support for auto-filling tags yet, just description and project!

NB: I'm quite aware this will not work for all integrations, but it should work for most of them. If you're still skeptical I can include a couple more tools in this PR before it goes in. ☀️ 

## :bug: Recommendations for testing

:octocat: Make sure the Github integration still works properly:
- Open any standalone issue. The button should appear above the assignee.
- Open a project board and click an issue. The button should appear inside the issue details view at the right of the screen.
- Start an entry in each view and make sure the description and the project are filled correctly.

👼 Make sure the Toggl Plan integration still works properly:
- Open any task. The button should appear at the top of the modal.
- Start an entry and make sure the description and the project are filled correctly.

All changes should be tested across Chrome and Firefox.

## :memo: Links to relevant issues or information

Closes #1141 
