### PR TITLE
chore(travis): Update config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+os: linux
+dist: xenial
 language: node_js
 node_js:
   - 10.18.0
@@ -5,11 +7,11 @@ node_js:
 jobs:
   include:
     - stage: build
-      script: npm run lint:ci
-      script: npm run build
+      script:
+        - npm run lint:ci
+        - npm run build
     - stage: release
       deploy:
         provider: script
-        skip_cleanup: true
         script:
           - npx semantic-release


### PR DESCRIPTION
## :star2: What does this PR do?
Update Travis config to resolve warnings.

Check [this branch's  build](https://travis-ci.com/github/toggl/toggl-button/builds/233863887/config)
And previous [master build](https://travis-ci.com/github/toggl/toggl-button/builds/233862879/config) 

`skip_cleanup` is now [deprecated](https://blog.travis-ci.com/2019-08-27-deployment-tooling-dpl-v2-preview-release/#:~:text=skip_cleanup) and it's not cleaning up as default.
