### PR TITLE
Improve contrast for project/tag selection

### DIFF
--- a/src/styles/autocomplete.css
+++ b/src/styles/autocomplete.css
@@ -29,13 +29,9 @@
 }
 
 #project-autocomplete li:not(.ws-row):not(.client-row):hover {
-  background-color: var(--main-bg-color);
+  color: var(--active-font-color);
+  background-color: var(--hover-selection);
   border-radius:0px;
-}
-
-#project-autocomplete li.selected-project {
-  background-color: rgba(74,199,0,.12);
-  color: #4bc800!important;
 }
 
 #project-autocomplete ul {
@@ -129,6 +125,12 @@
   text-overflow: ellipsis;
   color: var(--font-color);
 }
+li:hover span.item-name,
+li:hover span.task-count,
+li.selected-project span.item-name,
+li.selected-project span.task-count {
+  color: var(--active-font-color) !important;
+}
 
 /* PROJECT BULLETS */
 
@@ -186,13 +188,15 @@
 }
 
 #tag-autocomplete .tag-list li:hover {
-  background-color: rgba(0, 0, 0, 0.05);
+  color: var(--active-font-color);
+  background-color: var(--hover-selection);
   cursor: pointer;
 }
 
+#project-autocomplete li.selected-project,
 #tag-autocomplete .tag-list li.selected-tag {
-  background-color: rgba(75, 200, 0, 0.12);
-  color: #4bc800;
+  background-color: var(--active-selection);
+  color: var(--active-font-color) !important;
 }
 
 .tag-clear {
@@ -283,8 +287,8 @@
 }
 
 .selected-task {
-  background-color: rgba(75, 200, 0, 0.12);
-  color: #4bc800;
+  background-color: var(--active-selection);
+  color: var(--active-font-color);
 }
 
 .filtered .tasklist-opened.filter li.task-item {

--- a/src/styles/colours.css
+++ b/src/styles/colours.css
@@ -15,6 +15,16 @@
   --pink: #DD6FD1;
   --light-pink: #E57CD8;
 
+  --pink-20: #FAE5F7;
+  --pink-30: #F7D8F3;
+
   --dark-purple: #412a4c;
   --darker-purple: #0a040c;
+  --dark-purple-10: #EAE7EB;
+  --dark-purple-20: #D5D0D7;
+  --dark-purple-60: #817187;
+  --dark-purple-70: #6b5a74;
+  --dark-purple-80: #564260;
+
+  --peach: #fefbfa;
 }

--- a/src/styles/popup.css
+++ b/src/styles/popup.css
@@ -12,6 +12,10 @@ body {
   --border-color: var(--extra-light-grey);
   --font-color: var(--another-black);
   --danger-color: var(--red);
+
+  --active-font-color: var(--dark-purple);
+  --hover-selection: var(--dark-purple-10);
+  --active-selection: var(--pink-30);
 }
 
 body.dark {
@@ -21,6 +25,10 @@ body.dark {
   --border-color: var(--dark-grey);
   --font-color: var(--lighter-grey);
   --danger-color: var(--red-on-dark);
+
+  --active-font-color: var(--peach);
+  --hover-selection: var(--dark-purple-60);
+  --active-selection: var(--dark-purple-80);
 }
 
 html, body {


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

<!-- A Concise description of what this PR achieves, including any context. -->

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

- Continuation of work from @devnetkc 
- Replace green/gray with rebrand pink/purple in the project/tag popdown


## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

#### Dark Mode

![image](https://user-images.githubusercontent.com/1716853/92452472-b846c900-f1db-11ea-99bd-e65115b87cb3.png)

![image](https://user-images.githubusercontent.com/1716853/92452427-a9f8ad00-f1db-11ea-8fe1-8dc91b914d7b.png)


#### Light Mode

![image](https://user-images.githubusercontent.com/1716853/92452042-2b037480-f1db-11ea-95ac-61424715bd39.png)
![image](https://user-images.githubusercontent.com/1716853/92451975-10c99680-f1db-11ea-8632-730304e653da.png)

## :memo: Links to relevant issues or information

Related #1813

<!-- Link to relevant issues, comments, etc. -->
