### PR TITLE
feat: Add support for Shortuct (previously Clubhouse)

### DIFF
--- a/src/scripts/content/shortcut.js
+++ b/src/scripts/content/shortcut.js
@@ -1,0 +1,31 @@
+'use strict';
+
+togglbutton.render('.story-state:not(.toggl)', { observe: true }, function (
+  elem
+) {
+  const wrap = createTag('div');
+  const element = elem;
+  elem = elem.parentNode.parentNode.parentNode;
+
+  const getDescription = function () {
+    const storyId = $('.story-id > input', elem).value;
+    const title = $('h2.story-name', elem).textContent;
+
+    return `#${storyId} - ${title}`;
+  };
+
+  const getProject = function () {
+    return $('.story-project .value', elem).textContent;
+  };
+
+  const link = togglbutton.createTimerLink({
+    className: 'toggl-shortcut',
+    description: getDescription,
+    projectName: getProject
+  });
+
+  wrap.className = 'attribute editable-attribute toggl-button-shortcut-wrapper';
+  wrap.appendChild(link);
+
+  element.parentNode.insertBefore(wrap, element.nextSibling);
+});

--- a/src/scripts/origins.js
+++ b/src/scripts/origins.js
@@ -503,6 +503,10 @@ export default {
     url: '*://*.sentry.io/*',
     name: 'Sentry'
   },
+  'app.shortcut.com': {
+    url: '*://app.shortcut.com/*',
+    name: 'Shortcut'
+  },
   'sifterapp.com': {
     url: '*://*.sifterapp.com/*',
     name: 'Sifterapp'

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1180,6 +1180,29 @@ a.toggl-button.workfront.min {
   padding-left: 27px;
 }
 
+/********* SHORTCUT *********/
+.toggl-button.toggl-shortcut:not(.toggl-button-edit-form-button) {
+  width: 100%;
+  margin: 6px;
+  height: 23px;
+}
+
+.toggl-button.toggl-shortcut svg {
+  height: 24px;
+  width: 24px;
+  margin-left: 1px;
+}
+
+.toggl-button.toggl-shortcut span {
+  padding-left: 4px;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.toggl-button-shortcut-wrapper {
+  padding: 0 !important;
+}
+
 /********* TEAMLEADER *********/
 .toggl-button.teamleader {
   background: none;


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

<!-- A Concise description of what this PR achieves, including any context. -->

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

Clubhouse have changed their name to Shortcut, and their domain to `shortcut.com`. This PR uses the old integration to add support for this new domain, skins the button to better match the website theme, and adds the ability to pulls the story id from the card.

![Screenshot](https://cleanshot-cloud-fra.s3.eu-central-1.amazonaws.com/media/15798/NbRL5RSxvTg6TxYFlq1z21CL8WZSnv2tHXOuZyGe.jpeg?X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEJv%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaDGV1LWNlbnRyYWwtMSJHMEUCICjCyoeUkNJ8fYR6N45vU0Ybz3YMW02YraKEN60qDbOKAiEA2WebAJsjQ%2F9Fr8RsT32iTAVxUYNgL%2FIZbeA9%2B0UGd7YqqAII5P%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FARAAGgw5MTk1MTQ0OTE2NzQiDLN08YgUJ%2BxU3s1nKSr8ATE7aJojIHL%2BHvtg12wYyHRr%2F03ql9IC71BRaLTIeiE%2FnCyyMSHnTByTMXpX6qG3IbyiKLPc06H6g%2BIEWeM%2B%2BSDiJw5Dt%2BUlGRun%2FwMKaXl9tCfyBdVKKqneInOtO1HfxfzvG2m%2FX8XdWpFAb%2Fr6M%2FGPFKTv7BnKst7tidi93MPOkuNPkmP1yKh6c%2FrHZergdyIA83Ad4GqF54rJQuVY0%2FZYpZHeD2kTVAugVUrGkE%2BvK88JCJxWUDM4fEf6DnfFU9aVJSqrqWzSRyc2VPnDtlk7mGSgbr07vipF6vLLY5nmr3yQdA6u7R8QGt57vd1jRWCCMut0CTDscwt0CTDoqPCJBjqaAV6Akwe3q2AioBsRf3K2lCQGj4GIsavvZF7bpmxbiwPNgZ2R%2FDDOJk4%2Bt3aTM7KTBk7A%2FtOHmMXaF6Xg4rUIW6cGxeacFSyjYXN1%2BBS%2BPVvxvmIBrQnCllZBB0mR9U31fY3S3FfhbQQT2mdhk9xIq3CHVymaCcJjuSTwKG0vYCGZDOWOPBCinei7t6RN9de%2FTeC5jI8TmqzxggQ%3D&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIA5MF2VVMNL6RSEG6D%2F20210911%2Feu-central-1%2Fs3%2Faws4_request&X-Amz-Date=20210911T041842Z&X-Amz-SignedHeaders=host&X-Amz-Expires=300&X-Amz-Signature=d149e8b5a34867cd95341e6715dcb285fd167ffbf42e44fd224382cd685964ec)

## :bug: Recommendations for testing

I have tested this on both Firefox and Chrome. The button is accessible on a card in Shortcut.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
[Clubhouse's name is now Shortcut](https://clubhouse.io/blog/clubhouse-changing-our-name-to-shortcut/)
