### PR TITLE
fix(linear): handle project view and stabilize issue view sidebar anchor

### DIFF
--- a/src/content/linear.js
+++ b/src/content/linear.js
@@ -38,15 +38,40 @@ togglbutton.render(
   },
 )
 
-// Add linear integration for issue view
+// Add linear integration for issue view and project view (single render)
 togglbutton.render(
-  'div[data-view-id="issue-view"]:not(.toggl)',
+  'div[data-view-id="issue-view"]:not(.toggl), [data-restore-scroll-view="project-overview"]:not(.toggl)',
   { observe: true },
   function (elem) {
-    if (elem.querySelector('.toggl-button')) {
+    if (elem.querySelector('.toggl-button')) return
+
+    // Project overview page — anchor next to the project icon at the top.
+    const iconBtn = elem.querySelector('button[aria-label="Choose icon"]')
+    if (iconBtn) {
+      const projectName = elem
+        .querySelector('[aria-label="Project name"]')
+        ?.textContent?.trim()
+
+      const link = togglbutton.createTimerLink({
+        description: projectName,
+        className: 'linear-project-view',
+        projectName: projectName,
+      })
+      link.style.cssText +=
+        ';display:inline-flex;align-items:center;line-height:0;margin-left:8px;'
+
+      // Linear's project header lays the icon out as a block, so a sibling
+      // ends up on the next row. Wrap both in a flex row so the timer
+      // button sits inline with the icon.
+      const row = document.createElement('div')
+      row.style.cssText = 'display:flex;align-items:center;gap:16px;'
+      iconBtn.parentElement.insertBefore(row, iconBtn)
+      row.appendChild(iconBtn)
+      row.appendChild(link)
       return
     }
 
+    // Issue view — anchor inside the right sidebar above the section list.
     const title = elem.querySelector('[aria-label="Issue title"]')?.textContent
     const projectElem = elem.parentElement.parentElement.querySelector(
       'svg[aria-label="Project"]',
@@ -61,7 +86,14 @@ togglbutton.render(
 
     const sidebar =
       elem.parentElement.parentElement.lastElementChild.firstElementChild
-    sidebar.lastElementChild.prepend(link)
+    const firstSectionBtn = sidebar.querySelector('button[aria-expanded]')
+    const sectionWrapper =
+      firstSectionBtn?.parentElement?.parentElement?.parentElement
+    if (sectionWrapper) {
+      sectionWrapper.prepend(link)
+    } else {
+      sidebar.appendChild(link)
+    }
   },
 )
 


### PR DESCRIPTION
## 🌟 What does this PR do?

### Issue
1. **Timer button off-screen on Linear issue pages.** On the issue detail view the Toggl button was rendering partially clipped in the top-right of the viewport instead of inside the right sidebar.
2. **No timer button on Linear project pages.** The project overview (`/project/.../overview`) had no Toggl button at all — users couldn't start a timer from a project.

### Cause
1. The issue-view render anchored the button with `sidebar.lastElementChild.prepend(link)`. Linear recently added a new positioned wrapper (`<div style="left:-3px">…`) as the last child of the sidebar, so the button was being prepended **into that wrapper**, which is positioned absolutely relative to the viewport — pushing the button off-screen.
2. The existing render only matched `div[data-view-id="issue-view"]`. Linear's project overview uses `[data-restore-scroll-view="project-overview"]` and was never targeted.

### Solution
Both pages are now handled by a single `togglbutton.render` with a combined selector, branching on which page matched:

- **Issue view:** the anchor walks up from the first `button[aria-expanded]` (Properties/Labels/… section headers) to the section container and prepends the button there. This is stable across Linear's styled-component class hashes and any extra positioned wrappers appended at the end of the sidebar.
- **Project view:** the anchor is `button[aria-label="Choose icon"]` at the top of the page. Both the icon and the timer button are wrapped in a `display:flex; align-items:center; gap:16px` row so they sit inline (Linear lays the icon out as a block by default). Project name is pulled from `[aria-label="Project name"]` and used as both the timer description and project name.

## Test Plan

### 1. Timer button visible on Linear issue page
- **Setup:** Linear account with an open issue (e.g. `linear.app/<team>/issue/FE-906/...`) and the extension loaded/signed in.
- **Steps:** Open the issue detail page → scroll the right sidebar.
- **Expected:** A "Start timer" button is rendered inside the sidebar at the top of the section list (above Properties/Labels/Project) — **not** clipped in the top-right corner of the viewport. Clicking it starts a timer with the issue title as the description.

### 2. Timer button visible on Linear project page
- **Setup:** Linear account with at least one project (e.g. `linear.app/<team>/project/<slug>/overview`) and the extension loaded/signed in.
- **Steps:** Open the project overview page.
- **Expected:** A "Start timer" button appears inline with the project icon at the top of the page, clearly separated from the icon (not stacked below it, not touching it). Clicking it starts a timer with the project name as both description and project.

## 💬 Summarise how you feel about this PR with a gif

![puzzle pieces clicking into place](https://media.giphy.com/media/WkwiIrhi0k6P9UJKtM/giphy.gif)