### PR TITLE
fix(common): Update button state when closing the form

### DIFF
--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -358,6 +358,7 @@ window.togglbutton = {
       projectAutocomplete.closeDropdown();
       tagAutocomplete.closeDropdown();
       editForm.style.display = 'none';
+      togglbutton.queryAndUpdateTimerLink();
     };
 
     const submitForm = function (that) {


### PR DESCRIPTION
## :star2: What does this PR do?

Update button state when closing the form directly instead of waiting for focus event so we can avoid issues with other
event listeners from the page.

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

- Create a ZenDesk trial account
- After you're done, access an example ticket
- Now try to start new entries and check if the button state is always the expected when starting/stopping time entries.

## :memo: Links to relevant issues or information

close #1904
