### PR TITLE
fix(trello): keep timer button visible over card covers and match list-dropdown style

### DIFF
--- a/src/content/trello.js
+++ b/src/content/trello.js
@@ -13,7 +13,9 @@ const getProject = () => {
 
 const getCardName = () => {
   return (
-    document.querySelector('[data-testid="card-back-title-input"]')?.value?.trim() ?? ''
+    document
+      .querySelector('[data-testid="card-back-title-input"]')
+      ?.value?.trim() ?? ''
   )
 }
 
@@ -65,9 +67,17 @@ togglbutton.inject(
       if (existing) existing.remove()
 
       const dialog = elem.closest('[data-testid="card-back-name"]')
-      const listNameContainer = dialog?.querySelector(
-        'header > div > div:first-child',
-      )
+      const header = dialog?.querySelector('header')
+      if (!header) return
+
+      // Anchor on the always-present actions ("…") button to reach the
+      // controls bar, then take its first child (the list-name dropdown).
+      // The card cover lives in a separate header child, so this never
+      // selects the cover — flexing the cover used to collapse its image.
+      const controlsBar = header
+        .querySelector('[data-testid="card-back-actions-button"]')
+        ?.closest('ul')?.parentElement
+      const listNameContainer = controlsBar?.firstElementChild
       if (!listNameContainer) return
 
       // Lay out the list-name container as a centered flex row so our

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -170,7 +170,8 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
 .trello-tb-wrapper {
   display: inline-flex;
   align-items: center;
-  padding: 0 0 0 5px;
+  align-self: center;
+  padding: 0;
   margin: 0 0 0 8px;
 }
 
@@ -178,21 +179,25 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
 .trello-tb-wrapper .toggl-button > div {
   display: inline-flex !important;
   align-items: center;
+  margin: 0 !important;
 }
 
 .trello-tb-wrapper .toggl-button button {
-  margin-top: 5px !important;
+  margin: 0 !important;
 }
 
 /* Checklist-item hover button — match Trello's other action icons */
-[data-testid="check-item-hover-buttons"] .checklist-item-menu {
+[data-testid='check-item-hover-buttons'] .checklist-item-menu {
   display: inline-flex !important;
   align-items: center;
   margin-left: 4px;
 }
 
-[data-testid="check-item-hover-buttons"] .checklist-item-menu .toggl-button,
-[data-testid="check-item-hover-buttons"] .checklist-item-menu .toggl-button > div {
+[data-testid='check-item-hover-buttons'] .checklist-item-menu .toggl-button,
+[data-testid='check-item-hover-buttons']
+  .checklist-item-menu
+  .toggl-button
+  > div {
   display: inline-flex !important;
   align-items: center;
 }
@@ -217,22 +222,42 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
   color: var(--ds-text, #172b4d);
 }
 
+/* Render as a flat Trello-style button matching the list dropdown. */
 .toggl-button.trello {
   text-decoration: none;
   cursor: pointer;
-  color: var(--ds-text-subtle, #44546f) !important;
+  white-space: nowrap;
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: 6px;
+  position: relative;
+  top: 2px; /* match the list dropdown's 2px internal text offset */
+  box-sizing: border-box;
   height: 24px;
-  padding: 0;
-  font-size: 12px;
-  background: none;
-  white-space: nowrap;
+  min-height: 0 !important;
+  padding: 0 8px;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1;
+  border-radius: var(--ds-radius-small, 3px);
+  color: var(--ds-text, #172b4d) !important;
+  background-color: var(
+    --ds-background-accent-gray-subtler,
+    rgba(9, 30, 66, 0.08)
+  ) !important;
+}
+
+.toggl-button.trello svg {
+  width: 14px !important;
+  height: 14px !important;
 }
 
 .toggl-button.trello:hover {
   color: var(--ds-text, #172b4d) !important;
+  background-color: var(
+    --ds-background-accent-gray-subtler-hovered,
+    rgba(9, 30, 66, 0.14)
+  ) !important;
 }
 
 /********* BASECAMP *********/


### PR DESCRIPTION
## 🌟 What does this PR do?

### Issue
On a Trello card that has a **cover image**, the card-back timer button broke:
1. **Cover image destroyed** — reopening the card collapsed the cover into a tiny thumbnail on the left and hid the button entirely.
2. **Button looked off** — it had no background and dark text (invisible over the cover), and didn't match Trello's native header controls.

### Cause
The button was injected via `header > div > div:first-child`. That resolves to the list-name container **only when there is no cover**. When a cover exists, Trello renders it as `header`'s first `div` (`[data-testid="card-cover"]`, a `background-image` element), so `:first-child` resolved to the **cover** itself. The renderer then forced `display: inline-flex !important` on the cover (collapsing the image) and appended the button **inside** it. It worked on first open only because the cover hadn't rendered yet when the observer fired.

### Solution
- **Stable anchor (fixes the broken cover):** locate the list-name container via the always-present `[data-testid="card-back-actions-button"]` → its `<ul>` → the controls bar → its first child (the list dropdown). The cover lives in a separate header child, so it is never selected, flexed, or used as an injection target.
- **Native styling:** render the card-back button as a flat Trello-style pill matching the **This Week** list dropdown — `--ds-background-accent-gray-subtler` background, `--ds-text` colour, `--ds-radius-small` corners, 24px height, 14px text, no shadow, with a matching hover. Custom properties are inherited from Trello's themed root, so colours/radius track Trello (including dark mode). Margins are zeroed and a 2px offset is applied so it sits flush with the dropdown. Shown consistently on every card so it always looks like a Trello control and stays legible on covers.

_Selectors are anchored to live Trello markup captured from a covered card; verified visually in-browser (alignment/size/radius matched against the list dropdown via DevTools)._

## Test Plan

### 1. Reopening a covered card no longer breaks the image
- **Setup:** A Trello card with an image cover.
- **Steps:** Open the card → close it → open it again.
- **Expected:** The cover image renders full-size every time; it is never collapsed into a thumbnail.

### 2. Button looks native, legible, and aligned
- **Setup:** Cards both with and without a cover image.
- **Steps:** Open each card → look at the header next to the list dropdown.
- **Expected:** The timer button is a flat gray pill matching the "This Week" dropdown (same height, corner radius, vertical alignment), readable in both cases, and clickable.

### 3. Typing/filtering still works
- **Setup:** Any open card.
- **Steps:** Click the timer button → type a project/tag name in the Toggl popup.
- **Expected:** Keystrokes go to the popup (not captured by Trello), and the card dialog stays open.

## 💬 Summarise how you feel about this PR with a gif

![pixel perfect](https://media.giphy.com/media/3o7TKMt1VVNkHV2PaE/giphy.gif)
