### PR TITLE
Add $$ for querySelectorAll helper

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,7 @@ module.exports = {
   extends: ['standard', 'plugin:react/recommended'],
   plugins: ['react'],
   globals: {
+    $$: false,
     $: false
   },
   rules: {

--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -10,6 +10,11 @@ window.$ = (s, elem) => {
   return elem.querySelector(s);
 };
 
+window.$$ = (s, elem) => {
+  elem = elem || document;
+  return elem.querySelectorAll(s);
+};
+
 window.createTag = (name, className, textContent) => {
   const tag = document.createElement(name);
   tag.className = className;


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

This adds `$$` global selector do perform `document.querySelectorAll` simlarly to `$` being alias to `document.querySelector`

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

For example, this PR could take advantage of the shortcut: https://github.com/toggl/toggl-button/pull/1878