### PR TITLE
fix(trello): move timer button to header and restore popup focus

### DIFF
--- a/src/content/trello.js
+++ b/src/content/trello.js
@@ -17,8 +17,13 @@ const getCardName = () => {
   )
 }
 
-// Intercept pointerdown events on the Toggl edit form to prevent
-// Trello's card dialog from closing (same approach as Google Calendar).
+// preventDefault on pointerdown blocks Trello's card-dialog from closing
+// (by suppressing the compat mousedown event its outside-click detector uses),
+// but it also blocks native focus on form fields — so we manually re-focus
+// the click target. Same pattern as the Google Calendar integration.
+// We intentionally do NOT call stopPropagation: that would prevent the event
+// from reaching React handlers inside #homeRoot (e.g. the description input's
+// own focus/click logic), which is what made the field unresponsive before.
 function initializeObserver() {
   const observer = new MutationObserver((mutations) => {
     for (const mutation of mutations) {
@@ -26,12 +31,17 @@ function initializeObserver() {
         if (node.nodeType !== Node.ELEMENT_NODE) continue
         const homeRoot = node.querySelector('#homeRoot')
         if (homeRoot) {
+          // Exempt the Toggl popup from Trello's Atlaskit focus trap —
+          // without this, focusing any input inside gets yanked back to
+          // the card title textarea by react-focus-lock.
+          homeRoot.setAttribute('data-no-focus-lock', 'true')
           homeRoot.addEventListener(
             'pointerdown',
             (e) => {
               e.preventDefault()
-              e.stopPropagation()
-              if (e.target.focus) e.target.focus()
+              if (e.target && e.target.focus) {
+                e.target.focus()
+              }
             },
             true,
           )
@@ -54,6 +64,20 @@ togglbutton.inject(
       const existing = document.querySelector('.trello-tb-wrapper')
       if (existing) existing.remove()
 
+      const dialog = elem.closest('[data-testid="card-back-name"]')
+      const listNameContainer = dialog?.querySelector(
+        'header > div > div:first-child',
+      )
+      if (!listNameContainer) return
+
+      // Lay out the list-name container as a centered flex row so our
+      // button aligns vertically with the 'Today' dropdown instead of
+      // floating above it on the line baseline. Trello's own CSS can
+      // override plain inline styles, so use !important.
+      listNameContainer.style.setProperty('display', 'inline-flex', 'important')
+      listNameContainer.style.setProperty('flex-direction', 'row', 'important')
+      listNameContainer.style.setProperty('align-items', 'center', 'important')
+
       const link = togglbutton.createTimerLink({
         className: 'trello',
         description: getCardName,
@@ -62,12 +86,15 @@ togglbutton.inject(
       })
 
       const wrapper = createTag('div', 'trello-tb-wrapper')
-      wrapper.addEventListener('pointerdown', (e) => {
-        e.preventDefault()
-        e.stopPropagation()
-      }, true)
+      wrapper.addEventListener(
+        'pointerdown',
+        (e) => {
+          e.stopPropagation()
+        },
+        true,
+      )
       wrapper.appendChild(link)
-      elem.after(wrapper)
+      listNameContainer.appendChild(wrapper)
     },
   },
   { observe: true },

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -168,8 +168,53 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
 
 /********* TRELLO *********/
 .trello-tb-wrapper {
-  padding: 4px 0 4px 5px;
+  display: inline-flex;
+  align-items: center;
+  padding: 0 0 0 5px;
+  margin: 0 0 0 8px;
+}
+
+.trello-tb-wrapper .toggl-button,
+.trello-tb-wrapper .toggl-button > div {
+  display: inline-flex !important;
+  align-items: center;
+}
+
+.trello-tb-wrapper .toggl-button button {
+  margin-top: 5px !important;
+}
+
+/* Checklist-item hover button — match Trello's other action icons */
+[data-testid="check-item-hover-buttons"] .checklist-item-menu {
+  display: inline-flex !important;
+  align-items: center;
+  margin-left: 4px;
+}
+
+[data-testid="check-item-hover-buttons"] .checklist-item-menu .toggl-button,
+[data-testid="check-item-hover-buttons"] .checklist-item-menu .toggl-button > div {
+  display: inline-flex !important;
+  align-items: center;
+}
+
+.toggl-button.trello-list {
+  display: inline-flex !important;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 4px;
   margin: 0;
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  cursor: pointer;
+  color: var(--ds-text-subtle, #44546f);
+}
+
+.toggl-button.trello-list:hover {
+  background-color: var(--ds-background-neutral-hovered, rgba(9, 30, 66, 0.14));
+  color: var(--ds-text, #172b4d);
 }
 
 .toggl-button.trello {


### PR DESCRIPTION
## 🌟 What does this PR do?

### Issue
1. The Toggl timer button on Trello's card back was rendered below the card title, not in the header row next to the list-name dropdown where users expect it.
2. Clicking input fields inside the Toggl edit popup (description, project picker, tag picker) didn't focus them — focus was pulled back to Trello's card title textarea, making the popup unusable.

### Cause
1. The button was injected as a sibling of `[data-testid="card-back-title-input"]` — a layout that predates Trello's Atlaskit-based card-back header.
2. Two things combined:
   - The capture-phase `stopPropagation` on `#homeRoot`'s `pointerdown` listener blocked React's own focus/click handlers inside the popup from running.
   - Atlaskit's modal focus trap yanked focus back to the first focusable element in the card dialog (the title textarea) the moment an input inside `#homeRoot` tried to gain focus.

### Solution
1. Find the list-name container inside the card-back header (`header > div > div:first-child`) and append the timer wrapper into it. Force the container to `inline-flex` with centered alignment so the button visually sits next to the "Today"/"Inbox" dropdown.
2. Drop `stopPropagation` from the `#homeRoot` `pointerdown` handler (keep `preventDefault` + manual `e.target.focus()` — same pattern as `google-calendar.js`), and set `data-no-focus-lock="true"` on `#homeRoot` so Atlaskit's focus trap exempts the popup subtree.
3. CSS: new flex layout rules for `.trello-tb-wrapper`, and circular 24×24 styling for the checklist-item `.toggl-button.trello-list` so it matches Trello's native action icons (Clock, Member, Overflow).

## Test Plan

### 1. Timer button placement in card-back header
- **Setup:** Signed into Toggl Track extension, Trello board open.
- **Steps:** Open any card → observe the card-back header.
- **Expected:** "Start timer" button sits in the header row immediately to the right of the list-name dropdown ("Today"/"Inbox"/etc.), vertically aligned with it.

### 2. Toggl popup description input accepts focus
- **Setup:** Card open with an active or startable timer, Toggl extension loaded.
- **Steps:** Click the Toggl timer button to open the edit popup → click inside the description input → type a character.
- **Expected:** The description input receives focus and the typed character appears there. Focus does not jump to Trello's card title textarea. Trello's card-back modal stays open.

### 3. Checklist hover button styling
- **Setup:** A Trello card with a checklist containing at least one item.
- **Steps:** Hover over a checklist item to reveal the action icons → observe the Toggl button next to Trello's Clock/Member/Overflow icons.
- **Expected:** Toggl icon is circular, 24×24, same size and hover background as the native Trello action icons. Clicking it starts a timer with description `Card name - Item text`.

## 💬 Summarise how you feel about this PR with a gif

![perfect fit](https://media.giphy.com/media/Anr30lufE0Z1fwc9Ss/giphy.gif)