### PR TITLE
fix(pomodoro): Improve pomdoro timer sync on new TEs

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -397,12 +397,13 @@ window.TogglButton = {
       TogglButton.localEntry.id === entry.id;
 
     TogglButton.$curEntry = entry;
+
     if (entry) {
-      if (update) {
-        TogglButton.checkPomodoroAlarm(entry);
-        clearTimeout(TogglButton.$nannyTimer);
-        TogglButton.$nannyTimer = null;
-      } else {
+      TogglButton.checkPomodoroAlarm(entry);
+      clearTimeout(TogglButton.$nannyTimer);
+      TogglButton.$nannyTimer = null;
+
+      if (!update) {
         browser.browserAction.setIcon({
           path: { '19': 'images/icon-19.png', '38': 'images/icon-38.png' }
         });
@@ -688,43 +689,58 @@ window.TogglButton = {
     return timeEntries[timeEntries.length - 1];
   },
 
-  checkPomodoroAlarm: async function (entry) {
+  checkPomodoroAlarm: function (entry) {
     const duration = new Date() - new Date(entry.start);
-    TogglButton.pomodoroInterval = await db.get('pomodoroInterval');
-    TogglButton.pomodoroFocusMode = await db.get('pomodoroFocusMode');
-    const interval = parseInt(TogglButton.pomodoroInterval, 10) * 60000;
-    if (duration < interval) {
-      TogglButton.triggerPomodoroAlarm(interval - duration);
-    }
+    TogglButton.triggerPomodoroAlarm(duration);
   },
 
-  triggerPomodoroAlarm: async function (value) {
+  triggerPomodoroAlarm: async function (duration) {
     if (TogglButton.pomodoroAlarm !== null) {
       clearTimeout(TogglButton.pomodoroAlarm);
       TogglButton.pomodoroAlarm = null;
       clearInterval(TogglButton.pomodoroProgressTimer);
     }
+
     const pomodoroModeEnabled = await db.get('pomodoroModeEnabled');
+    const intervalSetting = await db.get('pomodoroInterval');
+
     if (pomodoroModeEnabled) {
+      let updateProgress;
       TogglButton.startTicker();
-      const intervalSetting = await db.get('pomodoroInterval');
+      TogglButton.pomodoroFocusMode = await db.get('pomodoroFocusMode');
       const pomodoroInterval = parseInt(intervalSetting, 10) * 60000;
-      const interval = value || pomodoroInterval;
-      const steps = 120;
-      const elapsedTime = (pomodoroInterval - interval) / pomodoroInterval;
-      const updateProgress = TogglButton.updatePomodoroProgress(
-        interval,
-        steps,
-        elapsedTime
-      );
-      TogglButton.pomodoroAlarm = setTimeout(
-        TogglButton.pomodoroAlarmStop,
-        interval
-      );
-      TogglButton.pomodoroProgressTimer = setInterval(
-        updateProgress,
-        pomodoroInterval / steps
-      );
+      TogglButton.pomodoroInterval = pomodoroInterval;
+
+      if (duration > pomodoroInterval) {
+        clearTimeout(TogglButton.pomodoroAlarm);
+        TogglButton.pomodoroAlarm = null;
+        clearInterval(TogglButton.pomodoroProgressTimer);
+        updateProgress = TogglButton.updatePomodoroProgress(
+          0,
+          0,
+          0
+        );
+      } else {
+        const value = pomodoroInterval - duration;
+        const interval = value || pomodoroInterval;
+        const steps = 120;
+        const elapsedTime = (pomodoroInterval - interval) / pomodoroInterval;
+        TogglButton.pomodoroInterval = intervalSetting;
+        updateProgress = TogglButton.updatePomodoroProgress(
+          interval,
+          steps,
+          elapsedTime
+        );
+        TogglButton.pomodoroAlarm = setTimeout(
+          TogglButton.pomodoroAlarmStop,
+          interval
+        );
+        TogglButton.pomodoroProgressTimer = setInterval(
+          updateProgress,
+          pomodoroInterval / steps
+        );
+      }
+
       browser.runtime.sendMessage(renderTimeEntries());
       updateProgress();
     }


### PR DESCRIPTION
## :star2: What does this PR do?
Improve Pomodoro timer sync when creating TEs on other apps/API. The Pomodoro timer should restart when getting new TEs from other services/API

## :bug: Recommendations for testing
- Turn on Pomodoro 
- I would suggest setting a small interval so you can see the animation better
- Start a new using the extension
- After a few minutes (before the Pomodoro ends) make an API call to start a new running TE.
- The extension should change the running TE to newly created one and set the Pomodoro state based on the current duration of the new TE. 
- If the new TE has a duration already bigger than the Pomodoro interval than the animation should go back to 0% and no alarm should trigger 

#### Sanity check
- Check if Pomodoro still working as expected when only using the extension 
- Updating the duration of TEs should also remove the timer if the new duration is bigger than the interval settings

## :memo: Links to relevant issues or information

close #1801 related #1768
