### PR TITLE
fix(notion): restore timer button in redesigned side-peek topbar

### DIFF
--- a/src/content/notion.js
+++ b/src/content/notion.js
@@ -13,23 +13,68 @@ function createWrapper(link) {
   return wrapper
 }
 
+// Climb from the share button to the peek panel that owns it, so the title
+// lookup stays scoped to the peek and never grabs the title of the full page
+// rendered behind it. The panel is the nearest ancestor that contains the
+// page title (the peek body lives below the topbar inside that same panel).
+function findPeekRoot(node) {
+  let current = node.closest('.notion-peek-renderer')
+  if (current) return current
+  current = node
+  while (current && current !== document.body) {
+    if (
+      current.querySelector(
+        'h1[contenteditable], h1[aria-roledescription="page title"]',
+      )
+    ) {
+      return current
+    }
+    current = current.parentElement
+  }
+  return null
+}
+
+// Find the direct child of the action-button row that holds the share button.
+// The row is the nearest ancestor that also contains the other topbar action
+// buttons; inserting the timer button before that child drops it into the row
+// rather than into the share button's own (tiny) wrapper.
+function getShareRowChild(shareButton) {
+  let row = shareButton.parentElement
+  while (
+    row &&
+    row !== document.body &&
+    !row.querySelector(
+      '.notion-topbar-more-button, .notion-topbar-comments-button',
+    )
+  ) {
+    row = row.parentElement
+  }
+  if (!row || row === document.body) return null
+
+  let child = shareButton
+  while (child.parentElement && child.parentElement !== row) {
+    child = child.parentElement
+  }
+  return child
+}
+
 // Button renders in popup/dialog (side-peek) view.
-// Target the share menu inside the peek renderer so that when React
-// re-renders and recreates the share button, the observer re-triggers.
+// Target the share menu inside the peek topbar so that when React re-renders
+// and recreates the share button, the observer re-triggers. Notion's peek
+// topbar markup changes often; match both the legacy `.notion-peek-renderer`
+// shell and the newer `.peek-top-hover-area` one.
 togglbutton.render(
-  '.notion-peek-renderer .notion-topbar-share-menu:not(.toggl)',
+  '.notion-peek-renderer .notion-topbar-share-menu:not(.toggl), .peek-top-hover-area .notion-topbar-share-menu:not(.toggl)',
   { observe: true },
   function (elem) {
     if (!elem) return
 
-    const peekRenderer = elem.closest('.notion-peek-renderer')
+    const peekRoot = findPeekRoot(elem)
 
     function getDescription() {
-      const descriptionElem = peekRenderer
-        ? peekRenderer.querySelector('h1[contenteditable]') ||
-          peekRenderer.querySelector(
-            'h1[aria-roledescription="page title"]',
-          )
+      const descriptionElem = peekRoot
+        ? peekRoot.querySelector('h1[contenteditable]') ||
+          peekRoot.querySelector('h1[aria-roledescription="page title"]')
         : null
       return descriptionElem ? descriptionElem.textContent.trim() : ''
     }
@@ -42,7 +87,12 @@ togglbutton.render(
 
     const wrapper = createWrapper(link)
 
-    elem.parentElement.prepend(wrapper)
+    const shareRowChild = getShareRowChild(elem)
+    if (shareRowChild) {
+      shareRowChild.parentElement.insertBefore(wrapper, shareRowChild)
+    } else {
+      elem.parentElement.prepend(wrapper)
+    }
   },
 )
 


### PR DESCRIPTION
## 🌟 What does this PR do?

### Issue
The Toggl timer button disappeared from Notion pages opened in **side-peek** view, so users could no longer start a timer from a peeked page.

### Cause
Notion shipped a redesigned side-peek topbar. The action buttons (Share, Comments, Favorite, …) now live in a new `peek-top-hover-area` container behind deeply-nested, obfuscated wrappers, and the old `.notion-topbar-action-buttons` row is gone from the peek. The previous code:
- Anchored on a `.notion-peek-renderer` ancestor, which the redesign no longer guarantees.
- Inserted the button with `elem.parentElement.prepend(wrapper)`, which now lands inside the Share button's own tiny single-button wrapper instead of the action row — so the button effectively vanished.

### Solution
Anchor on the Notion class names that survived the redesign (`notion-topbar-share-menu`, `notion-topbar-more-button`, `notion-topbar-comments-button`) instead of the volatile container shell:
- **Selector** now matches the share menu in either the legacy `.notion-peek-renderer` shell **or** the new `.peek-top-hover-area`, so the observer keeps re-triggering on React re-renders.
- **`getShareRowChild()`** walks up from Share to the real action-button row (the nearest ancestor that also holds the Comments/More buttons) and inserts the timer button beside Share inside that row — robust to however deeply Notion nests the wrappers.
- **`findPeekRoot()`** scopes the page-title lookup to the peek panel (nearest ancestor containing the title `h1`), so the description is never taken from the full page rendered behind the peek; if no peek panel is found it falls back to an empty description rather than the wrong one.

The wrapper styling (`.toggl-button-notion-wrapper`) is not scoped to `.notion-peek-renderer`, so the button renders correctly in the new container.

## Test Plan

### 1. Timer button restored in side-peek view
- **Setup:** Logged in to the extension; open any Notion page that contains a sub-page or database row.
- **Steps:** Click a row/sub-page to open it in side-peek → look at the peek topbar next to the Share button.
- **Expected:** The Toggl timer button appears beside Share and is clickable.

### 2. Description captured from the peeked page
- **Setup:** Open a page titled e.g. "User Roles in Toggl Focus" in side-peek.
- **Steps:** Click the Toggl timer button in the peek topbar → open the Toggl tracker.
- **Expected:** A timer starts with the description set to the **peeked** page's title (not the full page behind it).

### 3. Button persists across React re-renders
- **Setup:** Side-peek open with the timer button visible.
- **Steps:** Interact with the peek (edit content, toggle peek mode, hover the topbar) so Notion re-renders the topbar.
- **Expected:** The timer button stays present / is re-injected, not lost.

## 💬 Summarise how you feel about this PR with a gif

![back from the dead](https://media.giphy.com/media/l0HlPystfePnAI3G8/giphy.gif)
