### PR TITLE
Update youtrack single issue CSS selector for issueId

### DIFF
--- a/src/content/youtrack.js
+++ b/src/content/youtrack.js
@@ -64,7 +64,7 @@ togglbutton.render(
 
     const reporterInfoContainer = reporterInfo.parentElement
 
-    const issueId = $('.idLink__ee62').textContent.trim()
+    const issueId = $('[class^="idLink__"]').textContent.trim()
     const issueTitle = $('h1').textContent.trim()
 
     const link = togglbutton.createTimerLink({


### PR DESCRIPTION
## :star2: What does this PR do?

The CSS class name for issueId on the Youtrack issue board is changing apparently by some build step on YT side. Changed the static selector to a more generic one.

<!-- If you're adding a new integration, please make sure it follows the "style guide" https://github.com/toggl/toggl-button/blob/master/.github/CONTRIBUTING.md -->

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
