### PR TITLE
Updated for OpenProject 11.1

### DIFF
--- a/src/scripts/content/openproject.js
+++ b/src/scripts/content/openproject.js
@@ -6,7 +6,7 @@ togglbutton.render(
   { observe: true },
   function (elem) {
     const workPackageId = $('.work-packages--info-row > span:first-of-type').textContent.trim();
-    const container = $('#toolbar-items', elem);
+    const container = $('.toolbar-items', elem);
     const description = '[OP' + workPackageId + '] ' + $('.subject').textContent.trim();
     const projectName = $('#projects-menu').title.trim();
 

--- a/src/scripts/content/openproject.js
+++ b/src/scripts/content/openproject.js
@@ -6,7 +6,7 @@ togglbutton.render(
   { observe: true },
   function (elem) {
     const workPackageId = $('.work-packages--info-row > span:first-of-type').textContent.trim();
-    const container = $('.attributes-group--header', elem);
+    const container = $('#toolbar-items', elem);
     const description = '[OP' + workPackageId + '] ' + $('.subject').textContent.trim();
     const projectName = $('#projects-menu').title.trim();
 
@@ -16,6 +16,6 @@ togglbutton.render(
       projectName: projectName
     });
 
-    container.appendChild(link);
+    container.prepend(link);
   }
 );

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1088,7 +1088,7 @@ li > .toggl-button.phabricator {
 
 /********* OPENPROJECT *********/
 .work-packages--show-view .toggl-button.openproject {
-  margin-bottom: 0.4rem;
+  margin: 0.4rem;
 }
 
 /********* ZUBE *********/

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1089,6 +1089,7 @@ li > .toggl-button.phabricator {
 /********* OPENPROJECT *********/
 .work-packages--show-view .toggl-button.openproject {
   margin: 0.4rem;
+  margin-right: 10px;
 }
 
 /********* ZUBE *********/


### PR DESCRIPTION
## :star2: What does this PR do?

OpenProject 11.1 updated the work package detail page, removing the description heading that was previously used to show the toggl button. This PR moves the toggle button to the toolbar at the top of the work package page, keeping compatability with OP < 11.1, while also gaining compatability with future versions. I also think this generally is a better place for the button, as it is closer to where OP's built-in timetracking features are also presented.

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

## :memo: Links to relevant issues or information

https://github.com/opf/openproject/releases/tag/v11.1.0
