### PR TITLE
Fix blocking full URLs 

### DIFF
--- a/src/scripts/website-blocking/WebsiteBlocking.ts
+++ b/src/scripts/website-blocking/WebsiteBlocking.ts
@@ -64,15 +64,28 @@ class WebsiteBlocking {
       return;
     }
 
+    const hostname = WebsiteBlocking.getHostnameFromUrl(url);
+
     const websiteBlockingEnabled = await WebsiteBlocking.db().get('enableWebsiteBlocking');
     const websiteBlockingList = await WebsiteBlocking.db().get('websiteBlockingList');
 
-    const shouldBlock = websiteBlockingEnabled && !!(websiteBlockingList.find(record => record.url === url));
+    const shouldBlock = websiteBlockingEnabled && !!(websiteBlockingList.find(record => {
+      return hostname === WebsiteBlocking.getHostnameFromUrl(record.url)
+    }));
     let TogglButton = browser.extension.getBackgroundPage().TogglButton;
     if (shouldBlock && TogglButton.$curEntry) {
       WebsiteBlocking.youShallNotPass(tabId);
     }
   };
+
+  static getHostnameFromUrl(url: string) {
+    const hostname = new URL(url).hostname;
+    if (hostname.startsWith('www.')) {
+      return hostname.replace('www.', '');
+    }
+    return hostname;
+  }
+
 }
 
 export default WebsiteBlocking;


### PR DESCRIPTION
## :star2: What does this PR do?

The current implementation does block `https://www.instagram.com/`, but it fails to block `https://www.instagram.com/accounts/login/`.
The same is for `https://www.youtube.com` and direct links to videos like `https://www.youtube.com/watch?v=DYzXKZn_Z3w`.

## :bug: Recommendations for testing

Try opening `https://www.youtube.com/watch?v=DYzXKZn_Z3w` while blocking YT and tracking time.
