### PR TITLE
fix(asana): fix asana board view project selection

### DIFF
--- a/src/content/asana.js
+++ b/src/content/asana.js
@@ -6,17 +6,11 @@
 'use strict'
 
 const projectHeaderSelector = () => {
-  // Try to look for for page project title instead.
-  const projectHeader = document.querySelector(
-    '.ProjectPageHeaderProjectTitle-container',
-  )
-
+  const projectHeader = document.querySelector('.PageHeaderEditableTitle-input')
   if (!projectHeader) {
     return ''
   }
-  return projectHeader.textContent
-    .replace(/\u00a0/g, ' ') // There can be &nbsp; in Asana header content
-    .trim()
+  return projectHeader.value.trim()
 }
 
 // Board view. Inserts button next to assignee/due date.


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/track-extension/blob/master/docs/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

**Issue**

Projects weren't preselected in the Toggl button context dialog when starting from the board view.

**Cause**

Asana changed their UI, breaking the project selector.

**Solution**

Updated the selectors to match the new Asana UI structure.


All changes should be tested across Chrome and Firefox.

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## :memo: Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
