### PR TITLE
fix(trello): keep timer button visible and stop breaking card cover images

### DIFF
--- a/src/content/notion.js
+++ b/src/content/notion.js
@@ -13,23 +13,68 @@ function createWrapper(link) {
   return wrapper
 }
 
+// Climb from the share button to the peek panel that owns it, so the title
+// lookup stays scoped to the peek and never grabs the title of the full page
+// rendered behind it. The panel is the nearest ancestor that contains the
+// page title (the peek body lives below the topbar inside that same panel).
+function findPeekRoot(node) {
+  let current = node.closest('.notion-peek-renderer')
+  if (current) return current
+  current = node
+  while (current && current !== document.body) {
+    if (
+      current.querySelector(
+        'h1[contenteditable], h1[aria-roledescription="page title"]',
+      )
+    ) {
+      return current
+    }
+    current = current.parentElement
+  }
+  return null
+}
+
+// Find the direct child of the action-button row that holds the share button.
+// The row is the nearest ancestor that also contains the other topbar action
+// buttons; inserting the timer button before that child drops it into the row
+// rather than into the share button's own (tiny) wrapper.
+function getShareRowChild(shareButton) {
+  let row = shareButton.parentElement
+  while (
+    row &&
+    row !== document.body &&
+    !row.querySelector(
+      '.notion-topbar-more-button, .notion-topbar-comments-button',
+    )
+  ) {
+    row = row.parentElement
+  }
+  if (!row || row === document.body) return null
+
+  let child = shareButton
+  while (child.parentElement && child.parentElement !== row) {
+    child = child.parentElement
+  }
+  return child
+}
+
 // Button renders in popup/dialog (side-peek) view.
-// Target the share menu inside the peek renderer so that when React
-// re-renders and recreates the share button, the observer re-triggers.
+// Target the share menu inside the peek topbar so that when React re-renders
+// and recreates the share button, the observer re-triggers. Notion's peek
+// topbar markup changes often; match both the legacy `.notion-peek-renderer`
+// shell and the newer `.peek-top-hover-area` one.
 togglbutton.render(
-  '.notion-peek-renderer .notion-topbar-share-menu:not(.toggl)',
+  '.notion-peek-renderer .notion-topbar-share-menu:not(.toggl), .peek-top-hover-area .notion-topbar-share-menu:not(.toggl)',
   { observe: true },
   function (elem) {
     if (!elem) return
 
-    const peekRenderer = elem.closest('.notion-peek-renderer')
+    const peekRoot = findPeekRoot(elem)
 
     function getDescription() {
-      const descriptionElem = peekRenderer
-        ? peekRenderer.querySelector('h1[contenteditable]') ||
-          peekRenderer.querySelector(
-            'h1[aria-roledescription="page title"]',
-          )
+      const descriptionElem = peekRoot
+        ? peekRoot.querySelector('h1[contenteditable]') ||
+          peekRoot.querySelector('h1[aria-roledescription="page title"]')
         : null
       return descriptionElem ? descriptionElem.textContent.trim() : ''
     }
@@ -42,7 +87,12 @@ togglbutton.render(
 
     const wrapper = createWrapper(link)
 
-    elem.parentElement.prepend(wrapper)
+    const shareRowChild = getShareRowChild(elem)
+    if (shareRowChild) {
+      shareRowChild.parentElement.insertBefore(wrapper, shareRowChild)
+    } else {
+      elem.parentElement.prepend(wrapper)
+    }
   },
 )
 

--- a/src/content/trello.js
+++ b/src/content/trello.js
@@ -96,11 +96,6 @@ togglbutton.inject(
       })
 
       const wrapper = createTag('div', 'trello-tb-wrapper')
-      // Covers render behind the header controls, so the transparent button
-      // is invisible on top of them — give it a solid pill when one exists.
-      if (header.querySelector('[data-testid="card-cover"]')) {
-        wrapper.classList.add('trello-tb-wrapper--on-cover')
-      }
       wrapper.addEventListener(
         'pointerdown',
         (e) => {

--- a/src/content/trello.js
+++ b/src/content/trello.js
@@ -13,7 +13,9 @@ const getProject = () => {
 
 const getCardName = () => {
   return (
-    document.querySelector('[data-testid="card-back-title-input"]')?.value?.trim() ?? ''
+    document
+      .querySelector('[data-testid="card-back-title-input"]')
+      ?.value?.trim() ?? ''
   )
 }
 
@@ -65,9 +67,17 @@ togglbutton.inject(
       if (existing) existing.remove()
 
       const dialog = elem.closest('[data-testid="card-back-name"]')
-      const listNameContainer = dialog?.querySelector(
-        'header > div > div:first-child',
-      )
+      const header = dialog?.querySelector('header')
+      if (!header) return
+
+      // Anchor on the always-present actions ("…") button to reach the
+      // controls bar, then take its first child (the list-name dropdown).
+      // The card cover lives in a separate header child, so this never
+      // selects the cover — flexing the cover used to collapse its image.
+      const controlsBar = header
+        .querySelector('[data-testid="card-back-actions-button"]')
+        ?.closest('ul')?.parentElement
+      const listNameContainer = controlsBar?.firstElementChild
       if (!listNameContainer) return
 
       // Lay out the list-name container as a centered flex row so our
@@ -86,6 +96,11 @@ togglbutton.inject(
       })
 
       const wrapper = createTag('div', 'trello-tb-wrapper')
+      // Covers render behind the header controls, so the transparent button
+      // is invisible on top of them — give it a solid pill when one exists.
+      if (header.querySelector('[data-testid="card-cover"]')) {
+        wrapper.classList.add('trello-tb-wrapper--on-cover')
+      }
       wrapper.addEventListener(
         'pointerdown',
         (e) => {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -238,22 +238,28 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
   color: var(--ds-text, #172b4d) !important;
 }
 
-/* Card has a cover image: the button overlays it, so give it a solid pill */
+/* Card has a cover image: the button overlays it, so render it as a solid
+   Trello-style button (like the list dropdown) instead of bare text. */
 .trello-tb-wrapper--on-cover {
-  padding: 2px 8px;
+  padding: 0;
   margin-left: 8px;
-  background-color: var(--ds-surface-overlay, #ffffff);
-  border-radius: 8px;
+}
+
+.trello-tb-wrapper--on-cover .toggl-button.trello {
+  height: 32px;
+  padding: 0 12px;
+  gap: 6px;
+  border-radius: 3px;
+  font-weight: 500;
+  margin-top: 0 !important;
+  color: var(--ds-text, #172b4d) !important;
+  background-color: var(--ds-surface-overlay, #ffffff) !important;
   box-shadow: var(--ds-shadow-overlay, 0 1px 3px rgba(9, 30, 66, 0.25));
 }
 
-.trello-tb-wrapper--on-cover .toggl-button.trello,
 .trello-tb-wrapper--on-cover .toggl-button.trello:hover {
   color: var(--ds-text, #172b4d) !important;
-}
-
-.trello-tb-wrapper--on-cover .toggl-button button {
-  margin-top: 0 !important;
+  background-color: var(--ds-surface-overlay-hovered, #f7f8f9) !important;
 }
 
 /********* BASECAMP *********/

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -228,10 +228,13 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  box-sizing: border-box;
   height: 28px;
+  min-height: 0 !important;
   padding: 0 10px;
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 500;
+  line-height: 1;
   border-radius: 3px;
   color: var(--ds-text, #172b4d) !important;
   background-color: var(
@@ -241,8 +244,8 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
 }
 
 .toggl-button.trello svg {
-  width: 16px;
-  height: 16px;
+  width: 14px !important;
+  height: 14px !important;
 }
 
 .toggl-button.trello:hover {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -239,7 +239,7 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
   font-size: 14px;
   font-weight: 500;
   line-height: 1;
-  border-radius: 3px;
+  border-radius: 8px;
   color: var(--ds-text, #172b4d) !important;
   background-color: var(
     --ds-background-accent-gray-subtler,

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -185,14 +185,17 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
 }
 
 /* Checklist-item hover button — match Trello's other action icons */
-[data-testid="check-item-hover-buttons"] .checklist-item-menu {
+[data-testid='check-item-hover-buttons'] .checklist-item-menu {
   display: inline-flex !important;
   align-items: center;
   margin-left: 4px;
 }
 
-[data-testid="check-item-hover-buttons"] .checklist-item-menu .toggl-button,
-[data-testid="check-item-hover-buttons"] .checklist-item-menu .toggl-button > div {
+[data-testid='check-item-hover-buttons'] .checklist-item-menu .toggl-button,
+[data-testid='check-item-hover-buttons']
+  .checklist-item-menu
+  .toggl-button
+  > div {
   display: inline-flex !important;
   align-items: center;
 }
@@ -233,6 +236,24 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
 
 .toggl-button.trello:hover {
   color: var(--ds-text, #172b4d) !important;
+}
+
+/* Card has a cover image: the button overlays it, so give it a solid pill */
+.trello-tb-wrapper--on-cover {
+  padding: 2px 8px;
+  margin-left: 8px;
+  background-color: var(--ds-surface-overlay, #ffffff);
+  border-radius: 8px;
+  box-shadow: var(--ds-shadow-overlay, 0 1px 3px rgba(9, 30, 66, 0.25));
+}
+
+.trello-tb-wrapper--on-cover .toggl-button.trello,
+.trello-tb-wrapper--on-cover .toggl-button.trello:hover {
+  color: var(--ds-text, #172b4d) !important;
+}
+
+.trello-tb-wrapper--on-cover .toggl-button button {
+  margin-top: 0 !important;
 }
 
 /********* BASECAMP *********/

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -229,10 +229,10 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
   align-items: center;
   gap: 6px;
   box-sizing: border-box;
-  height: 28px;
+  height: 24px;
   min-height: 0 !important;
-  padding: 0 10px;
-  font-size: 13px;
+  padding: 0 8px;
+  font-size: 14px;
   font-weight: 500;
   line-height: 1;
   border-radius: 3px;

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -170,7 +170,8 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
 .trello-tb-wrapper {
   display: inline-flex;
   align-items: center;
-  padding: 0 0 0 5px;
+  align-self: center;
+  padding: 0;
   margin: 0 0 0 8px;
 }
 
@@ -178,10 +179,11 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
 .trello-tb-wrapper .toggl-button > div {
   display: inline-flex !important;
   align-items: center;
+  margin: 0 !important;
 }
 
 .trello-tb-wrapper .toggl-button button {
-  margin-top: 0 !important;
+  margin: 0 !important;
 }
 
 /* Checklist-item hover button — match Trello's other action icons */

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -238,8 +238,8 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
   color: var(--ds-text, #172b4d) !important;
 }
 
-/* Card has a cover image: the button overlays it, so render it as a solid
-   Trello-style button (like the list dropdown) instead of bare text. */
+/* Card has a cover image: the button overlays it, so render it as a flat
+   Trello-style button matching the list dropdown instead of bare text. */
 .trello-tb-wrapper--on-cover {
   padding: 0;
   margin-left: 8px;
@@ -253,13 +253,18 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
   font-weight: 500;
   margin-top: 0 !important;
   color: var(--ds-text, #172b4d) !important;
-  background-color: var(--ds-surface-overlay, #ffffff) !important;
-  box-shadow: var(--ds-shadow-overlay, 0 1px 3px rgba(9, 30, 66, 0.25));
+  background-color: var(
+    --ds-background-accent-gray-subtler,
+    rgba(9, 30, 66, 0.08)
+  ) !important;
 }
 
 .trello-tb-wrapper--on-cover .toggl-button.trello:hover {
   color: var(--ds-text, #172b4d) !important;
-  background-color: var(--ds-surface-overlay-hovered, #f7f8f9) !important;
+  background-color: var(
+    --ds-background-accent-gray-subtler-hovered,
+    rgba(9, 30, 66, 0.14)
+  ) !important;
 }
 
 /********* BASECAMP *********/

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -239,7 +239,7 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
   font-size: 14px;
   font-weight: 500;
   line-height: 1;
-  border-radius: 8px;
+  border-radius: var(--ds-radius-small, 3px);
   color: var(--ds-text, #172b4d) !important;
   background-color: var(
     --ds-background-accent-gray-subtler,

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -228,8 +228,8 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  height: 32px;
-  padding: 0 12px;
+  height: 28px;
+  padding: 0 10px;
   font-size: 14px;
   font-weight: 500;
   border-radius: 3px;
@@ -238,6 +238,11 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
     --ds-background-accent-gray-subtler,
     rgba(9, 30, 66, 0.08)
   ) !important;
+}
+
+.toggl-button.trello svg {
+  width: 16px;
+  height: 16px;
 }
 
 .toggl-button.trello:hover {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -181,7 +181,7 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
 }
 
 .trello-tb-wrapper .toggl-button button {
-  margin-top: 5px !important;
+  margin-top: 0 !important;
 }
 
 /* Checklist-item hover button — match Trello's other action icons */
@@ -220,38 +220,19 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
   color: var(--ds-text, #172b4d);
 }
 
+/* Render as a flat Trello-style button matching the list dropdown. */
 .toggl-button.trello {
   text-decoration: none;
   cursor: pointer;
-  color: var(--ds-text-subtle, #44546f) !important;
+  white-space: nowrap;
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  height: 24px;
-  padding: 0;
-  font-size: 12px;
-  background: none;
-  white-space: nowrap;
-}
-
-.toggl-button.trello:hover {
-  color: var(--ds-text, #172b4d) !important;
-}
-
-/* Card has a cover image: the button overlays it, so render it as a flat
-   Trello-style button matching the list dropdown instead of bare text. */
-.trello-tb-wrapper--on-cover {
-  padding: 0;
-  margin-left: 8px;
-}
-
-.trello-tb-wrapper--on-cover .toggl-button.trello {
+  gap: 6px;
   height: 32px;
   padding: 0 12px;
-  gap: 6px;
-  border-radius: 3px;
+  font-size: 14px;
   font-weight: 500;
-  margin-top: 0 !important;
+  border-radius: 3px;
   color: var(--ds-text, #172b4d) !important;
   background-color: var(
     --ds-background-accent-gray-subtler,
@@ -259,7 +240,7 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
   ) !important;
 }
 
-.trello-tb-wrapper--on-cover .toggl-button.trello:hover {
+.toggl-button.trello:hover {
   color: var(--ds-text, #172b4d) !important;
   background-color: var(
     --ds-background-accent-gray-subtler-hovered,

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -230,6 +230,8 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  position: relative;
+  top: 2px; /* match the list dropdown's 2px internal text offset */
   box-sizing: border-box;
   height: 24px;
   min-height: 0 !important;


### PR DESCRIPTION
## 🌟 What does this PR do?

### Issue
On a Trello card that has a **cover image**, the card-back timer button broke in two ways:
1. **Cover image destroyed** — reopening the card shoved the cover image into a tiny thumbnail on the left and hid the button entirely.
2. **Button hard to see / inconsistent** — over a cover the button had no background and dark text, so it blended into the image; it also didn't match Trello's native header controls.

### Cause
The button was injected via `header > div > div:first-child`. That resolves to the list-name container **only when there is no cover**. When a cover exists, Trello renders it as `header`'s first `div` (`[data-testid="card-cover"]`, a `background-image` element), so `:first-child` resolved to the **cover** itself. The renderer then forced `display: inline-flex !important` on the cover (collapsing the image to a thumbnail) and appended the button **inside** it. It worked on first open only because the cover hadn't rendered yet when the observer fired.

### Solution
- **Stable anchor:** locate the list-name container via the always-present `[data-testid="card-back-actions-button"]` → its `<ul>` → the controls bar → its first child (the list dropdown). The cover lives in a separate header child, so it is never selected, flexed, or used as an injection target.
- **Native styling:** render the card-back button as a flat Trello-style pill matching the list dropdown — `--ds-background-accent-gray-subtler` background, `--ds-text` text, 3px radius, 32px height, no shadow, with a matching hover. Applied consistently on every card (cover or not) so it always looks like a Trello header control and stays legible on top of cover images.

Note: selectors are anchored to live Trello markup captured from a covered card; couldn't run the extension against Trello locally, so please verify in-browser (test plan below).

## Test Plan

### 1. Reopening a covered card no longer breaks the image
- **Setup:** A Trello card with an image set as its cover.
- **Steps:** Open the card → close it → open it again.
- **Expected:** The cover image renders full-size every time; it is never collapsed into a thumbnail.

### 2. Button looks native and is legible
- **Setup:** Cards both with and without a cover image.
- **Steps:** Open each card → look at the header next to the list dropdown.
- **Expected:** The timer button appears as a flat gray pill matching the "This Week" list dropdown, clearly readable in both cases, and clickable.

### 3. Typing/filtering still works
- **Setup:** Any open card.
- **Steps:** Click the timer button → type a project/tag name in the Toggl popup.
- **Expected:** Keystrokes go to the popup (not captured by Trello), and the card dialog stays open.

## 💬 Summarise how you feel about this PR with a gif

![now you see it](https://media.giphy.com/media/3o7TKMt1VVNkHV2PaE/giphy.gif)
