### PR TITLE
fix(bugsnag): Treat empty hostnames

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -2252,6 +2252,10 @@ window.TogglButton = {
     const hostname = new URL(url).hostname.replace('www.', '');
     const file = await db.getOriginFileName(hostname);
 
+    if (!hostname) {
+      return false;
+    }
+
     return {
       file: file,
       origins: ['*://' + hostname + '/*']


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?
* Treats empty hostnames, so we don't get `"Invalid value for origin pattern *:///*: Host can not be empty."`

## :memo: Links to relevant issues or information
Possibly related bugsnag error: `5b88010bab6255001a65abbf`