### PR TITLE
feat(outlook): add timer button to calendar event editor

### DIFF
--- a/src/content/outlook.js
+++ b/src/content/outlook.js
@@ -72,12 +72,20 @@ togglbutton.render(
   '[role="toolbar"][data-app-section="Toolbar"]:not(:has(.toggl-button))',
   { observe: true },
   (toolbar) => {
-    const dialog = toolbar.closest(".ms-Modal-scrollableContent") || document;
+    // The toolbar must live inside an event modal. Without this guard a non-modal
+    // Outlook toolbar would fall back to a document-wide lookup and could match a
+    // CalendarCompose subject from a different editor — injecting a calendar
+    // button (and the wrong event title) onto an unrelated toolbar.
+    const dialog = toolbar.closest(".ms-Modal-scrollableContent");
+    if (!dialog) {
+      return;
+    }
+
+    // Scope the subject lookup to this modal; only the calendar event editor has
+    // a CalendarCompose subject block.
     const subjectBlock = dialog.querySelector(
       '[id*="CalendarCompose"][id$="_SUBJECT"]'
     );
-
-    // Only the calendar event editor has a CalendarCompose subject block.
     if (!subjectBlock) {
       return;
     }
@@ -87,6 +95,12 @@ togglbutton.render(
       return;
     }
 
+    // Tag this specific modal (the subject id is unique per editor instance) so
+    // the post-start popup portals into *this* editor, not the first modal on
+    // the page when several editors are open.
+    const popupHostId = subjectBlock.id;
+    dialog.setAttribute("data-toggl-popup-host", popupHostId);
+
     function getDescription() {
       const titleInput = subjectBlock.querySelector("input");
       return titleInput ? titleInput.value.trim() : "";
@@ -95,9 +109,9 @@ togglbutton.render(
     const link = togglbutton.createTimerLink({
       className: "outlook-calendar",
       description: getDescription,
-      // Portal the post-start edit popup into the event modal; on document.body
+      // Portal the post-start edit popup into this event modal; on document.body
       // it renders behind Outlook's modal (z-index + focus trap) and is invisible.
-      container: ".ms-Modal-scrollableContent",
+      container: `[data-toggl-popup-host="${popupHostId}"]`,
     });
 
     target.appendChild(link);

--- a/src/content/outlook.js
+++ b/src/content/outlook.js
@@ -62,6 +62,48 @@ togglbutton.render(
   }
 );
 
+// Calendar event editor (create / edit an event). Anchor on the event command
+// toolbar and re-add the button whenever it's missing (`:not(:has(.toggl-button))`)
+// so it survives Outlook re-rendering the toolbar after the timer starts.
+// The subject block (id carries `CalendarCompose` — stable, not localised, and
+// unique to the event form) confirms we're in the event editor and supplies the
+// title used as the timer description.
+togglbutton.render(
+  '[role="toolbar"][data-app-section="Toolbar"]:not(:has(.toggl-button))',
+  { observe: true },
+  (toolbar) => {
+    const dialog = toolbar.closest(".ms-Modal-scrollableContent") || document;
+    const subjectBlock = dialog.querySelector(
+      '[id*="CalendarCompose"][id$="_SUBJECT"]'
+    );
+
+    // Only the calendar event editor has a CalendarCompose subject block.
+    if (!subjectBlock) {
+      return;
+    }
+
+    const target = toolbar.querySelector(".fui-ToolbarGroup") || toolbar;
+    if (target.querySelector(".toggl-button")) {
+      return;
+    }
+
+    function getDescription() {
+      const titleInput = subjectBlock.querySelector("input");
+      return titleInput ? titleInput.value.trim() : "";
+    }
+
+    const link = togglbutton.createTimerLink({
+      className: "outlook-calendar",
+      description: getDescription,
+      // Portal the post-start edit popup into the event modal; on document.body
+      // it renders behind Outlook's modal (z-index + focus trap) and is invisible.
+      container: ".ms-Modal-scrollableContent",
+    });
+
+    target.appendChild(link);
+  }
+);
+
 function getOpenedEmailSubject() {
   const emailSubjectElement = document.querySelector('div[role="heading"][title]');
 


### PR DESCRIPTION
## 🌟 What does this PR do?

### Requirement
The Outlook integration only ever injected a timer button into **inbox emails** and the **email compose** view — there was no support for **Outlook Calendar events**. Users on the calendar couldn't start a timer for an event (the only button they sometimes saw was the inbox-panel button incidentally matching the calendar page, which varies by tenant/layout).

### Solution
Add a timer button to the **calendar event editor** (create/edit), anchored on the event command toolbar, using the event title as the timer description. Two Outlook-specific wrinkles handled:
- **Self-healing injection** — Outlook re-renders the toolbar after the timer starts, dropping the button. Anchoring with `:not(:has(.toggl-button))` makes the observer re-add it the moment it's missing, so it survives re-renders.
- **Popup portal** — the post-start edit popup defaults to `document.body`, which renders *behind* Outlook's modal (z-index + focus trap) and is invisible. Portaling it into the modal (`container: '.ms-Modal-scrollableContent'`) makes it visible, same pattern as `placker.js`.

### Implementation
A new `togglbutton.render` block in `src/content/outlook.js`:
- **Anchor:** `[role="toolbar"][data-app-section="Toolbar"]:not(:has(.toggl-button))` — the event command toolbar; the `:not(:has(...))` self-heals across re-renders.
- **Scope:** only injects when a `[id*="CalendarCompose"][id$="_SUBJECT"]` subject block is present — that id is stable, not localised, and unique to the event editor (so it doesn't fire on email toolbars).
- **Description:** the event title `<input>` inside the subject block.
- **`container: '.ms-Modal-scrollableContent'`** so the edit popup renders inside the event modal.

Note: uses CSS `:has()` (Chrome/Edge 105+, Firefox 121+), which is within the extension's supported browser baseline.

## Test Plan

### 1. Button appears in the event editor
- **Setup:** Outlook integration enabled on `outlook.office.com` (also `outlook.live.com` / `outlook.cloud.microsoft`); open Calendar.
- **Steps:** Create or open an event to bring up the editor.
- **Expected:** A Toggl timer button appears in the event command toolbar (next to Event/Series/Delete…).

### 2. Description = event title; popup shows in the modal
- **Steps:** Give the event a title, click the Toggl button to start a timer.
- **Expected:** The post-start edit popup appears **inside the modal** (visible, not hidden behind it), prefilled with the event title.

### 3. Survives Outlook's re-render
- **Steps:** Start a timer, let the popup close (submit/cancel).
- **Expected:** The toolbar button returns and remains — it does **not** stay hidden until the dialog is reopened.

### 4. Doesn't leak into email views
- **Steps:** Open an inbox email and the email compose view.
- **Expected:** The existing email/compose buttons are unchanged; the calendar block doesn't inject there (no CalendarCompose subject block).

## 💬 Summarise how you feel about this PR with a gif

_Tracking time straight from the calendar:_ [calendar time](https://giphy.com/explore/calendar)
