### PR TITLE
fix(jira): Make button ready for new issue view

### DIFF
--- a/src/scripts/content/atlassian.js
+++ b/src/scripts/content/atlassian.js
@@ -37,8 +37,17 @@ togglbutton.render(
   '#jira-issue-header:not(.toggl)',
   { observe: true },
   function (elem) {
-    const container = elem.querySelector('[class^=BreadcrumbsContainer]');
-    const issueNumberElement = container.lastElementChild;
+    const issueWrapper = elem.querySelector('.issue_view_permalink_button_wrapper');
+    let issueNumberElement;
+    let container;
+
+    if (issueWrapper) {
+      issueNumberElement = issueWrapper.previousElementSibling;
+      container = issueWrapper.parentElement.parentElement;
+    } else {
+      container = elem.querySelector('[class^=BreadcrumbsContainer]');
+      issueNumberElement = container.lastElementChild;
+    }
 
     if (container.querySelector('.toggl-button')) {
       // We're checking for existence of the button as re-rendering in Jira SPA is not reliable for our uses.
@@ -87,7 +96,7 @@ const getDescription = (issueNumberElement) => () => {
 };
 
 function getProject () {
-  let project = '';
+  const project = '';
   let projectElement;
 
   // Best effort to find the "Project switcher" found in the sidebar of most pages, and extract
@@ -97,7 +106,14 @@ function getProject () {
   if (!projectElement) projectElement = $('a[href^="/browse/"][target=_self]');
 
   if (projectElement) {
-    project = projectElement.textContent.trim();
+    return projectElement.textContent.trim();
+  }
+
+  projectElement = $('[data-test-id="issue.views.issue-base.foundation.breadcrumbs.breadcrumb-current-issue-container"]');
+
+  if (projectElement) {
+    const projectWrapper = projectElement.previousElementSibling;
+    return projectWrapper.querySelector('a > span:last-child').textContent.trim();
   }
 
   return project;


### PR DESCRIPTION
## :star2: What does this PR do?
Make extension ready for new Issue View mode on Jira. The new feature will be fully released on March 31 but we already have some users using it so let's make it compatible 💪 

## :bug: Recommendations for testing
- Go to Jira
- `<domain>/secure/ViewPersonalSettings.jspa`
- Jira Labs, allow new Issue view mode
- Check if the button still showing 

### Regression
- Go to Jira
- With the old view mode, check if the button still working


## :memo: Links to relevant issues or information
closes #1913