### PR TITLE
fix(notion): anchor side-peek timer button on close button, not shell class

### DIFF
--- a/.github/workflows/update-origins.js
+++ b/.github/workflows/update-origins.js
@@ -65,7 +65,9 @@ exec(`git diff --name-only HEAD^ HEAD`, (_, out) => {
   const newOrigins = infos.reduce(
     (_origins, { name, urlAlias, urlRegex, file }) => ({
       ...origins,
-      [urlAlias]: { url: urlRegex, name, file },
+      // Preserve manually-maintained fields on an existing entry (e.g.
+      // `aliasOf`) instead of overwriting it with only url/name/file.
+      [urlAlias]: { ...origins[urlAlias], url: urlRegex, name, file },
     }),
     origins
   );

--- a/src/content/notion.js
+++ b/src/content/notion.js
@@ -58,16 +58,32 @@ function getShareRowChild(shareButton) {
   return child
 }
 
-// Button renders in popup/dialog (side-peek) view.
-// Target the share menu inside the peek topbar so that when React re-renders
-// and recreates the share button, the observer re-triggers. Notion's peek
-// topbar markup changes often; match both the legacy `.notion-peek-renderer`
-// shell and the newer `.peek-top-hover-area` one.
+// Walk up from the share button to the peek topbar that owns it. The topbar is
+// identified by the close button (`.notion-peek-close`), which only exists in a
+// peek — the full-page topbar has none — so this also tells a peek share menu
+// apart from the full-page one rendered behind it.
+function getPeekTopbar(shareButton) {
+  let topbar = shareButton.parentElement
+  while (topbar && topbar !== document.body) {
+    if (topbar.querySelector('.notion-peek-close')) return topbar
+    topbar = topbar.parentElement
+  }
+  return null
+}
+
+// Button renders in popup/dialog (side-peek) view. Notion keeps reshuffling the
+// peek shell class (legacy `.notion-peek-renderer`, then `.peek-top-hover-area`,
+// now neither wraps the share button), so anchor on the share menu directly and
+// gate to peeks via the close button instead of chasing the shell class.
 togglbutton.render(
-  '.notion-peek-renderer .notion-topbar-share-menu:not(.toggl), .peek-top-hover-area .notion-topbar-share-menu:not(.toggl)',
+  '.notion-topbar-share-menu:not(.toggl)',
   { observe: true },
   function (elem) {
     if (!elem) return
+
+    const topbar = getPeekTopbar(elem)
+    if (!topbar) return
+    if (topbar.querySelector('.toggl-button-notion-wrapper')) return
 
     const peekRoot = findPeekRoot(elem)
 

--- a/src/content/notion.js
+++ b/src/content/notion.js
@@ -2,6 +2,8 @@
  * @name Notion
  * @urlAlias notion.so
  * @urlRegex *://*.notion.so/*
+ * @urlAlias notion.com
+ * @urlRegex *://*.notion.com/*
  */
 'use strict'
 

--- a/src/content/notion.js
+++ b/src/content/notion.js
@@ -60,17 +60,27 @@ function getShareRowChild(shareButton) {
   return child
 }
 
-// Walk up from the share button to the peek topbar that owns it. The topbar is
-// identified by the close button (`.notion-peek-close`), which only exists in a
-// peek — the full-page topbar has none — so this also tells a peek share menu
-// apart from the full-page one rendered behind it.
+// Resolve the peek topbar that owns this share button, bounded so a full-page
+// share button can't match a peek open elsewhere in the document. The topbar is
+// the container of the action-button group (the group holding more/comments);
+// its other side holds the peek close button (`.notion-peek-close`), which only
+// exists in a peek. The close lookup is scoped to that bounded topbar rather
+// than searching broad ancestors' whole subtrees.
 function getPeekTopbar(shareButton) {
-  let topbar = shareButton.parentElement
-  while (topbar && topbar !== document.body) {
-    if (topbar.querySelector('.notion-peek-close')) return topbar
-    topbar = topbar.parentElement
+  let group = shareButton.parentElement
+  while (
+    group &&
+    group !== document.body &&
+    !group.querySelector(
+      '.notion-topbar-more-button, .notion-topbar-comments-button',
+    )
+  ) {
+    group = group.parentElement
   }
-  return null
+  if (!group || group === document.body) return null
+
+  const topbar = group.parentElement
+  return topbar && topbar.querySelector('.notion-peek-close') ? topbar : null
 }
 
 // Button renders in popup/dialog (side-peek) view. Notion keeps reshuffling the

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,6 +5,7 @@ declare const _default = origins as {
     name: string;
     url: string;
     file?: string;
+    aliasOf?: string;
   };
 };
 

--- a/src/origins.js
+++ b/src/origins.js
@@ -427,6 +427,12 @@ export default {
     name: 'Notion',
     file: 'notion.js'
   },
+  'notion.com': {
+    url: '*://*.notion.com/*',
+    name: 'Notion',
+    file: 'notion.js',
+    aliasOf: 'notion.so'
+  },
   'app.nozbe.com': {
     url: '*://app.nozbe.com/*',
     name: 'Nozbe'

--- a/src/origins.js
+++ b/src/origins.js
@@ -430,8 +430,7 @@ export default {
   'notion.com': {
     url: '*://*.notion.com/*',
     name: 'Notion',
-    file: 'notion.js',
-    aliasOf: 'notion.so'
+    file: 'notion.js'
   },
   'app.nozbe.com': {
     url: '*://app.nozbe.com/*',

--- a/src/origins.js
+++ b/src/origins.js
@@ -430,7 +430,8 @@ export default {
   'notion.com': {
     url: '*://*.notion.com/*',
     name: 'Notion',
-    file: 'notion.js'
+    file: 'notion.js',
+    aliasOf: 'notion.so'
   },
   'app.nozbe.com': {
     url: '*://app.nozbe.com/*',


### PR DESCRIPTION
## 🌟 What does this PR do?

### Issue
The Toggl timer button disappeared from Notion's **side-peek** view — users with the Notion integration enabled saw no button next to "Share" when opening a page in the peek. It also never appeared at all on Notion's newer **`app.notion.com`** domain.

### Cause
Two separate regressions:
1. **The peek selector broke.** Notion redesigned the side-peek topbar and moved the Share button out of the wrapper classes the integration keyed on (`.notion-peek-renderer` / `.peek-top-hover-area`). The render selector matched nothing, so the button never rendered.
2. **The newer domain was unsupported.** Notion now serves the app on `app.notion.com` (root domain `notion.com`), which the integration never registered — only `notion.so` existed in the origins, so nothing injected there.

### Solution
1. **Anchor on `.notion-peek-close`** instead of chasing Notion's rotating shell classes. The close button exists only in a peek topbar (the full-page topbar has none), so it both locates the peek's topbar and distinguishes the peek's share menu from the full-page one rendered behind it. Added an idempotency guard (skip if a wrapper already exists) and kept the existing `getShareRowChild` insertion.
2. **Added a `notion.com` origin that aliases `notion.so`** (`aliasOf: 'notion.so'`), plus the `aliasOf` field on the origin type. Aliasing means `app.notion.com` is treated as the *same* "Notion" integration — no second toggle, and existing Notion-enabled users get it automatically. The consuming alias logic lives in **toggl/track-extension-core#1547** (required companion).

## Test Plan

### 1. Peek button restored (notion.so)
- **Setup:** Notion integration enabled; a Notion page open on `notion.so`.
- **Steps:** Open the page in side-peek → look at the topbar, left of "Share."
- **Expected:** The Toggl timer button appears; clicking it starts a timer with the page title as the description.

### 2. Works on app.notion.com
- **Setup:** Same user, Notion already enabled (no extra setup).
- **Steps:** Open a page on `app.notion.com` in side-peek.
- **Expected:** Button appears automatically — no new toggle, no re-enabling.

### 3. No full-page false positive
- **Setup:** Notion integration enabled.
- **Steps:** Open a full (non-peek) Notion page.
- **Expected:** The peek button is not injected into the full-page topbar; only the side-peek gets the close-anchored button.

> Requires **toggl/track-extension-core#1547** to be released for `app.notion.com` injection to take effect end to end.

## 💬 Summarise how you feel about this PR with a gif

_When the button finally shows up in the peek again:_ [reappearing magic button](https://giphy.com/explore/magic-button)
