### PR TITLE
Fix "first-child" pseudo class error by applying styles directly to t…

### DIFF
--- a/src/scripts/components/Timer.tsx
+++ b/src/scripts/components/Timer.tsx
@@ -103,13 +103,6 @@ const TimerContainer = styled.div`
   box-shadow: var(--border-color) 0px -1px 0px 0px inset;
   background: var(--base-color);
 
-  > div:first-child {
-    flex: 1;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    overflow: hidden;
-  }
-
   > div:last-child {
     display: flex;
     align-items: center;
@@ -118,6 +111,10 @@ const TimerContainer = styled.div`
 
 const RunningTimerDescription = styled.div`
   margin-left: 10px;
+  flex: 1;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
 `
 
 const TimerInput = styled.input`


### PR DESCRIPTION
## :star2: What does this PR do?

Fix the error thrown by Emotion JS when using `:first-child` pseudo class selector.

The error stems from the `RunningTimerDescription` component inside the `Timer` component.

![first-child-pseudo-class](https://user-images.githubusercontent.com/28924121/113683249-2ca00700-96ee-11eb-9af1-3ea5dd29376e.png)

The `RunningTimerDescription` component, denoted by the smaller rectangle with orange stroke, is targeted via `>div:first-child`. However, this component uses Emotion JS, which sometimes inject a `<style>` element as the first child of an element, making the `:first-child` rule vulnerable to break.

Hence, I removed the `>div::first-child` rule and applied CSS properties directly to the `RunningTimerDescription`.

## :bug: Recommendations for testing
1. Install the extension in development mode following the README file.
2. Leave the Chrome and Firefox Extension Management page open.
3. Click the extension button to open the popup.
4. Go back to each Extension Management page and you should see no error warning regarding `:first-child` selector.
5. In the popup, type anything in the Input field of the `Timer` component and press Enter key or click the Stop button next to it. The input field will turn into the `RunningTimerDescription` and all the styling remain the same as before.

## :memo: Links to relevant issues or information

https://github.com/toggl/toggl-button/issues/1934
