### PR TITLE
chore(toggl-plan): Use additional data-attr selector to inject

### DIFF
--- a/src/scripts/content/toggl-plan.js
+++ b/src/scripts/content/toggl-plan.js
@@ -2,7 +2,7 @@
 
 // Changed from teamweek to Toggl-Plan
 // Version active on July 2020
-togglbutton.render('.task-form:not(.toggl)',
+togglbutton.render('.task-form[data-track-inject-button]:not(.toggl)',
   { observe: true },
   element => {
     const container = element.querySelector('[data-hook=actions-menu]');


### PR DESCRIPTION

## :star2: What does this PR do?
Plan has now their own integration with Track, so we must disable button if it's enabled on their side.

## :bug: Recommendations for testing
Just verify if it still injects properly on Plan. You can also create two elements (one with `data-track-inject-button` attr) and verify selector.

## :memo: Links to relevant issues or information
See: https://toggl.slack.com/archives/C0198AEAZ7T/p1605003706176300
