### PR TITLE
fix(Airtable): Fix showing Toggl Button in Airtable

### DIFF
--- a/src/scripts/content/airtable.js
+++ b/src/scripts/content/airtable.js
@@ -1,13 +1,13 @@
 'use strict';
 
 togglbutton.render(
-  '.detailViewWithActivityFeedBase .dialog > .header > .flex-auto:not(.toggl)',
+  '.DetailViewWithActivityFeed .detailView .body:not(.toggl)',
   { observe: true },
   function (elem) {
-    const container = $('.justify-center.relative > .items-center', elem);
+    const container = $('.recordTitle > .relative', elem);
 
     const getDescription = () => {
-      const description = $('.truncate.line-height-3', elem);
+      const description = $('.detailCell .contentEditableTextbox', elem);
       return description ? description.innerText : '';
     };
 

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1316,6 +1316,8 @@ a.toggl-button.workfront.min {
 /********* AIRTABLE ********/
 .toggl-button.airtable {
   margin-left: 30px;
+  position: relative;
+  bottom: 5px;
 }
 
 /********* PROTONMAIL *********/


### PR DESCRIPTION
## :star2: What does this PR do?

Fixes the broken selectors for Airtable, so that the Toggl Button appears in place.

## :bug: Recommendations for testing

1. Sign in to Airtable (we have test credentials)
2. Make sure the Toggl Button is visible:

<img src="https://user-images.githubusercontent.com/4663690/143243300-fe5e1c67-3b66-42ed-9338-2ed140029edf.png" width="400" />

## :memo: Links to relevant issues or information

https://github.com/toggl/toggl-button/issues/1849