### PR TITLE
fix(notion): Remove Toggl Button from default description

### DIFF
--- a/src/scripts/content/notion.js
+++ b/src/scripts/content/notion.js
@@ -35,7 +35,8 @@ togglbutton.render(
     elem.style.position = 'relative';
 
     function getDescription () {
-      const descriptionElem = elem;
+      const descriptionElem = elem ? elem.querySelector('div[data-root="true"]') : '';
+
       return descriptionElem ? descriptionElem.textContent.trim() : '';
     }
 


### PR DESCRIPTION
## :star2: What does this PR do?
Remove the Toggl Button prefix from the auto description when starting a new time entry

## :bug: Recommendations for testing
- Go to Notion
- Use the button next to the document title to start a new TE
- Description should not contain `Toggl Button`

## :memo: Links to relevant issues or information

close #1845
