### PR TITLE
fix(todoist): Fix todoist project population

### DIFF
--- a/src/scripts/content/todoist.js
+++ b/src/scripts/content/todoist.js
@@ -52,7 +52,9 @@ togglbutton.render(
     let project = '';
     const projectId = rootEl.getAttribute('data-item-id');
 
-    if (document.getElementById(`item_${projectId}`)) {
+    if (document.querySelector('.project_view h1 span.simple_content')) {
+      project = document.querySelector('.project_view h1 span.simple_content').textContent.trim();
+    } else if (document.getElementById(`item_${projectId}`)) {
       // (legacy?) project ID element
       const projectContent = document.getElementById(`item_${projectId}`).querySelector('.content');
       project = getProjectNames(projectContent);


### PR DESCRIPTION
## :star2: What does this PR do?

Fixes project field not populating on Todoist integration.

## :bug: Recommendations for testing

* First make sure there's a project in Todoist that has the same name as a Toggl project

Try two different things:

* Open the project page and create a task. See if starting a time entry based on that task populates the project by the same name. (this is the one that is fixed by this PR)
* Create a task in a project and schedule it for today. Then open the upcoming/today page and check whether starting a TE on that page will pick up the project name correctly (it's a different DOM). This used to work even before this PR and you need to verify that it still does.

## :memo: Links to relevant issues or information
Closes #1856