### PR TITLE
fix(jira): Getting Issue and Project name from new view 

### DIFF
--- a/src/scripts/content/atlassian.js
+++ b/src/scripts/content/atlassian.js
@@ -42,7 +42,7 @@ togglbutton.render(
     let container;
 
     if (issueWrapper) {
-      issueNumberElement = issueWrapper.previousElementSibling || issueWrapper.querySelector('.issue_view_permalink_button_wrapper').previousElementSibling;
+      issueNumberElement = issueWrapper.querySelector('.issue_view_permalink_button_wrapper').previousElementSibling;
       container = issueWrapper.parentElement.parentElement;
     } else {
       container = elem.querySelector('[class^=BreadcrumbsContainer]');
@@ -113,11 +113,11 @@ function getProject () {
     return projectElement.textContent.trim();
   }
 
-  projectElement = $('[data-testid="rapidboard-breadcrumbs"]') || $('[data-test-id="rapidboard-breadcrumbs"]');
+  projectElement = $('[data-testid="rapidboard-breadcrumbs"] a[href*="browse"] span') || $('[data-test-id="rapidboard-breadcrumbs"] a[href*="browse"] span');
 
   if (projectElement) {
     try {
-      return projectElement.children[0].firstElementChild.children[1].querySelector('span').textContent.trim();
+      return projectElement.textContent.trim();
     } catch (e) {
       return '';
     }

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -258,7 +258,7 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
   margin-left: 8px;
   margin-top: 0;
   position: relative; /* margin interferes with Jira layout, using relative pos instead */
-  top: 2px;
+  top: 0;
   cursor: pointer;
 }
 


### PR DESCRIPTION
## :star2: What does this PR do?
Fix code to get the correct Issue number and Project not matter the view mode

## :bug: Recommendations for testing
All tests need to be done on Board view and Single page view

- Check if we get the issue number when an issue is part of an Epic
- Check if we get the project name when an issue is part of an Epic

### Regression
- Check if we get the issue number correct no matter if part of a project or not
- Check if things are still working on old view mode, you can turn it on/off on "Personal Settings"

## :memo: Links to relevant issues or information
closes #1918
