### PR TITLE
fix(idb): Fix IDB initialization

### DIFF
--- a/src/scripts/lib/dbUtils.ts
+++ b/src/scripts/lib/dbUtils.ts
@@ -1,63 +1,66 @@
 const indexedDB = window.indexedDB;
 
-const DB_NAME = 'TogglExtension';
-const DB_VERSION = 1;
+const DB_NAME = "TogglExtension";
+const DB_VERSION = 2;
 
-const open = indexedDB.open(DB_NAME, DB_VERSION);
+const openDb = (): Promise<IDBDatabase> =>
+  new Promise((resolve, reject) => {
+    const open = indexedDB.open(DB_NAME, DB_VERSION);
 
-open.onupgradeneeded = () => {
-  const db = open.result;
-  db.createObjectStore("LocalData", {keyPath: "id"});
-};
-
-export const getIDBItem = (key) => {
-  return new Promise((resolve, reject) => {
-    const open = indexedDB.open(DB_NAME, DB_VERSION)
-    open.onsuccess = () => {
+    open.onupgradeneeded = () => {
       const db = open.result;
-      const transaction = db.transaction("LocalData", "readonly");
-      const store = transaction.objectStore("LocalData");
-      const query = store.get(key);
-      query.onsuccess = () => resolve(query.result && query.result.value);
-      query.onerror = reject;
-      transaction.oncomplete = () => db.close()
-      transaction.onerror = reject
-    }
-    open.onerror = reject;
-  })
-}
+      if (!db.objectStoreNames.contains("LocalData")) {
+        console.log("Creating IDB Object Store");
+        db.createObjectStore("LocalData", { keyPath: "id" });
+      }
+    };
 
-export const setIDBItem = (key, value) => {
-  return new Promise((resolve, reject) => {
-    const open = indexedDB.open(DB_NAME, DB_VERSION)
     open.onsuccess = () => {
-      const db = open.result;
-      const transaction = db.transaction("LocalData", "readwrite");
-      const store = transaction.objectStore("LocalData");
-      const data = {id: key, value}
-      const request = store.put(data);
-      request.onerror = reject;
-      request.onsuccess = resolve;
-      transaction.oncomplete = () => db.close()
-      transaction.onerror = reject
-    }
-    open.onerror = reject;
-  })
-}
+      resolve(open.result);
+    };
 
-export const clearIDBAll = () => {
-  return new Promise((resolve, reject) => {
-    const open = indexedDB.open(DB_NAME, DB_VERSION)
-    open.onsuccess = () => {
-      const db = open.result;
-      const transaction = db.transaction("LocalData", "readwrite");
-      const store = transaction.objectStore("LocalData");
-      const request = store.clear();
-      request.onerror = reject;
-      request.onsuccess = resolve;
-      transaction.oncomplete = () => db.close()
-      transaction.onerror = reject
-    }
     open.onerror = reject;
-  })
-}
+  });
+
+export const getIDBItem = (key) =>
+  openDb().then(
+    (db) =>
+      new Promise((resolve, reject) => {
+        const transaction = db.transaction("LocalData", "readonly");
+        const store = transaction.objectStore("LocalData");
+        const query = store.get(key);
+        query.onsuccess = () => resolve(query.result && query.result.value);
+        query.onerror = reject;
+        transaction.oncomplete = () => db.close();
+        transaction.onerror = reject;
+      })
+  );
+
+export const setIDBItem = (key, value) =>
+  openDb().then(
+    (db) =>
+      new Promise((resolve, reject) => {
+        const transaction = db.transaction("LocalData", "readwrite");
+        const store = transaction.objectStore("LocalData");
+        const data = { id: key, value };
+        const request = store.put(data);
+        request.onerror = reject;
+        request.onsuccess = resolve;
+        transaction.oncomplete = () => db.close();
+        transaction.onerror = reject;
+      })
+  );
+
+export const clearIDBAll = () =>
+  openDb().then(
+    (db) =>
+      new Promise((resolve, reject) => {
+        const transaction = db.transaction("LocalData", "readwrite");
+        const store = transaction.objectStore("LocalData");
+        const request = store.clear();
+        request.onerror = reject;
+        request.onsuccess = resolve;
+        transaction.oncomplete = () => db.close();
+        transaction.onerror = reject;
+      })
+  );


### PR DESCRIPTION
## :star2: What does this PR do?
Makes sure we "upgrade/initialize" the database before we try to interact with it.
Before this there could be a race condition where we try before we initialize, and then after this the upgrade callback never tries to run again, as the database is already on the same requested version. So whoever got to that state wouldn't be able to get out of it, only if uninstalling and reinstalling, to clear related IDB db, I believe.
I bumped the version number to make sure the upgrade code runs.

## :bug: Recommendations for testing
* Go to chrome://extensions and inspect background.js of the extension
* Go to the "Application" tab and delete the IndexedDB database for the extension
* Disable and re-enable the extension (sometimes this wasn't enough for me. But a `chrome://restart` always seemed to do the trick
* You'll notice console errors about accessing an object store. Also, the `LocalData` object store will never get created.
* Hopefully on this branch you won't be able to get to this state.


## :memo: Links to relevant issues or information
Closes #2004

<!-- Link to relevant issues, comments, etc. -->
