### PR TITLE
feat(siteBlock) Better UI/UX (existing records in lines) and some refactoring

### DIFF
--- a/src/html/settings.html
+++ b/src/html/settings.html
@@ -324,12 +324,18 @@
             <input type="checkbox" id="enable-website-blocking">
             <label for="enable-website-blocking">
               <span class="setting">Enable website blocking</span>
-              <span class="description">If enabled, visiting websites from the website blocking list will be disallowed while you're tracking time</span>
+              <span class="description">If enabled, visiting websites from the blocking list will be disallowed while you're tracking time</span>
             </label>
           </div>
+
+          <div id="website-blocking-list-section" class="field website-blocking-list-section">
+            <div class="text-bold">Website blocking list</div>
+            <div id="website-blocking-list-section-currently-blocking"></div>
+          </div>
+
           <div class="textarea field">
             <label for="website-blocking-list">
-              <span class="setting">Website blocking list</span>
+              <span class="setting">Add websites to block</span>
               <span class="description">Enter the list of domains you would like to block, each one on a new line</span>
             </label>
             <textarea id="website-blocking-list" rows="3"></textarea>

--- a/src/html/settings.html
+++ b/src/html/settings.html
@@ -328,18 +328,31 @@
             </label>
           </div>
 
-          <div id="website-blocking-list-section" class="field website-blocking-list-section">
+          <div id="website-blocking-list-section" class="field">
             <div class="text-bold">Website blocking list</div>
             <div id="website-blocking-list-section-currently-blocking"></div>
           </div>
 
+          <div id="website-blocking-known-distractions-section" class="field">
+            <label for="well-known-distractions"><span class="setting">Block well-known distractions</span></label>
+            <div id="block-well-known-distraction-container">
+              <select id="well-known-distractions"></select>
+              <button id="block-well-known-distraction-button" class="button">Block</button>
+            </div>
+          </div>
+
           <div class="textarea field">
             <label for="website-blocking-list">
-              <span class="setting">Add websites to block</span>
-              <span class="description">Enter the list of domains you would like to block, each one on a new line</span>
+              <span class="setting">Add websites to block manually</span>
+              <span class="description">Enter the list of URLs you would like to block, each one on a new line</span>
             </label>
-            <textarea id="website-blocking-list" rows="3"></textarea>
-            <div class="hidden error-message"></div>
+            <div id="website-blocking-list-container">
+              <div class="website-blocking-list-textarea-wrapper">
+                <textarea id="website-blocking-list" rows="3"></textarea>
+                <div class="hidden error-message"></div>
+              </div>
+              <button id="website-blocking-list-button" class="button">Block</button>
+            </div>
           </div>
         </section>
       </div>

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -2088,6 +2088,7 @@ window.TogglButton = {
           db.updateSetting('enableWebsiteBlocking', request.state);
         } else if (request.type === 'update-website-blocking-list') {
           db.updateSetting('websiteBlockingList', request.state);
+          browser.runtime.sendMessage({ type: 'website-blocking-list-updated' });
         } else if (
           request.type === 'update-enable-auto-tagging'
         ) {

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -2087,8 +2087,9 @@ window.TogglButton = {
         } else if (request.type === 'update-enable-website-blocking') {
           db.updateSetting('enableWebsiteBlocking', request.state);
         } else if (request.type === 'update-website-blocking-list') {
-          db.updateSetting('websiteBlockingList', request.state);
-          browser.runtime.sendMessage({ type: 'website-blocking-list-updated' });
+          const { records, ...payload } = request.state;
+          db.updateSetting('websiteBlockingList', records);
+          browser.runtime.sendMessage({ type: 'website-blocking-list-updated', payload });
         } else if (
           request.type === 'update-enable-auto-tagging'
         ) {

--- a/src/scripts/lib/db.js
+++ b/src/scripts/lib/db.js
@@ -32,6 +32,9 @@ const DEFAULT_SETTINGS = {
   rememberProjectPer: 'false',
   enableAutoTagging: false,
 
+  enableWebsiteBlocking: false,
+  websiteBlockingList: [],
+
   sendErrorReports: true,
   sendUsageStatistics: true
 };

--- a/src/scripts/lib/utils.ts
+++ b/src/scripts/lib/utils.ts
@@ -66,3 +66,24 @@ export async function isActiveUser (db: TogglDB) {
   const timeEntriesTracked = await db.get<number>('timeEntriesTracked') || 0;
   return (timeEntriesTracked >= ACTIVE_USER_TRESHOLD);
 }
+
+export function findArrayDuplicates(arr, unique = false) {
+  let sortedArray = arr.slice().sort();
+  let duplicates: string[] = [];
+  for (let i = 0; i < sortedArray.length - 1; i++) {
+    if (sortedArray[i + 1] == sortedArray[i]) {
+      duplicates.push(sortedArray[i]);
+    }
+  }
+  if (unique) {
+    return [...new Set(duplicates)]
+  } else {
+    return duplicates;
+  }
+}
+
+export function findArrayIntersection(array1, array2) {
+  return array1.filter((n) =>{
+    return array2.includes(n);
+  });
+}

--- a/src/scripts/lib/utils.ts
+++ b/src/scripts/lib/utils.ts
@@ -1,16 +1,16 @@
 import bugsnagClient from './bugsnag';
-import { Event } from "@bugsnag/core/types";
+import {Event} from "@bugsnag/core/types";
 
 const togglUrlRegex = /^(\w+\.)?toggl\.(space|com)$/
 
-export function secToHHMM (sum: number) {
+export function secToHHMM(sum: number) {
   const hours = Math.floor(sum / 3600);
   const minutes = Math.floor((sum % 3600) / 60);
 
   return hours + 'h ' + minutes + 'm';
 }
 
-export function report (e: Error) {
+export function report(e: Error) {
   if (process.env.DEBUG) {
     console.error(e);
   } else {
@@ -27,29 +27,29 @@ const entityMap = {
   '/': '&#x2F;'
 };
 
-export function escapeHtml (string: string) {
+export function escapeHtml(string: string) {
   return String(string).replace(/[&<>"'/]/g, function (s) {
     return entityMap[s];
   });
 }
 
-export function getUrlParam (location: string, key: string) {
+export function getUrlParam(location: string, key: string) {
   const url = new URL(location);
   return url.searchParams.get(key);
 }
 
-export function isTogglURL (url: string) {
+export function isTogglURL(url: string) {
   try {
     return togglUrlRegex.test(new URL(url).hostname);
   } catch (err) {
     bugsnagClient.notify(err, (evt: Event) => {
-      evt.addMetadata('general', { url })
+      evt.addMetadata('general', {url})
     });
     return false;
   }
 }
 
-export function getStoreLink (isFirefox = false) {
+export function getStoreLink(isFirefox = false) {
   if (isFirefox) {
     return 'https://addons.mozilla.org/en-US/firefox/addon/toggl-button-time-tracker/';
   }
@@ -62,7 +62,7 @@ export function getStoreLink (isFirefox = false) {
  */
 const ACTIVE_USER_TRESHOLD = 30;
 
-export async function isActiveUser (db: TogglDB) {
+export async function isActiveUser(db: TogglDB) {
   const timeEntriesTracked = await db.get<number>('timeEntriesTracked') || 0;
   return (timeEntriesTracked >= ACTIVE_USER_TRESHOLD);
 }
@@ -83,7 +83,17 @@ export function findArrayDuplicates(arr, unique = false) {
 }
 
 export function findArrayIntersection(array1, array2) {
-  return array1.filter((n) =>{
+  return array1.filter((n) => {
     return array2.includes(n);
   });
+}
+
+export function isValidUrl(str) {
+  const pattern = new RegExp('^(https?:\\/\\/)' +
+    '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' +
+    '((\\d{1,3}\\.){3}\\d{1,3}))' +
+    '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' +
+    '(\\?[;&a-z\\d%_.~+=-]*)?' +
+    '(\\#[-a-z\\d_]*)?$', 'i');
+  return pattern.test(str);
 }

--- a/src/scripts/website-blocking/WebsiteBlocking.ts
+++ b/src/scripts/website-blocking/WebsiteBlocking.ts
@@ -1,90 +1,46 @@
 import browser from 'webextension-polyfill';
 
 import WebsiteBlockingApi from "./WebsiteBlockingApi";
-import WebsiteBlockingConverter from "./WebsiteBlockingConverter";
+
+import CurrentlyBlockingListController from "./ui/CurrentlyBlockingListController";
+import WellKnownDistractionsController from "./ui/WellKnownDistractionsController";
+import ManuallyAddDistractionsController from "./ui/ManuallyAddDistractionsController";
 
 class WebsiteBlocking {
   settings: any
-  db: {get: Function, set: Function}
   enabledCheckbox: HTMLElement
-  blockingListTextarea: HTMLTextAreaElement
+  currentlyBlockingListController: CurrentlyBlockingListController
+  wellKnownDistractionsController: WellKnownDistractionsController
+  manuallyAddDistractionsController: ManuallyAddDistractionsController
 
-  constructor(Settings) {
-    this.settings = Settings;
-
-    this.enabledCheckbox = Settings.$websiteBlockingEnabled;
-    this.blockingListTextarea = Settings.$websiteBlockingList;
-    this.init().catch(this.onError);
+  constructor(settings) {
+    this.settings = settings;
+    this.enabledCheckbox = settings.$websiteBlockingEnabled;
+    this.init().catch(WebsiteBlocking.onError);
+    this.currentlyBlockingListController = new CurrentlyBlockingListController(settings)
+    this.wellKnownDistractionsController = new WellKnownDistractionsController(settings)
+    this.manuallyAddDistractionsController = new ManuallyAddDistractionsController(settings)
   }
 
   async init() {
     const websiteBlockingEnabled = await WebsiteBlocking.db().get('enableWebsiteBlocking');
-    const websiteBlockingList = await WebsiteBlocking.db().get('websiteBlockingList');
     this.settings.toggleState(this.enabledCheckbox, websiteBlockingEnabled);
-    this.blockingListTextarea.value = WebsiteBlockingConverter.blockRecordsStringToString(websiteBlockingList);
 
     WebsiteBlockingApi.getWebsiteBlockingRecordsFromApi().then(records => {
-      this.blockingListTextarea.value = WebsiteBlockingConverter.blockRecordsToString(records);
-      this.settings.saveSetting(JSON.stringify(records), 'update-website-blocking-list');
-    }).catch(this.onError);
+      this.settings.saveSetting({records}, 'update-website-blocking-list');
+    }).catch(WebsiteBlocking.onError);
 
     this.enabledCheckbox.addEventListener('click', this.onEnabledCheckboxClick)
-    this.blockingListTextarea.addEventListener('blur', this.onBlockingListTextareaBlur)
-    this.currentlyBlockingListController.render().catch(this.onError)
+    this.currentlyBlockingListController.render().catch(WebsiteBlocking.onError)
+    this.wellKnownDistractionsController.render().catch(WebsiteBlocking.onError)
   }
 
-   onEnabledCheckboxClick = async (e) => {
+  onEnabledCheckboxClick = async (e) => {
     const enableWebsiteBlocking = await WebsiteBlocking.db().get('enableWebsiteBlocking');
     this.settings.toggleSetting(e.target, !enableWebsiteBlocking, 'update-enable-website-blocking');
   }
 
-  onBlockingListTextareaBlur = async (e) => {
-    const error = await WebsiteBlocking.validateWebsiteBlockingListInput(e.target.value);
-    this.setWebsiteBlockingError(error);
-    if (error || !e.target.value) {
-      return;
-    }
-
-    const currentBlockRecords = await WebsiteBlocking.db().get('websiteBlockingList');
-    const { blockRecordsString, blockRecords } = WebsiteBlockingConverter.processWebsiteBlockingListInput(e.target.value);
-
-    if (JSON.stringify(currentBlockRecords) === blockRecordsString) {
-      return;
-    }
-
-    const blockRecordsToAdd = blockRecords.filter(newRecord => {
-      return !Boolean(currentBlockRecords.find(currentRecord => currentRecord.name === newRecord.name))
-    })
-    if (blockRecordsToAdd.length) {
-      WebsiteBlockingApi.saveWebsiteBlockingRecordsToApi(blockRecordsToAdd).catch(this.onError);
-    }
-
-    const allBlockRecords = [
-      ...currentBlockRecords,
-      ...blockRecords,
-    ];
-
-    this.settings.saveSetting(allBlockRecords, 'update-website-blocking-list');
-    this.blockingListTextarea.value = '';
-  }
-
-  setWebsiteBlockingError(error: string | null) {
-    const errorElement = this.blockingListTextarea.parentElement &&
-      this.blockingListTextarea.parentElement.querySelector('.error-message');
-    if (!errorElement) {
-      return;
-    }
-    if (error) {
-      errorElement.innerHTML = error;
-      errorElement.classList.remove('hidden');
-      return;
-    } else {
-      errorElement.classList.add('hidden');
-      errorElement.innerHTML = '';
-    }
-  }
-
-  onError = (e) => {
+  static onError = (e) => {
     browser.runtime.sendMessage({
       type: 'error',
       stack: e.stack,
@@ -92,34 +48,18 @@ class WebsiteBlocking {
     });
   }
 
-  static async validateWebsiteBlockingListInput(rawInput: string) {
-    const currentBlockRecords = await db.get('websiteBlockingList');
-    const urls = [
-      ...currentBlockRecords.map(record => record.url),
-      ...rawInput.split('\n').map(url => url.trim()).filter(Boolean)
-    ];
-    const uniqueUrls = [...new Set(urls)];
-    if (urls.length !== uniqueUrls.length) {
-      return 'Duplicates are found. Please, make sure that each URL is unique.';
-    }
-    const invalidUrls = urls.filter(url => {
-      try {
-        new URL(url);
-        return false;
-      } catch {
-        return true;
-      }
-    });
-    if (invalidUrls.length) {
-      return `Invalid URL(s) found: ${invalidUrls.join(', ')}. <br />
-      Make sure all your URLs are formatted like "https://example.com"`;
-    }
-    return null;
+  static youShallNotPass(tabId) {
+    browser.tabs.update(tabId, {url: browser.runtime.getURL('html/website-blocking.html')})
+  }
+
+  static db () {
+    return browser.extension.getBackgroundPage().db;
   }
 
   static async closeOnStart() {
     const websiteBlockingList = JSON.parse(await WebsiteBlocking.db().get('websiteBlockingList') || '[]');
     const blockedSites = websiteBlockingList.map(entry => entry.url);
+
     if (blockedSites.length > 0) {
       const blockedTabs = await browser.tabs.query({ url: blockedSites });
       blockedTabs.forEach(tab => WebsiteBlocking.youShallNotPass(tab.id));
@@ -132,7 +72,6 @@ class WebsiteBlocking {
       return;
     }
 
-
     const websiteBlockingEnabled = await WebsiteBlocking.db().get('enableWebsiteBlocking');
     const websiteBlockingList = JSON.parse(await WebsiteBlocking.db().get('websiteBlockingList') || '[]');
 
@@ -142,14 +81,6 @@ class WebsiteBlocking {
       WebsiteBlocking.youShallNotPass(tabId);
     }
   };
-
-  static youShallNotPass(tabId) {
-    browser.tabs.update(tabId, {url: browser.runtime.getURL('html/website-blocking.html')})
-  }
-
-  static db () {
-    return browser.extension.getBackgroundPage().db;
-  }
 }
 
 export default WebsiteBlocking;

--- a/src/scripts/website-blocking/WebsiteBlockingApi.ts
+++ b/src/scripts/website-blocking/WebsiteBlockingApi.ts
@@ -16,7 +16,14 @@ export default class WebsiteBlockingApi {
     return await response.json()
   }
 
-  static async deleteWebsiteBlockingRecords(entries: WebsiteBlockRecord[]) {
+  static async deleteWebsiteBlockingRecord(name: string) {
+    return fetch(`${process.env.API_URL}/v9/me/blocked_sites/${name}`, {
+      method: 'DELETE',
+      headers: WebsiteBlockingApi._getHeaders(),
+    })
+  }
+
+  static async deleteMultipleWebsiteBlockingRecords(entries: WebsiteBlockRecord[]) {
     return await Promise.all(entries.map(({name}) => {
       return fetch(`${process.env.API_URL}/v9/me/blocked_sites/${name}`, {
         method: 'DELETE',

--- a/src/scripts/website-blocking/WebsiteBlockingConverter.ts
+++ b/src/scripts/website-blocking/WebsiteBlockingConverter.ts
@@ -12,7 +12,7 @@ export default class WebsiteBlockingConverter {
     const urls = rawInput.split('\n').map(url => url.trim()).filter(Boolean);
     return urls.reduce((acc: WebsiteBlockRecord[], url) => {
       acc.push({
-        name: url,
+        name: `${url.replace(/[\W]+/g,"_")}_${Date.now()}`,
         url: url,
         device: 'all'
       });
@@ -25,22 +25,12 @@ export default class WebsiteBlockingConverter {
     return JSON.stringify(records);
   }
 
-  static blockRecordsStringToString(blockRecordsString: string) {
-    try {
-      const records = JSON.parse(blockRecordsString);
-      return WebsiteBlockingConverter.blockRecordsToString(records);
-    } catch (e) {
-      return '';
-    }
-  }
-
   static blockRecordsToString(records: WebsiteBlockRecord[]) {
     return records.map(record => record.url).join('\n')
   }
 
   static processWebsiteBlockingListInput (rawInput: string) {
     return {
-      string: WebsiteBlockingConverter.formatRawInput(rawInput),
       blockRecordsString: WebsiteBlockingConverter.stringToBlockRecordsString(rawInput),
       blockRecords: WebsiteBlockingConverter.stringToBlockRecords(rawInput)
     };

--- a/src/scripts/website-blocking/WebsiteBlockingConverter.ts
+++ b/src/scripts/website-blocking/WebsiteBlockingConverter.ts
@@ -1,7 +1,10 @@
 export default class WebsiteBlockingConverter {
 
-  static formatRawInput(rawInput: string) {
-    return rawInput.split('\n').map(url => url.trim()).filter(Boolean).join('\n')
+  static parseRawInput(rawInput: string) {
+    return rawInput.split('\n')
+      .map(url => url.trim())
+      .map(url => !url.endsWith('/') ? url + '/' : url)
+      .filter(Boolean)
   }
 
   static (records: WebsiteBlockRecord[]) {
@@ -9,7 +12,7 @@ export default class WebsiteBlockingConverter {
   }
 
   static stringToBlockRecords(rawInput: string) {
-    const urls = rawInput.split('\n').map(url => url.trim()).filter(Boolean);
+    const urls = WebsiteBlockingConverter.parseRawInput(rawInput);
     return urls.reduce((acc: WebsiteBlockRecord[], url) => {
       acc.push({
         name: `${url.replace(/[\W]+/g,"_")}_${Date.now()}`,
@@ -23,10 +26,6 @@ export default class WebsiteBlockingConverter {
   static stringToBlockRecordsString(rawInput: string) {
     const records = WebsiteBlockingConverter.stringToBlockRecords(rawInput);
     return JSON.stringify(records);
-  }
-
-  static blockRecordsToString(records: WebsiteBlockRecord[]) {
-    return records.map(record => record.url).join('\n')
   }
 
   static processWebsiteBlockingListInput (rawInput: string) {

--- a/src/scripts/website-blocking/WebsiteBlockingConverter.ts
+++ b/src/scripts/website-blocking/WebsiteBlockingConverter.ts
@@ -3,8 +3,8 @@ export default class WebsiteBlockingConverter {
   static parseRawInput(rawInput: string) {
     return rawInput.split('\n')
       .map(url => url.trim())
-      .map(url => !url.endsWith('/') ? url + '/' : url)
       .filter(Boolean)
+      .map(url => !url.endsWith('/') ? url + '/' : url)
   }
 
   static (records: WebsiteBlockRecord[]) {

--- a/src/scripts/website-blocking/WellKnownDistractions.ts
+++ b/src/scripts/website-blocking/WellKnownDistractions.ts
@@ -1,7 +1,7 @@
 export default [
   {
     "name": "Instagram",
-    "url": "https://instagram.com/",
+    "url": "https://www.instagram.com/",
     "androidAppId": "com.instagram.android",
     "device": "all"
   },

--- a/src/scripts/website-blocking/WellKnownDistractions.ts
+++ b/src/scripts/website-blocking/WellKnownDistractions.ts
@@ -1,18 +1,18 @@
-[
+export default [
   {
     "name": "Instagram",
-    "url": "https://instagram.com",
+    "url": "https://instagram.com/",
     "androidAppId": "com.instagram.android",
     "device": "all"
   },
   {
     "name": "Facebook",
-    "url": "https://www.facebook.com",
+    "url": "https://www.facebook.com/",
     "androidAppId": "com.facebook.katana"
   },
   {
     "name": "YouTube",
-    "url": "https://www.youtube.com",
+    "url": "https://www.youtube.com/",
     "androidAppId": "com.google.android.youtube",
     "device": "all"
   },
@@ -24,31 +24,31 @@
   },
   {
     "name": "Reddit",
-    "url": "https://www.reddit.com",
+    "url": "https://www.reddit.com/",
     "androidAppId": "com.reddit.frontpage",
     "device": "all"
   },
   {
     "name": "Twitch",
-    "url": "https://www.twitch.tv",
+    "url": "https://www.twitch.tv/",
     "androidAppId": "tv.twitch.android.app",
     "device": "all"
   },
   {
     "name": "LinkedIn",
-    "url": "https://www.linkedin.com",
+    "url": "https://www.linkedin.com/",
     "androidAppId": "com.linkedin.android",
     "device": "all"
   },
   {
     "name": "Netflix",
-    "url": "https://www.netflix.com",
+    "url": "https://www.netflix.com/",
     "androidAppId": "com.netflix.mediaclient",
     "device": "all"
   },
   {
     "name": "TikTok",
-    "url": "https://www.tiktok.com",
+    "url": "https://www.tiktok.com/",
     "androidAppId": "com.zhiliaoapp.musically",
     "device": "all"
   }

--- a/src/scripts/website-blocking/predefined-websites.json
+++ b/src/scripts/website-blocking/predefined-websites.json
@@ -1,0 +1,55 @@
+[
+  {
+    "name": "Instagram",
+    "url": "https://instagram.com",
+    "androidAppId": "com.instagram.android",
+    "device": "all"
+  },
+  {
+    "name": "Facebook",
+    "url": "https://www.facebook.com",
+    "androidAppId": "com.facebook.katana"
+  },
+  {
+    "name": "YouTube",
+    "url": "https://www.youtube.com",
+    "androidAppId": "com.google.android.youtube",
+    "device": "all"
+  },
+  {
+    "name": "Twitter",
+    "url": "https://twitter.com/",
+    "androidAppId": "com.twitter.android",
+    "device": "all"
+  },
+  {
+    "name": "Reddit",
+    "url": "https://www.reddit.com",
+    "androidAppId": "com.reddit.frontpage",
+    "device": "all"
+  },
+  {
+    "name": "Twitch",
+    "url": "https://www.twitch.tv",
+    "androidAppId": "tv.twitch.android.app",
+    "device": "all"
+  },
+  {
+    "name": "LinkedIn",
+    "url": "https://www.linkedin.com",
+    "androidAppId": "com.linkedin.android",
+    "device": "all"
+  },
+  {
+    "name": "Netflix",
+    "url": "https://www.netflix.com",
+    "androidAppId": "com.netflix.mediaclient",
+    "device": "all"
+  },
+  {
+    "name": "TikTok",
+    "url": "https://www.tiktok.com",
+    "androidAppId": "com.zhiliaoapp.musically",
+    "device": "all"
+  }
+]

--- a/src/scripts/website-blocking/ui/BlockingEnabledController.ts
+++ b/src/scripts/website-blocking/ui/BlockingEnabledController.ts
@@ -1,0 +1,26 @@
+import browser from 'webextension-polyfill';
+import WebsiteBlocking from "../WebsiteBlocking";
+
+const db = browser.extension.getBackgroundPage().db;
+
+export default class BlockingEnabledController {
+  settings: any
+  enabledCheckbox: HTMLElement
+
+  constructor(settings) {
+    this.settings = settings;
+    this.enabledCheckbox = settings.$websiteBlockingEnabled;
+    this.enabledCheckbox.addEventListener('click', this.onEnabledCheckboxClick)
+    this.init().catch(WebsiteBlocking.onError)
+  }
+
+  async init() {
+    const websiteBlockingEnabled = await db.get('enableWebsiteBlocking');
+    this.settings.toggleState(this.enabledCheckbox, websiteBlockingEnabled);
+  }
+
+  onEnabledCheckboxClick = async (e) => {
+    const enableWebsiteBlocking = await db.get('enableWebsiteBlocking');
+    this.settings.toggleSetting(e.target, !enableWebsiteBlocking, 'update-enable-website-blocking');
+  }
+}

--- a/src/scripts/website-blocking/ui/CurrentlyBlockingListController.ts
+++ b/src/scripts/website-blocking/ui/CurrentlyBlockingListController.ts
@@ -1,0 +1,73 @@
+import browser from 'webextension-polyfill';
+import WebsiteBlockingApi from "../WebsiteBlockingApi";
+
+const db = browser.extension.getBackgroundPage().db;
+
+export default class CurrentlyBlockingListController {
+  settings: any
+  container: HTMLElement;
+  listContainer: HTMLElement;
+
+  constructor(settings) {
+    this.settings = settings;
+    this.container = document.getElementById('website-blocking-list-section')!
+    this.listContainer = document.getElementById('website-blocking-list-section-currently-blocking')!
+    browser.runtime.onMessage.addListener(this.onMessage);
+  }
+
+  onMessage = (request) => {
+    if (request.type === 'website-blocking-list-updated') {
+      this.render()
+    }
+  }
+
+  onDelete = async (e) => {
+    const name = e.target.dataset.blockingRecordDeleteName;
+    const currentRecords = await db.get('websiteBlockingList') || [];
+    const url = currentRecords.find(record => record.name === name).url;
+    const isSure = window.confirm(`Are you sure you would like to remove ${url} from the blocking list?`);
+    if (isSure) {
+      e.target.setAttribute('disabled', 'disabled')
+      e.target.classList.add('disabled')
+      try {
+        await WebsiteBlockingApi.deleteWebsiteBlockingRecord(name)
+      } catch (e) {
+        e.target.removeAttribute('disabled')
+        e.target.classList.remove('disabled')
+        return;
+      }
+      const newRecords = currentRecords.filter(record => record.name !== name);
+      this.settings.saveSetting(newRecords, 'update-website-blocking-list');
+    }
+  }
+
+  subscribeToEvents() {
+    this.listContainer.querySelectorAll('.website-blocking-list-section-delete button').forEach(button => {
+      button.addEventListener('click', this.onDelete)
+    })
+  }
+
+  render = async () => {
+    const currentRecords = (await db.get('websiteBlockingList')) || [];
+    if (!currentRecords.length) {
+      this.container.classList.add('hidden')
+      this.listContainer.innerHTML = ''
+      return
+    }
+    this.container.classList.remove('hidden')
+    this.listContainer.innerHTML = currentRecords.map(record => this.renderRecord(record)).join('')
+    this.subscribeToEvents();
+  }
+
+  renderRecord(record: WebsiteBlockRecord) {
+    const {name, url} = record;
+    return `
+      <div class="website-blocking-list-section-currently-blocking-record">
+        <div class="website-blocking-list-section-url">${url}</div>
+        <div class="website-blocking-list-section-delete">
+          <button data-blocking-record-delete-name="${name}" class="inline-danger">Delete</button>
+        </div>
+      </div>
+    `
+  }
+}

--- a/src/scripts/website-blocking/ui/ManuallyAddDistractionsController.ts
+++ b/src/scripts/website-blocking/ui/ManuallyAddDistractionsController.ts
@@ -3,7 +3,7 @@ import WebsiteBlockingApi from "../WebsiteBlockingApi";
 import WebsiteBlocking from "../WebsiteBlocking";
 import WebsiteBlockingConverter from "../WebsiteBlockingConverter";
 
-import {findArrayDuplicates, findArrayIntersection} from '../../lib/utils'
+import {findArrayDuplicates, findArrayIntersection, isValidUrl} from '../../lib/utils'
 
 const db = browser.extension.getBackgroundPage().db;
 
@@ -64,8 +64,6 @@ export default class ManuallyAddDistractionsController {
     }
   }
 
-
-  // @ts-ignore
   static async validateWebsiteBlockingListInput(rawInput: string) {
     const currentBlockRecords = await db.get('websiteBlockingList');
     const enteredUrls = WebsiteBlockingConverter.parseRawInput(rawInput);
@@ -82,16 +80,9 @@ export default class ManuallyAddDistractionsController {
               Please remove them before saving.`;
     }
 
-    const invalidUrls = enteredUrls.filter(url => {
-      try {
-        new URL(url);
-        return false;
-      } catch {
-        return true;
-      }
-    });
+    const invalidUrls = enteredUrls.filter(url => !isValidUrl(url));
     if (invalidUrls.length) {
-      return `Invalid URL(s) found: ${invalidUrls.join(', ')}. <br />
+      return `Invalid URL(s) found: <strong>${invalidUrls.join(', ')}</strong>. <br />
       Make sure all your URLs are formatted like "https://example.com"`;
     }
     return null;

--- a/src/scripts/website-blocking/ui/ManuallyAddDistractionsController.ts
+++ b/src/scripts/website-blocking/ui/ManuallyAddDistractionsController.ts
@@ -1,0 +1,100 @@
+import browser from 'webextension-polyfill';
+import WebsiteBlockingApi from "../WebsiteBlockingApi";
+import WebsiteBlocking from "../WebsiteBlocking";
+import WebsiteBlockingConverter from "../WebsiteBlockingConverter";
+
+import {findArrayDuplicates, findArrayIntersection} from '../../lib/utils'
+
+const db = browser.extension.getBackgroundPage().db;
+
+export default class ManuallyAddDistractionsController {
+  settings: any
+  blockingListTextarea: HTMLTextAreaElement
+  blockButton: HTMLButtonElement
+
+  constructor(settings) {
+    this.settings = settings;
+    this.blockingListTextarea = settings.$websiteBlockingList;
+    this.blockButton = <HTMLButtonElement>document.getElementById('website-blocking-list-button');
+    this.blockButton.addEventListener('click', this.onAdd);
+  }
+
+  onAdd = async (e) => {
+    const value = this.blockingListTextarea.value;
+    const error = await ManuallyAddDistractionsController.validateWebsiteBlockingListInput(value);
+    this.setWebsiteBlockingError(error);
+    if (error || !value) {
+      return;
+    }
+    const {blockRecords} = WebsiteBlockingConverter.processWebsiteBlockingListInput(value);
+    try {
+      e.target.setAttribute('disabled', 'disabled')
+      e.target.classList.add('disabled')
+      await WebsiteBlockingApi.saveWebsiteBlockingRecordsToApi(blockRecords).catch(WebsiteBlocking.onError);
+    } catch (e) {
+      return;
+    } finally {
+      e.target.removeAttribute('disabled')
+      e.target.classList.remove('disabled')
+    }
+
+    const currentBlockRecords = await db.get('websiteBlockingList');
+    const allBlockRecords = [
+      ...currentBlockRecords,
+      ...blockRecords,
+    ];
+
+    this.settings.saveSetting({records: allBlockRecords, scrollListToBottom: true}, 'update-website-blocking-list');
+    this.blockingListTextarea.value = '';
+  }
+
+  setWebsiteBlockingError(error: string | null) {
+    const errorElement = this.blockingListTextarea.parentElement &&
+      this.blockingListTextarea.parentElement.querySelector('.error-message');
+    if (!errorElement) {
+      return;
+    }
+    if (error) {
+      errorElement.innerHTML = error;
+      errorElement.classList.remove('hidden');
+      return;
+    } else {
+      errorElement.classList.add('hidden');
+      errorElement.innerHTML = '';
+    }
+  }
+
+
+  // @ts-ignore
+  static async validateWebsiteBlockingListInput(rawInput: string) {
+    const currentBlockRecords = await db.get('websiteBlockingList');
+    const enteredUrls = WebsiteBlockingConverter.parseRawInput(rawInput);
+
+    const duplicates = findArrayDuplicates(enteredUrls, true);
+    if (duplicates.length) {
+      return `Duplicates are found: <strong>${duplicates.join(', ')}</strong>. <br/>
+              Please, make sure that each URL is unique.`;
+    }
+
+    const alreadyBlockedUrls = findArrayIntersection(currentBlockRecords.map(record => record.url), enteredUrls)
+    if (alreadyBlockedUrls.length) {
+      return `You are already blocking some of the entered URLs: <strong>${alreadyBlockedUrls.join(', ')}</strong>. <br/>
+              Please remove them before saving.`;
+    }
+
+    const invalidUrls = enteredUrls.filter(url => {
+      try {
+        new URL(url);
+        return false;
+      } catch {
+        return true;
+      }
+    });
+    if (invalidUrls.length) {
+      return `Invalid URL(s) found: ${invalidUrls.join(', ')}. <br />
+      Make sure all your URLs are formatted like "https://example.com"`;
+    }
+    return null;
+  }
+}
+

--- a/src/scripts/website-blocking/ui/WellKnownDistractionsController.ts
+++ b/src/scripts/website-blocking/ui/WellKnownDistractionsController.ts
@@ -1,0 +1,75 @@
+import browser from 'webextension-polyfill';
+import wellKnownDistractions from '../WellKnownDistractions';
+import WebsiteBlockingApi from "../WebsiteBlockingApi";
+import WebsiteBlocking from "../WebsiteBlocking";
+
+const db = browser.extension.getBackgroundPage().db;
+
+export default class WellKnownDistractionsController {
+  settings: any
+  container: HTMLElement;
+  select: HTMLSelectElement;
+  blockButton: HTMLButtonElement;
+
+  constructor(settings) {
+    this.settings = settings;
+    this.container = document.getElementById('website-blocking-known-distractions-section')!
+    this.select = <HTMLSelectElement>document.getElementById('well-known-distractions')!
+    this.blockButton = <HTMLButtonElement>document.getElementById('block-well-known-distraction-button')!
+    this.blockButton.addEventListener('click', this.onAdd)
+    browser.runtime.onMessage.addListener(this.onMessage);
+  }
+
+  onMessage = (request) => {
+    if (request.type === 'website-blocking-list-updated') {
+      this.render()
+    }
+  }
+
+  onAdd = async (e) => {
+    const currentRecords = await db.get('websiteBlockingList') || [];
+    const value = this.select.value;
+    const blockingRecord = <WebsiteBlockRecord>wellKnownDistractions.find(record => record.name === value)!;
+
+    try {
+      e.target.setAttribute('disabled', 'disabled')
+      e.target.classList.add('disabled')
+      await WebsiteBlockingApi.saveWebsiteBlockingRecordsToApi([blockingRecord])
+        .catch(WebsiteBlocking.onError);
+    } catch (e) {
+      return;
+    } finally {
+      e.target.removeAttribute('disabled')
+      e.target.classList.remove('disabled')
+    }
+
+    const allBlockRecords = [
+      ...currentRecords,
+      blockingRecord,
+    ];
+    this.settings.saveSetting({records: allBlockRecords, scrollListToBottom: true}, 'update-website-blocking-list');
+  }
+
+  render = async () => {
+    this.select.innerHTML = '';
+    const currentRecords = await db.get('websiteBlockingList') || [];
+    const availableDistractions = wellKnownDistractions.filter(distraction => {
+      return !currentRecords.find(currentRecord => currentRecord.name === distraction.name || currentRecord.url === distraction.url)
+    })
+    if (availableDistractions.length) {
+      this.container.classList.remove('hidden')
+      availableDistractions.forEach((distraction, i) => {
+        const option = document.createElement('option');
+        option.id = distraction.name;
+        option.value = distraction.name;
+        option.textContent = distraction.name;
+        this.select.appendChild(option);
+        if (i === 0) {
+          this.select.value = option.value;
+        }
+      })
+    } else {
+      this.container.classList.add('hidden')
+    }
+  }
+}

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -715,7 +715,7 @@ body[data-show-review-banner="true"] #review-prompt {
   margin-top: 10px;
   max-height: 150px;
   overflow-y: auto;
-  max-width: 445px;
+  max-width: 388px;
 }
 
 .website-blocking-list-section-currently-blocking-record {
@@ -732,8 +732,22 @@ body[data-show-review-banner="true"] #review-prompt {
   margin-right: 20px;
 }
 
+#block-well-known-distraction-container {
+  display: inline;
+}
+
+#website-blocking-list-container {
+  display: flex;
+}
+
+.website-blocking-list-textarea-wrapper {
+  width: 300px;
+  margin-right: 4px;
+}
+
 .error-message {
   color: var(--danger-color);
+  word-break: break-word;
 }
 
 .text-bold {

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -175,6 +175,30 @@ button.danger:hover, button.danger:enabled:hover {
   background: var(--main-bg-color);
 }
 
+button.inline-danger {
+  margin-top: 0;
+  padding: 0;
+  box-shadow: none;
+  border: none;
+  color: var(--danger-color);
+  background: var(--header-bg-color);
+  min-height: initial;
+  height: 22px;
+  text-shadow: none;
+}
+
+button.inline-danger:hover {
+  color: var(--danger-color) !important;
+  background: var(--header-bg-color);
+  background-image: none !important;
+  box-shadow: none !important;
+  text-decoration: underline;
+}
+
+button.inline-danger:disabled {
+  background: var(--header-bg-color);
+}
+
 input[type="time"] {
   -moz-appearance: textfield;
 }
@@ -687,9 +711,33 @@ body[data-show-review-banner="true"] #review-prompt {
   transform: translateY(0);
 }
 
+#website-blocking-list-section-currently-blocking {
+  margin-top: 10px;
+  max-height: 150px;
+  overflow-y: auto;
+  max-width: 445px;
+}
+
+.website-blocking-list-section-currently-blocking-record {
+  display: flex;
+  align-items: center;
+}
+
+.website-blocking-list-section-url {
+  flex: 1;
+  max-width: 350px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-right: 20px;
+}
 
 .error-message {
   color: var(--danger-color);
+}
+
+.text-bold {
+  font-weight: 500;
 }
 
 .has-error {
@@ -698,4 +746,8 @@ body[data-show-review-banner="true"] #review-prompt {
 
 .hidden {
   display: none !important;
+}
+
+.disabled {
+  opacity: 0.6;
 }


### PR DESCRIPTION
## :star2: What does this PR do?

Adds displaying list of existing website blocking records with Delete buttons.
Adds a dropdown for selecting and blocking well-known distractos
Does some refactoring - we no longer use `JSON.stringify/parse` for storing the records data in db as it is totally fine with objects.
Complements error messages - how they list the URLs that are duplicated or already blocked

![image](https://user-images.githubusercontent.com/4663690/119986925-1d8e5480-bfcd-11eb-9596-d644345a4e6f.png)

## :bug: Recommendations for testing

Add some records, remove some records.
Try to block websites from the well-known blockers dropdown. Make sure that dropdowns goes away when all records are blocked. Make sure it is refreshed when unblocking a well-known distractor
It might be incompatible with old data format - if something goes wrong, reset the settings to defaults.