### PR TITLE
Treats Bugsnag error: Receiving end doesnt exist

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -2089,7 +2089,7 @@ window.TogglButton = {
         } else if (request.type === 'logout') {
           TogglButton.logoutUser().then(resolve);
         } else if (request.type === 'sync') {
-          const res = TogglButton.fetchUser();
+          const res = await TogglButton.fetchUser();
           if (request.respond) {
             resolve(res);
           }

--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -667,18 +667,20 @@ window.togglbutton = {
     return undefined;
   },
 
-  newMessage: function (request, sender, sendResponse) {
-    if (request.type === 'stop-entry') {
-      togglbutton.updateTimerLink();
-      togglbutton.entries = request.user.time_entries;
-      togglbutton.projects = request.user.projectMap;
-      togglbutton.updateTrackedTimerLink();
-    } else if (request.type === 'sync') {
-      if ($('#toggl-button-edit-form') !== null) {
-        $('#toggl-button-edit-form').remove();
+  newMessage: function (request) {
+    return new Promise(resolve => {
+      if (request.type === 'stop-entry') {
+        togglbutton.updateTimerLink();
+        togglbutton.entries = request.user.time_entries;
+        togglbutton.projects = request.user.projectMap;
+        togglbutton.updateTrackedTimerLink();
+      } else if (request.type === 'sync') {
+        if ($('#toggl-button-edit-form') !== null) {
+          $('#toggl-button-edit-form').remove();
+        }
       }
-    }
-    return undefined;
+      resolve(undefined);
+    });
   }
 };
 


### PR DESCRIPTION
## :star2: What does this PR do?
Apparently those bugsnag errors are related to both `sync` and `stop-entry` messages, and this PR corrects both onMessage listeners per spec.

So... This should be covering:
* `5de0b5e4f79de300196e4f1b`
* `5b88010bab6255001a65abbf`
* `5ece29f9145cee0018b120c7`
* `6079720a12b7f10007ed979b`
And maybe
* `5f7de457f6ee25001783b977` (for erroring out when trying to fetch user data)

## :memo: Links to relevant issues or information
Closes #1942 