### PR TITLE
fix(youtrack): Fix task description from agile board (closes #1797)

### DIFF
--- a/src/scripts/content/youtrack.js
+++ b/src/scripts/content/youtrack.js
@@ -52,8 +52,8 @@ togglbutton.render('.yt-agile-card:not(.toggl)', { observe: true }, function (
   const projectName = $('.yt-issue-id').textContent.split('-');
 
   const description = function () {
-    const text = $('.yt-agile-card__summary', elem).textContent;
-    const id = $('.yt-agile-card__id ', elem).textContent;
+    const text = $('.yt-agile-card__summary', elem).children[1].textContent;
+    const id = $('.yt-agile-card__id', elem).textContent;
     return (id ? id + ' ' : '') + (text ? text.trim() : '');
   };
 


### PR DESCRIPTION
## :star2: What does this PR do?

This PR fixes the task description when starting a task from youtrack's agile board. Currently the description layout is <code>A-1337 A-1337Task name &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Toggl Button</code>, while it should be just `A-1337 Task name`.

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox. As mentioned in #1797 it should be tested multiple times, since Toggle Track adds sometimes another (pre-PR conflicting) html container.

## :memo: Links to relevant issues or information

#1797
