### PR TITLE
Bugsnag spring cleaning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1109,24 +1109,45 @@
       }
     },
     "@bugsnag/browser": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-6.0.0.tgz",
-      "integrity": "sha512-EZ+I9CscLLkCsPdY8+X47yAjb7n/qWdLx299GNdW53/D4pO2Yo2sKCE53flyUx5BtR9yfE1Yu1vCojq89uKq7w=="
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-7.9.2.tgz",
+      "integrity": "sha512-vD0UEpInqoOWxqSdXhDN7wbt8hUnaqmHF/nyQK6pVYlPmBOaseexwjGBWQ1BCa4QWwK1CDDBy6sS9onUvWKsnw==",
+      "requires": {
+        "@bugsnag/core": "^7.9.2"
+      }
+    },
+    "@bugsnag/core": {
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-7.9.2.tgz",
+      "integrity": "sha512-iz18qkEhrF0Bra0lpEP4VC0EJa48R+3QDDiTtfHW9fiZGKw+ADrUhwW7pHJn+LDqWfq4kMqJNuQC+8s4dV3MYg==",
+      "requires": {
+        "@bugsnag/cuid": "^3.0.0",
+        "@bugsnag/safe-json-stringify": "^6.0.0",
+        "error-stack-parser": "^2.0.3",
+        "iserror": "0.0.2",
+        "stack-generator": "^2.0.3"
+      }
+    },
+    "@bugsnag/cuid": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/cuid/-/cuid-3.0.0.tgz",
+      "integrity": "sha512-LOt8aaBI+KvOQGneBtpuCz3YqzyEAehd1f3nC5yr9TIYW1+IzYKa2xWS4EiMz5pPOnRPHkyyS5t/wmSmN51Gjg=="
     },
     "@bugsnag/js": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-6.0.0.tgz",
-      "integrity": "sha512-tF1D7hjhG8aXPk5rx23rDo0j7ZrIjuRSTcgkvD0mJX6cg3f1+qqXL2GlUMQ1siSx6hvNONTr3Q7SnlhEEQ1G6A==",
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-7.9.2.tgz",
+      "integrity": "sha512-RkajX7cnlYKm4uWclf4oQKZL69A9Vo5jNyQiE7u8uFXhotHoDyHi5QLkdHOSIOZHkBGkgoRV9tkbPAJKcnJSuQ==",
       "requires": {
-        "@bugsnag/browser": "^6.0.0",
-        "@bugsnag/node": "^6.0.0"
+        "@bugsnag/browser": "^7.9.2",
+        "@bugsnag/node": "^7.9.2"
       }
     },
     "@bugsnag/node": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@bugsnag/node/-/node-6.0.0.tgz",
-      "integrity": "sha512-TUsX8N9Dzpxisfml8n6LmMyo2YdjItJ5A3RoIVokZ8qBHbFXp3lQmtvp5nTVQc/buL42hFW2+ZPWxcNRQUDcEA==",
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@bugsnag/node/-/node-7.9.2.tgz",
+      "integrity": "sha512-e+tEyUBQ6e5z4WJlPAi962rnbR0f+0wxPjSoUHV5uVFg5Dkjg3ioXDdzKVbxfOEv3nVpXlMD8DrQqYe5g0O6sA==",
       "requires": {
+        "@bugsnag/core": "^7.9.2",
         "byline": "^5.0.0",
         "error-stack-parser": "^2.0.2",
         "iserror": "^0.0.2",
@@ -1144,6 +1165,11 @@
           }
         }
       }
+    },
+    "@bugsnag/safe-json-stringify": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/safe-json-stringify/-/safe-json-stringify-6.0.0.tgz",
+      "integrity": "sha512-htzFO1Zc57S8kgdRK9mLcPVTW1BY2ijfH7Dk2CeZmspTWKdKqSo1iwmqrq2WtRjFlo8aRZYgLX0wFrDXF/9DLA=="
     },
     "@emotion/cache": {
       "version": "10.0.9",
@@ -6071,11 +6097,11 @@
       }
     },
     "error-stack-parser": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.2.tgz",
-      "integrity": "sha512-E1fPutRDdIj/hohG0UpT5mayXNCxXP9d+snxFsPU9X0XgccOumKraa3juDMwTUyi7+Bu5+mCGagjg4IYeNbOdw==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
+      "integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
       "requires": {
-        "stackframe": "^1.0.4"
+        "stackframe": "^1.1.1"
       }
     },
     "es-abstract": {
@@ -16176,17 +16202,17 @@
       }
     },
     "stack-generator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.3.tgz",
-      "integrity": "sha512-kdzGoqrnqsMxOEuXsXyQTmvWXZmG0f3Ql2GDx5NtmZs59sT2Bt9Vdyq0XdtxUi58q/+nxtbF9KOQ9HkV1QznGg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.5.tgz",
+      "integrity": "sha512-/t1ebrbHkrLrDuNMdeAcsvynWgoH/i4o8EGGfX7dEYDoTXOYVAkEpFdtshlvabzc6JlJ8Kf9YdFEoz7JkzGN9Q==",
       "requires": {
-        "stackframe": "^1.0.4"
+        "stackframe": "^1.1.1"
       }
     },
     "stackframe": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.0.4.tgz",
-      "integrity": "sha512-to7oADIniaYwS3MhtCa/sQhrxidCCQiF/qp4/m5iN3ipf0Y7Xlri0f6eG29r08aL7JYl8n32AF3Q5GYBZ7K8vw=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
+      "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA=="
     },
     "staged-git-files": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "webpack-log": "2.0.0"
   },
   "dependencies": {
-    "@bugsnag/js": "6.0.0",
+    "@bugsnag/js": "7.9.2",
     "@emotion/core": "10.0.10",
     "@emotion/styled": "10.0.10",
     "date-fns": "1.30.1",

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -246,11 +246,11 @@ window.TogglButton = {
               TogglButton.setCanSeeBillable();
               ga.reportOs();
             } else {
-              bugsnagClient.notify(new Error(`Fetch user failed ${xhr.status}`), {
-                metaData: {
+              bugsnagClient.notify(new Error(`Fetch user failed ${xhr.status}`), evt => {
+                evt.addMetadata('general', {
                   status: xhr.status,
                   responseText: xhr.responseText
-                }
+                });
               });
               TogglButton.setBrowserActionBadge();
               resolve({
@@ -283,9 +283,9 @@ window.TogglButton = {
 
   updateBugsnag: function () {
     // Set user data
-    bugsnagClient.user = {
+    bugsnagClient.setUser({
       id: TogglButton.$user.id
-    };
+    });
   },
 
   setCanSeeBillable: function () {
@@ -316,7 +316,7 @@ window.TogglButton = {
     try {
       TogglButton.websocket.socket = new WebSocket('wss://stream.toggl.com/ws');
     } catch (error) {
-      bugsnagClient.notify(error, { context: 'websocket' });
+      bugsnagClient.notify(error, evt => { evt.context = 'websocket'; });
       TogglButton.retryWebsocketConnection();
       return;
     }
@@ -336,7 +336,7 @@ window.TogglButton = {
         return TogglButton.websocket.socket.send(data);
       } catch (error) {
         if (process.env.DEBUG) console.log(error);
-        bugsnagClient.notify(error, { context: 'websocket' });
+        bugsnagClient.notify(error, evt => { evt.context = 'websocket'; });
       }
     };
 
@@ -365,7 +365,7 @@ window.TogglButton = {
           TogglButton.websocket.socket.send(pingResponse);
         } catch (error) {
           if (process.env.DEBUG) console.log(error);
-          bugsnagClient.notify(error, { context: 'websocket' });
+          bugsnagClient.notify(error, evt => { evt.context = 'websocket'; });
         }
       }
     };
@@ -1236,8 +1236,8 @@ window.TogglButton = {
       const { api_token: apiToken } = parsedResponse.data;
       localStorage.setItem('userToken', apiToken);
     } catch (err) {
-      bugsnagClient.notify(new Error('Login token-parse failed'), {
-        metaData: { response }
+      bugsnagClient.notify(new Error('Login token-parse failed'), evt => {
+        evt.addMetadata({ general: { response } });
       });
     }
   },
@@ -1260,11 +1260,13 @@ window.TogglButton = {
             if (xhr.status === 403) {
               error = 'Wrong Email or Password!';
             }
-            bugsnagClient.notify(new Error(`Login failed (${xhr.status})`), {
-              metaData: {
-                status: xhr.status,
-                responseText: xhr.responseText
-              }
+            bugsnagClient.notify(new Error(`Login failed (${xhr.status})`), evt => {
+              evt.addMetadata({
+                general: {
+                  status: xhr.status,
+                  responseText: xhr.responseText
+                }
+              });
             });
             resolve({ success: false, error: error });
           }

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -246,12 +246,14 @@ window.TogglButton = {
               TogglButton.setCanSeeBillable();
               ga.reportOs();
             } else {
-              bugsnagClient.notify(new Error(`Fetch user failed ${xhr.status}`), evt => {
-                evt.addMetadata('general', {
-                  status: xhr.status,
-                  responseText: xhr.responseText
+              if (xhr.status !== 403) {
+                bugsnagClient.notify(new Error(`Fetch user failed ${xhr.status}`), evt => {
+                  evt.addMetadata('general', {
+                    status: xhr.status,
+                    responseText: xhr.responseText
+                  });
                 });
-              });
+              }
               TogglButton.setBrowserActionBadge();
               resolve({
                 success: false,

--- a/src/scripts/components/LoginPage.tsx
+++ b/src/scripts/components/LoginPage.tsx
@@ -57,7 +57,7 @@ export default function LoginPage ({ source, isLoggedIn, isPopup }: LoginProps) 
 
   React.useEffect(() => {
     if (error) {
-      bugsnagClient.notify(new Error(error), { context: 'login-page' });
+      bugsnagClient.notify(new Error(error), evt => { evt.context = 'login-page'; });
     }
   }, [error]);
 

--- a/src/scripts/lib/bugsnag.ts
+++ b/src/scripts/lib/bugsnag.ts
@@ -16,6 +16,8 @@ function processError(err: Error) {
       /.*(moz-extension|chrome_extension|chrome-extension|file):\/\/.*\/scripts\/(.*)/gi,
       'togglbutton://scripts/$2'
     );
+    // Normalize path separators across OSs
+    frame.file = frame.file.replace(/\\/g, '/');
     return frame;
   });
   return err;

--- a/src/scripts/lib/utils.ts
+++ b/src/scripts/lib/utils.ts
@@ -1,4 +1,5 @@
 import bugsnagClient from './bugsnag';
+import { Event } from "@bugsnag/core/types";
 
 const togglUrlRegex = /^(\w+\.)?toggl\.(space|com)$/
 
@@ -41,7 +42,9 @@ export function isTogglURL (url: string) {
   try {
     return togglUrlRegex.test(new URL(url).hostname);
   } catch (err) {
-    bugsnagClient.notify(err);
+    bugsnagClient.notify(err, (evt: Event) => {
+      evt.addMetadata('general', { url })
+    });
     return false;
   }
 }

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -566,22 +566,25 @@ document.addEventListener('DOMContentLoaded', function () {
         PopUp.sendMessage(request);
       });
 
-    document
-      .querySelector('#toggl-button-duration')
-      .addEventListener('keydown', function (event) {
-        // Doesn't cover all cases; can't really do it without introducing more state.
-        // Need a refactor.
-        if (event.code !== 'Enter' && event.code !== 'Tab') {
-          PopUp.durationChanged = true;
-        }
-      });
-    document
-      .querySelector('#toggl-button-duration')
-      .addEventListener('blur', function (event) {
-        const value = event.target.value || '';
-        const parsedInput = parseDuration(value).asSeconds();
-        event.target.value = secToHhmmImproved(parsedInput, { html: false });
-      });
+    // TODO: Properly fix this
+    // Bugsnag error 5dde294cb118e1001ae5a1d7
+    const durationElement = document.querySelector('#toggl-button-duration');
+    if (durationElement) {
+      durationElement
+        .addEventListener('keydown', function (event) {
+          // Doesn't cover all cases; can't really do it without introducing more state.
+          // Need a refactor.
+          if (event.code !== 'Enter' && event.code !== 'Tab') {
+            PopUp.durationChanged = true;
+          }
+        });
+      durationElement
+        .addEventListener('blur', function (event) {
+          const value = event.target.value || '';
+          const parsedInput = parseDuration(value).asSeconds();
+          event.target.value = secToHhmmImproved(parsedInput, { html: false });
+        });
+    }
 
     PopUp.$entries.addEventListener('click', function (e) {
       if (!e.target.dataset.continueId) {


### PR DESCRIPTION
## :star2: What does this PR do?
Treats most common Bugsnag errors.

* Upgrades Bugsnag library to `7.9.2`. Check https://github.com/bugsnag/bugsnag-js/blob/master/UPGRADING.md#6x-to-7x
* Adjusts path separators so errors are merged across OSs
* Omits common 403 error on getting user data (error `5f0ea96fe8175c001787b602`)
* Checks for element on addEventListener error (error `5dde294cb118e1001ae5a1d7`)
* Adds more debug info to URL error (error `6045ddaba7d01e001798e085`)
* Fixes Promised response from onMessage listener went out of scope (error `6045decb96760f0018a4d639`)
  Helper docs on this one:
  `onMessage `[should](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage#sending_an_asynchronous_response_using_a_promise) either return `true`, and then use `sendResponse`, OR it should return a promise, and then use `resolve`. We were returning a promise and also trying to use `sendResponse` so I refactored it. Hopefully this solves it.

## :bug: Recommendations for testing
* Check each commit separately 🙏🏻
* Make sure you give https://github.com/bugsnag/bugsnag-js/blob/master/UPGRADING.md#6x-to-7x a read against commit ba75cda

All changes should be tested across Chrome and Firefox.

----

Closes #1938 