### PR TITLE
fix(github): Fix projects page numElem not passing

### DIFF
--- a/src/scripts/content/github.js
+++ b/src/scripts/content/github.js
@@ -43,7 +43,7 @@ togglbutton.render('.js-project-card-details .js-comment:not(.toggl)', { observe
   elem
 ) {
   const titleElem = $('.js-issue-title');
-  const numElem = $('.js-project-card-details .project-comment-title-hover span.text-gray-light');
+  const numElem = $('.js-project-card-details .project-comment-title-hover span.color-text-tertiary');
   const projectElem = $('h1.public strong a, h1.private strong a');
 
   let description = titleElem.textContent;


### PR DESCRIPTION
This is my first PR in this repo, I read the Contributing.md but let me know if I missed anything!

## :star2: What does this PR do?

The current plugin doesn't pass the issue or PR number on GitHub projects through to the toggl button on there. It looks like GitHub might have changed the class the plugin was using to select the element.

After the fix the numElem passes, for example below the `#1569` is now being passed:
<img width="418" alt="Screen Shot 2021-08-16 at 8 25 17 AM" src="https://user-images.githubusercontent.com/7334882/129564626-f16cd819-5249-4ff0-83c0-a51e2429f6e5.png">


## :bug: Recommendations for testing

Load the plugin in chrome and firefox, then go to a project page (e.g. [a project on this repo](https://github.com/toggl/toggl-button/projects/6)) and click a ticket and click the "Start Timer". It should now show the `numElem` being passed.
## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
