### PR TITLE
Improve keyboard navigation

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -152,11 +152,11 @@ window.TogglButton = {
     '</div>' +
     `
       <div class="tb-actions-button-group">
-        <div id="toggl-button-update" tabindex="0" class="TB__Button__button">Done</div>
+        <button type="button" id="toggl-button-update" tabindex="0" class="TB__Button__button">Done</button>
       </div>
       <div class="tb-actions-button-group">
         <button type="button" id="tb-edit-form-cancel" tabindex="0" class="TB__Secondary__button">Cancel</button>
-        <div id="toggl-button-delete" tabindex="0" class="TB__Button__button danger">Delete</div>
+        <button type="button" id="toggl-button-delete" tabindex="0" class="TB__Button__button danger">Delete</button>
       </div>
     ` +
     '<input type="submit" class="toggl-button-hidden">' +

--- a/src/scripts/lib/autocomplete.js
+++ b/src/scripts/lib/autocomplete.js
@@ -133,6 +133,9 @@ AutoComplete.prototype.closeDropdown = function (t) {
   if (that.addLink) that.addLink.parentNode.classList.remove('add-allowed');
   that.clearFilters();
 
+  // Make sure focus does not remain in a now hidden input
+  that.filter.blur();
+
   // Delay enabling of tabbing again to avoid trapping focus inside this dropdown
   // completely when using SHIFT+TAB.
   setTimeout(() => that.field.setAttribute('tabindex', '0'));

--- a/src/styles/edit-form.css
+++ b/src/styles/edit-form.css
@@ -1,7 +1,10 @@
 .TB__Dialog__field {
   position: relative;
-  outline: none;
   width: 320px;
+}
+
+.TB__Dialog__field:focus {
+  outline: 2px solid #8ab7f7;
 }
 
 .TB__Dialog__field.open {
@@ -32,7 +35,6 @@
   background-color: transparent;
   padding: 10px 12px !important;
   box-shadow: none !important;
-  outline: none !important;
   border-radius: inherit;
   border: none;
   width: 100%;
@@ -42,7 +44,6 @@
   width: 100%;
   height: 36px;
   padding: 10px 12px;
-  outline: none;
   border: 1px solid var(--border-color);
   border-radius: 8px;
   transition: color .5s;
@@ -57,6 +58,7 @@
   color: #000;
   background-color: hsla(0,0%,69.4%,.07);
   border-color: transparent;
+  outline: 2px solid #8ab7f7;
 }
 .TB__Input  error {
   /* enhanced input */
@@ -140,9 +142,12 @@
   border-radius: 8px;
   box-shadow: none;
   background: var(--base-color) url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTMiIGhlaWdodD0iMTIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiPjxkZWZzPjxjaXJjbGUgaWQ9ImEiIGN4PSI1IiBjeT0iNSIgcj0iNSIvPjxtYXNrIGlkPSJiIiBtYXNrQ29udGVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgbWFza1VuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeD0iMCIgeT0iMCIgd2lkdGg9IjEwIiBoZWlnaHQ9IjEwIiBmaWxsPSIjZmZmIj48dXNlIHhsaW5rOmhyZWY9IiNhIi8+PC9tYXNrPjwvZGVmcz48ZyBzdHJva2U9IiNDRUNFQ0UiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHVzZSBtYXNrPSJ1cmwoI2IpIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgeGxpbms6aHJlZj0iI2EiLz48cGF0aCBkPSJNOCA4bDQgNCIvPjwvZz48L3N2Zz4=) 10px no-repeat;
-  outline: none;
   line-height: 28px!important;
   color: var(--font-color);
+}
+
+.TB__Popdown__filter:focus {
+  outline: 2px solid #8ab7f7;
 }
 
 #toggl-button-edit-form .TB__Popdown__filter::placeholder {
@@ -270,7 +275,6 @@
   padding: 10px 18px;
   border: none;
   border-radius: 8px;
-  outline: none;
   cursor: pointer;
   transition: all .1s;
 
@@ -293,6 +297,11 @@
   border: 1px solid var(--main-bg-color);
 }
 
+.TB__Secondary__button:focus,
+.TB__Button__button:focus {
+  outline: 2px solid #8ab7f7;
+}
+
 .TB__Button__button:focus, .TB__Button__button:hover {
   background: #DD6FD1;
 }
@@ -300,7 +309,6 @@
 .TB__Secondary__button:focus, .TB__Secondary__button:hover {
   background: var(--main-bg-color);
   color: var(--font-color);
-  outline: none;
 }
 
 .TB__Button__button.danger {


### PR DESCRIPTION


## :star2: What does this PR do?

<!-- A Concise description of what this PR achieves, including any context. -->
- Improve visual focus outlines on the edit form
- Improve tab navigation behavior on the edit form



## :bug: Recommendations for testing

Open the edit form both from the "Start timer" button embedded on the website or from the extension's own page and navigate through it using keyboard only.

## Screenshots

<img width="381" alt="Screenshot 2021-11-19 at 12 18 58" src="https://user-images.githubusercontent.com/193923/142616027-802d6f2f-88ad-487a-8db4-f8cff92762e0.png">
<img width="360" alt="Screenshot 2021-11-19 at 12 17 10" src="https://user-images.githubusercontent.com/193923/142616030-4aaf0428-95d8-471c-9b9c-221dcdd2c0be.png">
<img width="361" alt="Screenshot 2021-11-19 at 12 17 02" src="https://user-images.githubusercontent.com/193923/142616035-35384887-b3f1-48d0-bdb2-773c46a7c773.png">
<img width="365" alt="Screenshot 2021-11-19 at 12 16 55" src="https://user-images.githubusercontent.com/193923/142616039-44941028-3f42-4fc3-b53a-ae11ab35a13e.png">

