### PR TITLE
fix(timer): Stop current time entry before starting

### DIFF
--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -543,8 +543,11 @@ window.togglbutton = {
         };
       }
       togglbutton.element = e.currentTarget;
+
       browser.runtime
-        .sendMessage(opts)
+        // Stop current time entry before starting a new one
+        .sendMessage({ type: 'stop' })
+        .then(() => browser.runtime.sendMessage(opts))
         .then(togglbutton.addEditForm);
 
       return false;


### PR DESCRIPTION
## :star2: What does this PR do?
Stop current time entry before starting a new one to avoid issues with time entry constraints

## :bug: Recommendations for testing
- Set some constraints to create time entries first
- Now go and create a new Time Entry using the button
- Try to start a new one without stopping the current one
- The first TE should stop and a new one should start 👍 

## :memo: Links to relevant issues or information
close #1846
