### PR TITLE
fix(asana): Prevent multiple buttons on board view

### DIFF
--- a/src/scripts/content/asana.js
+++ b/src/scripts/content/asana.js
@@ -3,6 +3,11 @@
 // Board view. Inserts button next to assignee/due date.
 togglbutton.render('.BaseCard .BoardCardLayout:not(.toggl)', { observe: true },
   boadCardElem => {
+    if (boadCardElem.querySelector('.toggl-button')) {
+      // Due to the way this UI is rendered, we must check for existence of old buttons manually.
+      return;
+    }
+
     const descriptionSelector = () => boadCardElem.querySelector('.BoardCard-taskName').textContent.trim();
 
     const projectSelector = () => {


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?
Prevent multiple buttons on Asana's board view

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

1. Load the extension, enable Asana integration, and head to https://app.asana.com/
2. Sign in and head to the board view of some project, there should be a sample or just create one (and at least one task)
3. When you hover a task card on the board there should be a Toggl button next to the 👍 button
4. Clicking on a card on the board to show its details and closing the side pane doesn't add any more Toggl buttons to the card when you hover it again

## :memo: Links to relevant issues or information
closes #1958 
