### PR TITLE
fix(to-do): Fix project selector for MS To-Do

### DIFF
--- a/src/scripts/content/microsoft-to-do.js
+++ b/src/scripts/content/microsoft-to-do.js
@@ -5,8 +5,8 @@ togglbutton.render('.taskItem-body:not(.toggl)', { observe: true }, function (
 ) {
   const container = createTag('a', 'taskItem-toggl');
   const titleElem = $('.taskItem-title', elem);
-  const projectTitleElem = $('.taskItemInfo-title', elem);
-  const activeList = $('ul.lists .listItem.active');
+  const projectTitleElem = $('.listTitle');
+  const activeList = $('.listItem-container.active');
   const activeListTitle = $('.listItem-title', activeList);
 
   const projectTitle = projectTitleElem


### PR DESCRIPTION
## :star2: What does this PR do?
Fix the project selector for Microsoft To-Do

## :bug: Recommendations for testing

1. Go to MS To-Do and start a task from a list for which there's a project with the same name in the workspace (or create one)
2. The project field should be filled automatically

## :memo: Links to relevant issues or information
closes #1976
