### PR TITLE
fix(gitlab): restore issue number prefix for work-items pages

### DIFF
--- a/src/content/gitlab.js
+++ b/src/content/gitlab.js
@@ -69,7 +69,14 @@ togglbutton.render(
 )
 
 function getId() {
-  return document.querySelector('body').getAttribute('data-page-type-id')
+  // GitLab's work-items rollout serves issue pages via WorkItemsController,
+  // whose route param is :iid (not :id), so the body's data-page-type-id is
+  // empty and the issue number disappears from the description.
+  const match = window.location.pathname.match(
+    /\/-\/(issues|work_items|merge_requests)\/(\d+)/,
+  )
+  if (match) return match[2]
+  return document.querySelector('body')?.getAttribute('data-page-type-id') ?? ''
 }
 
 function getProjectSelector() {


### PR DESCRIPTION
## 🌟 What does this PR do?

### Issue
On GitLab instances where the work-items rollout is active (self-hosted ≥ 18.8.7, and gitlab.com for migrated projects), the Toggl timer description on **issue** pages no longer includes the `#<id>` prefix — only the title is captured. MR pages are unaffected and still produce `MR<id>:: <title>`.

### Cause
`getId()` reads the issue number from `<body data-page-type-id="…">`. That attribute is populated by GitLab's `body_data` helper from `controller.params[:id]`.

When the work-items rollout is enabled, `Projects::IssuesController#show` redirects `/-/issues/:id` → `/-/work_items/:iid`. The `WorkItemsController` route is declared as `param: :iid`, so `controller.params[:id]` is `nil` and the body attribute is rendered empty. `getId()` then returns `""` and the prefix collapses out of the description.

MRs are unaffected because `/-/merge_requests/:id` is still served by `MergeRequestsController` with route param `:id`.

### Solution
Parse the IID from the URL pathname, which is reliable across both old and new GitLab routes and matches `issues`, `work_items`, and `merge_requests` paths. Fall back to the body attribute when the URL doesn't match, so coverage isn't lost on any GitLab variant that uses a different URL shape.

## Test Plan

### 1. Issue page on work-items route
- **Setup:** GitLab project where issues are served via `/-/work_items/<iid>` (current gitlab.com, or self-hosted ≥ 18.8.7 with work-items rollout). User signed in to the Toggl extension.
- **Steps:** Open any issue → click the Toggl button next to the work-item header.
- **Expected:** Timer description is `#<iid> <title>` (e.g. `#4 tesaada`), not just the title.

### 2. Issue page on legacy `/-/issues/<id>` route
- **Setup:** GitLab project still using the legacy issues route (work-items rollout off).
- **Steps:** Open any issue → click the Toggl button.
- **Expected:** Timer description is `#<id> <title>` — unchanged from previous behaviour.

### 3. Merge request page (regression check)
- **Setup:** Any GitLab project.
- **Steps:** Open any MR → click the Toggl button on the description block.
- **Expected:** Timer description is `MR<id>:: <title>` — unchanged from previous behaviour.

## 💬 Summarise how you feel about this PR with a gif

![puzzle pieces clicking together](https://media.giphy.com/media/WkwiIrhi0k6P9UJKtM/giphy.gif)