### PR TITLE
fix(siteBlock) Fix cannot read find of null for clean users

### DIFF
--- a/src/scripts/website-blocking/WebsiteBlocking.ts
+++ b/src/scripts/website-blocking/WebsiteBlocking.ts
@@ -53,7 +53,7 @@ class WebsiteBlocking {
       return;
     }
 
-    const currentBlockRecords = JSON.parse(currentValue);
+    const currentBlockRecords = JSON.parse(currentValue) || [];
 
     const entriesToAdd = blockRecords.filter(newRecord => {
       return !Boolean(currentBlockRecords.find(currentRecord => currentRecord.name === newRecord.name))


### PR DESCRIPTION
## :star2: What does this PR do?

Fixes this:

![image](https://user-images.githubusercontent.com/4663690/119816934-016bb400-bef6-11eb-9c97-9c82b9368e3a.png)