### PR TITLE
Fix bitrix for iframes

### DIFF
--- a/src/scripts/content/bitrix24.js
+++ b/src/scripts/content/bitrix24.js
@@ -1,19 +1,30 @@
 'use strict';
 /* global togglbutton, $ */
 
+const addButton = ($container, iframeSelector) => {
+  const link = togglbutton.createTimerLink({
+    className: 'bitrix24',
+    description: descriptionSelector,
+    projectName: projectSelector,
+    tags: tagsSelector
+  }, iframeSelector);
+
+  $container.appendChild(link);
+};
+
 togglbutton.render(
   '.task-detail .task-view-buttonset:not(.toggl)',
   { observe: true },
-  $container => {
-    const link = togglbutton.createTimerLink({
-      className: 'bitrix24',
-      description: descriptionSelector,
-      projectName: projectSelector,
-      tags: tagsSelector
-    });
+  addButton
+);
 
-    $container.appendChild(link);
-  }
+togglbutton.render(
+  '.task-detail .task-view-buttonset:not(.toggl)',
+  {
+    observe: true,
+    iframeSelector: 'iframe.side-panel-iframe:not(.toggl)'
+  },
+  $container => addButton($container, 'iframe.side-panel-iframe')
 );
 
 function descriptionSelector () {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1559,3 +1559,4 @@ body.notion-body.dark .toggl-button.notion {
   font-weight: bold;
   position: relative;
   top: -3px;
+}


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?
Our selector doesn't work for elements within iframes.
This PRs adds this functionality, and updates the bitrix content script to make use of it.

Also, there was a missing closing braces on our styles, so I added that.

## :bug: Recommendations for testing
* Sign up for a bitrix account.
* Go to tasks and projects
  ![image](https://user-images.githubusercontent.com/360894/117336209-dad8d100-ae93-11eb-9b02-b9910a38ba1c.png)
* Click a task, it should open in an iframe, and have the toggl button
* Refresh the page. The task should open on the main document, and still have the button

All changes should be tested across Chrome and Firefox.

## :memo: Links to relevant issues or information
Closes #1883 
