### PR TITLE
fix(github): strip injected 'Edit issue title' label from tracked description

### DIFF
--- a/src/content/github.js
+++ b/src/content/github.js
@@ -5,6 +5,54 @@
  */
 'use strict'
 
+// For users with write access, GitHub renders an inline "Edit issue title"
+// button inside the title element. Its (visually hidden) label leaks into
+// `textContent` and gets prepended to the tracked description (see #2438).
+// Read the title from the dedicated markdown-title/bdi node instead, falling
+// back to a copy of the element with interactive/hidden nodes stripped out.
+const getIssueTitleText = (titleElem) => {
+  if (!titleElem) {
+    return ''
+  }
+
+  const titleNode = titleElem.matches('.markdown-title, bdi')
+    ? titleElem
+    : titleElem.querySelector('.markdown-title, bdi')
+
+  if (titleNode) {
+    return titleNode.textContent.trim()
+  }
+
+  const clone = titleElem.cloneNode(true)
+  clone
+    .querySelectorAll(
+      'button, [role="button"], [class*="VisuallyHidden"], .sr-only',
+    )
+    .forEach((node) => node.remove())
+
+  return clone.textContent.trim()
+}
+
+// The issue/PR number lives in a sibling span (e.g. "#2438"). Match it by
+// shape instead of DOM position so the inline edit wrapper span (which carries
+// the leaked "Edit issue title" label) isn't picked up instead (see #2438).
+const getIssueNumberText = (titleElem) => {
+  const scope =
+    (titleElem && titleElem.closest('h1')) ||
+    (titleElem && titleElem.parentElement)
+
+  if (!scope) {
+    return ''
+  }
+
+  const numElem = Array.prototype.find.call(
+    scope.querySelectorAll('span'),
+    (span) => /^#\d+$/.test(span.textContent.trim()),
+  )
+
+  return numElem ? numElem.textContent.trim() : ''
+}
+
 // We need it to get the issue name, the tag value is being changed dynamically
 const getPaneDescription = async (elem) => {
   return new Promise((resolve) => {
@@ -55,9 +103,9 @@ togglbutton.render(
       return
     }
 
-    let description = titleElem.textContent
+    let description = getIssueTitleText(titleElem)
     if (numElem !== null) {
-      description = numElem.textContent + ' ' + description.trim()
+      description = numElem.textContent.trim() + ' ' + description
     }
 
     const div = document.createElement('div')
@@ -88,8 +136,6 @@ togglbutton.render(
     const projectElem = $('[data-testid="project-title"]')
     const existingTag = $('.discussion-sidebar-item.toggl')
 
-    const numElem = titleElem.parentElement.querySelector('span')
-
     if (existingTag) {
       if (existingTag.parentNode.firstChild.classList.contains('toggl')) {
         return
@@ -97,10 +143,11 @@ togglbutton.render(
       existingTag.parentNode.removeChild(existingTag)
     }
 
-    let description = titleElem.textContent
+    let description = getIssueTitleText(titleElem)
+    const numText = getIssueNumberText(titleElem)
 
-    if (numElem !== null) {
-      description = numElem.textContent + ' ' + description.trim()
+    if (numText) {
+      description = numText + ' ' + description
     }
 
     const elementOfBase = document.querySelector(

--- a/src/content/github.js
+++ b/src/content/github.js
@@ -5,11 +5,8 @@
  */
 'use strict'
 
-// For users with write access, GitHub renders an inline "Edit issue title"
-// button inside the title element. Its (visually hidden) label leaks into
-// `textContent` and gets prepended to the tracked description (see #2438).
-// Read the title from the dedicated markdown-title/bdi node instead, falling
-// back to a copy of the element with interactive/hidden nodes stripped out.
+// Strip GitHub's injected "Edit issue title" label (a visually-hidden node)
+// out of the tracked title so it isn't prepended to the description (see #2438).
 const readClean = (node) => {
   const clone = node.cloneNode(true)
   clone
@@ -33,9 +30,8 @@ const getIssueTitleText = (titleElem) => {
   return readClean(titleNode || titleElem)
 }
 
-// The issue/PR number lives in a sibling span (e.g. "#2438"). Match it by
-// shape instead of DOM position so the inline edit wrapper span (which carries
-// the leaked "Edit issue title" label) isn't picked up instead (see #2438).
+// Match the number span (e.g. "#2438") by shape, not DOM position, so the
+// inline-edit wrapper span isn't picked up instead (see #2438).
 const getIssueNumberText = (titleElem) => {
   const scope =
     (titleElem && titleElem.closest('h1')) ||

--- a/src/content/github.js
+++ b/src/content/github.js
@@ -10,6 +10,17 @@
 // `textContent` and gets prepended to the tracked description (see #2438).
 // Read the title from the dedicated markdown-title/bdi node instead, falling
 // back to a copy of the element with interactive/hidden nodes stripped out.
+const readClean = (node) => {
+  const clone = node.cloneNode(true)
+  clone
+    .querySelectorAll(
+      'button, [role="button"], [class*="VisuallyHidden"], .sr-only',
+    )
+    .forEach((n) => n.remove())
+
+  return clone.textContent.trim()
+}
+
 const getIssueTitleText = (titleElem) => {
   if (!titleElem) {
     return ''
@@ -19,18 +30,7 @@ const getIssueTitleText = (titleElem) => {
     ? titleElem
     : titleElem.querySelector('.markdown-title, bdi')
 
-  if (titleNode) {
-    return titleNode.textContent.trim()
-  }
-
-  const clone = titleElem.cloneNode(true)
-  clone
-    .querySelectorAll(
-      'button, [role="button"], [class*="VisuallyHidden"], .sr-only',
-    )
-    .forEach((node) => node.remove())
-
-  return clone.textContent.trim()
+  return readClean(titleNode || titleElem)
 }
 
 // The issue/PR number lives in a sibling span (e.g. "#2438"). Match it by


### PR DESCRIPTION
## Problem

For users with write access, GitHub renders an inline "Edit issue title" button inside the issue title element. Its visually-hidden label leaked into `titleElem.textContent` and was prepended to the Toggl time entry description (e.g. `#2438Edit issue title My title`).

## Fix

- Read the title from the dedicated `.markdown-title`/`bdi` node, with a fallback that clones the element and strips interactive/hidden nodes (`button`, `[role="button"]`, `[class*="VisuallyHidden"]`, `.sr-only`).
- Match the issue number by shape (`#\d+`) rather than DOM position, so the inline-edit wrapper span isn't mistaken for the number span.

- Fixes #2438