### PR TITLE
fix(asana): read board-card project from renamed PotTokenizerPill

### DIFF
--- a/src/content/asana.js
+++ b/src/content/asana.js
@@ -49,11 +49,20 @@ togglbutton.render(
         return projectHeader
       }
 
-      const projectPill = boadCardElem.querySelector(
-        '.BoardCardPotPills-potPill[aria-label]',
-      )
+      // Asana renamed the card project pill: the current markup is
+      // `.BoardCardProjectPills-potPillButton .PotTokenizerPill` with the name
+      // in `title` (no `aria-label`); the legacy selector is kept as a fallback.
+      const projectPill =
+        boadCardElem.querySelector(
+          '.BoardCardProjectPills-potPillButton .PotTokenizerPill',
+        ) || boadCardElem.querySelector('.BoardCardPotPills-potPill[aria-label]')
       if (projectPill) {
-        return projectPill.getAttribute('aria-label').trim()
+        return (
+          projectPill.getAttribute('title') ||
+          projectPill.getAttribute('aria-label') ||
+          projectPill.textContent ||
+          ''
+        ).trim()
       }
 
       return ''


### PR DESCRIPTION
## 🌟 What does this PR do?

### Issue
Starting a timer from an Asana **board card** didn't pick up the card's **project** — the entry started with no project assigned. Confusingly, it kept working for some users while failing for others.

### Cause
Asana is rolling out a renamed board-card project pill (a gradual UI / A-B change). The board-view handler read the project from `.BoardCardPotPills-potPill[aria-label]`. On the **new** markup the pill is `.BoardCardProjectPills-potPillButton .PotTokenizerPill`, with the project name in a `title` attribute and **no `aria-label`** — so the selector matched nothing and no project was sent. Accounts still on the old markup kept working, which is why it "worked for a colleague but not for the reporter": same code, different DOM served per account.

### Solution
Read the project from the new pill first, falling back to the legacy selector so **both** UI cohorts are covered during the rollout. The value is taken from `title`, then `aria-label`, then text content.

## Test Plan

### 1. Project picked up on the new board UI
- **Setup:** Asana integration enabled; a board card with a project pill in the new markup (`.BoardCardProjectPills-potPillButton .PotTokenizerPill`).
- **Steps:** Hover the card → click the Toggl button to start a timer.
- **Expected:** The timer starts with the card's project (e.g. `123123`) assigned.

### 2. Legacy board UI still works
- **Setup:** An account still on the old board markup (`.BoardCardPotPills-potPill[aria-label]`).
- **Steps:** Start a timer from a board card.
- **Expected:** Project is still detected via the fallback selector.

### 3. No project pill
- **Setup:** A board card with no project pill, not on a project page.
- **Steps:** Start a timer from the card.
- **Expected:** Timer starts with no project (empty), no error thrown.

## 💬 Summarise how you feel about this PR with a gif

_Same code, two DOMs, finally both covered:_ [a-b test](https://giphy.com/explore/ab-test)
