### PR TITLE
fix(microsoft-planner): restore timer button on redesigned board cards

### DIFF
--- a/src/content/microsoft-planner.js
+++ b/src/content/microsoft-planner.js
@@ -1,3 +1,9 @@
+/**
+ * @name Microsoft Planner
+ * @urlAlias planner.cloud.microsoft
+ * @urlRegex *://planner.cloud.microsoft/*
+ */
+
 'use strict';
 
 togglbutton.render('.taskCard:not(.toggl)', { observe: true }, function (elem) {

--- a/src/content/microsoft-planner.js
+++ b/src/content/microsoft-planner.js
@@ -23,3 +23,46 @@ togglbutton.render('.taskCard:not(.toggl)', { observe: true }, function (elem) {
   });
   $('.leftSection', elem).appendChild(link);
 });
+
+// Redesigned board cards (Fluent layout). The legacy .taskCard/.title/.leftSection
+// selectors are gone; cards are now .planner-draggable-task-card with a stable
+// .taskMenuSection action area and a role="textbox" title. Self-heal via
+// :not(:has(.toggl-button)) so the button survives the card re-rendering.
+togglbutton.render(
+  '.planner-draggable-task-card:not(:has(.toggl-button))',
+  { observe: true },
+  function (card) {
+    const menu = card.querySelector('.taskMenuSection');
+    if (!menu || menu.querySelector('.toggl-button')) {
+      return;
+    }
+
+    function getDescription() {
+      const title = card.querySelector('[role="textbox"]');
+      return title ? title.textContent.trim() : '';
+    }
+
+    function getProject() {
+      // The card has no plan name; it's the last breadcrumb item in the board
+      // header. Fall back to the legacy taskboard header for old-layout tenants.
+      const breadcrumbItems = document.querySelectorAll(
+        '.fui-Breadcrumb__list .fui-BreadcrumbItem'
+      );
+      const planItem = breadcrumbItems[breadcrumbItems.length - 1];
+      if (planItem) {
+        return planItem.textContent.trim();
+      }
+      const legacyHeader = $('.planTaskboardPage .primaryTextSection h1');
+      return legacyHeader ? legacyHeader.textContent.trim() : '';
+    }
+
+    const link = togglbutton.createTimerLink({
+      className: 'microsoftplanner',
+      description: getDescription,
+      projectName: getProject,
+      buttonType: 'minimal'
+    });
+
+    menu.appendChild(link);
+  }
+);


### PR DESCRIPTION
## 🌟 What does this PR do?

### Issue
The Toggl timer button stopped appearing on **Microsoft Planner** board task cards. Reported by a user; reproduced. Planner recently shipped a Fluent UI layout change.

### Cause
The integration anchored on the **old** board-card markup — `.taskCard`, `.title`, `.leftSection`, `.planName`, `.planTaskboardPage .primaryTextSection h1`. The redesign removed all of those (cards are now `.planner-draggable-task-card` with obfuscated Fluent classes), so nothing matched → no button.

### Solution
Add a handler for the redesigned board cards, using the stable (non-obfuscated) hooks in the new markup, and keep the legacy `.taskCard` handler for any tenants still mid-rollout:
- **Anchor:** `.planner-draggable-task-card:not(:has(.toggl-button))` — self-healing, so the button is re-added if Planner re-renders the card (e.g. on hover).
- **Inject point:** `.taskMenuSection` (the card's action area, next to More options).
- **Description:** the card's `[role="textbox"]` title.
- **Project:** the plan name from the board header — the last `.fui-Breadcrumb__list .fui-BreadcrumbItem` (the card itself has no plan name); falls back to the legacy taskboard header.

Labels and assignee are now present on the card too, but the integration has never used them, so they're left out (this is a fix, not a feature add).

## Test Plan

### 1. Button appears on board cards (new layout)
- **Setup:** Microsoft Planner integration enabled (`planner.cloud.microsoft` / `tasks.office.com` / `tasks.office365.com`); open a plan's **Board** view.
- **Steps:** Look at a task card's action area (next to More options).
- **Expected:** The Toggl timer button is present on each card.

### 2. Description + project are captured
- **Steps:** Click the button on a card to start a timer.
- **Expected:** The entry's description is the task title and its project is the plan name (from the breadcrumb).

### 3. Survives card re-render
- **Steps:** Hover/interact with the card after the button appears.
- **Expected:** The button stays (self-heal re-adds it if a re-render drops it).

### 4. Old layout still works
- **Setup:** A tenant still on the legacy `.taskCard` layout.
- **Expected:** The original handler still injects the button (unchanged).

## 💬 Summarise how you feel about this PR with a gif

_Button's back on the board:_ [back in action](https://giphy.com/explore/back-in-action)
