### PR TITLE
fix(dark-mode): Dark-Mode project-list improved hover contrast

### DIFF
--- a/src/styles/autocomplete.css
+++ b/src/styles/autocomplete.css
@@ -28,6 +28,11 @@
   outline: 0;
 }
 
+#project-autocomplete li:not(.ws-row):not(.client-row):hover {
+  background-color: var(--main-bg-color);
+  border-radius:0px;
+}
+
 #project-autocomplete li.selected-project {
   background-color: rgba(74,199,0,.12);
   color: #4bc800!important;


### PR DESCRIPTION
## :star2: What does this PR do?

- Adds hover background to project list
- adds unique selector below to not interrupt other selectors.
- I tried adding light border as well; however, decided against it as I wanted to keep this simple and direct unless asked to do otherwise.

<!-- A Concise description of what this PR achieves, including any context. -->

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

## :bug: Recommendations for testing

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

This was tested in Chrome and Firefox and works fine

To reproduce, open the toggle button, tap on a task, select to choose a project, move mouse over project list options.

### Previous Behavior
Cursor would change, but no change to bg-color.

### Current Behavior
bg-color for project name changes to `var(--main-bg-color);` for consistency across themes.

### Chrome
<img width="377" alt="Screen Shot 2020-08-23 at 8 12 37 PM" src="https://user-images.githubusercontent.com/26221344/90994943-f7d8a880-e57f-11ea-95ac-43e0110e7b81.png">

### Firefox 
<img width="467" alt="Screen Shot 2020-08-23 at 8 23 37 PM" src="https://user-images.githubusercontent.com/26221344/90994956-032bd400-e580-11ea-9130-d72012c7722d.png">


## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
issue #1813 requested this fix.
feat(dark-mode) #1769 was the original PR for adding dark-theme feature. 