### PR TITLE
fix(basecamp): add support for redesigned Basecamp 5 to-do lists

### DIFF
--- a/src/content/basecamp.js
+++ b/src/content/basecamp.js
@@ -1,3 +1,9 @@
+/**
+ * @name Basecamp
+ * @urlAlias basecamp.com
+ * @urlRegex *://*.basecamp.com/*
+ */
+
 'use strict';
 
 // Basecamp Next
@@ -103,3 +109,42 @@ togglbutton.render('header.todo__header:not(.toggl)', { observe: true }, functio
 
   container.appendChild(link);
 });
+
+// Basecamp 5. The todo list container is a div (was article.todolist) and the
+// row content moved to .todo__content; the project name is only available in
+// the breadcrumb. Rows are re-rendered by Turbo, so guard against duplicates.
+togglbutton.render(
+  '.todolist ul.todos li.todo:not(.toggl)',
+  { observe: true },
+  function (elem) {
+    const content = elem.querySelector('.todo__content');
+    if (!content || content.querySelector('.toggl-button')) {
+      return;
+    }
+
+    const titleLink = content.querySelector('a[href*="/todos/"]');
+    if (!titleLink) {
+      return;
+    }
+
+    function getProject () {
+      const breadcrumb = document.querySelector(
+        '.perma-toolbar__breadcrumb--bucket strong'
+      );
+      if (breadcrumb) {
+        return breadcrumb.textContent.trim();
+      }
+      const subtitle = document.querySelector('meta[name="current-page-subtitle"]');
+      return subtitle ? subtitle.getAttribute('content') : '';
+    }
+
+    const link = togglbutton.createTimerLink({
+      className: 'basecamp5-todos',
+      buttonType: 'minimal',
+      description: titleLink.textContent.trim(),
+      projectName: getProject
+    });
+
+    content.appendChild(link);
+  }
+);

--- a/src/origins.js
+++ b/src/origins.js
@@ -46,7 +46,8 @@ export default {
   },
   'basecamp.com': {
     url: '*://*.basecamp.com/*',
-    name: 'Basecamp'
+    name: 'Basecamp',
+    file: 'basecamp.js'
   },
   'basecamphq.com': {
     url: '*://*.basecamphq.com/*',

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -319,6 +319,22 @@ SingleTaskPaneToolbar .toggl-button.asana-board, /* new ui v1 */
   opacity: 0 !important;
 }
 
+/********* BASECAMP 5 *********/
+/* Basecamp gives row children chip styling (gray pill); strip it from both
+   the wrapper div returned by createTimerLink and the button inside it. */
+.todo .todo__content .toggl-button {
+  background: none !important;
+  border: none !important;
+  box-shadow: none !important;
+  padding: 0 !important;
+  border-radius: 0 !important;
+}
+
+.todo .todo__content > .toggl-button {
+  margin-left: 8px;
+  vertical-align: middle;
+}
+
 /********* TOGGL-PLAN *********/
 a.toggl-button.toggl-plan {
   margin-top: -1px;


### PR DESCRIPTION
## 🌟 What does this PR do?

### Issue
The timer button no longer appears anywhere in Basecamp, so time entries can't be started from Basecamp to-dos. Reported by a user via support (see #browser-extension-support, July 1).

### Cause
37signals launched Basecamp 5, a ground-up rewrite of the app with all-new markup. Every selector in `basecamp.js` targets Basecamp Classic/2/3-era DOM — the to-do list container is now a `div.todolist` (was `article.todolist`), row content moved to `.todo__content`/`.checkbox-field__content` (was `.checkbox__content`), and the `meta[name="current-page-subtitle"]` tag used for the project name is gone. Nothing matches, so no button is ever rendered.

### Solution
Added a Basecamp 5 render block targeting `.todolist ul.todos li.todo`:
- **Description** comes from the to-do title link (`a[href*="/todos/"]`).
- **Project name** is resolved lazily from the project breadcrumb (`.perma-toolbar__breadcrumb--bucket strong`), falling back to the legacy meta tag for accounts still on the old markup.
- **Duplicate guard** since Basecamp 5 re-renders rows via Turbo.

Also added CSS to strip Basecamp's chip styling (gray pill background, padding) from the injected button, since BC5 styles arbitrary children of the to-do row as metadata chips, and added the `@name/@urlAlias/@urlRegex` integration header required by the origins-generator workflow.

The existing Classic/BC2/BC3 blocks are untouched — 37signals keeps old versions running indefinitely, so this is additive.

## Test Plan

### 1. Timer button on Basecamp 5 to-do rows
- **Setup:** Toggl Track extension installed and logged in, Basecamp integration enabled; a Basecamp 5 account with a project containing a to-do list with at least one to-do.
- **Steps:** Open the project → open the To-dos tool → look at a to-do row
- **Expected:** A minimal Toggl timer button appears inline after the to-do title, with no gray pill background, vertically aligned with the text. Clicking it starts a time entry with the to-do title as description and the Basecamp project name (from the breadcrumb) matched as the Toggl project.

### 2. Button survives Turbo re-renders
- **Setup:** Same as above.
- **Steps:** On the to-do list page, check a to-do complete and uncheck it → navigate to another tool and back
- **Expected:** Exactly one timer button per row — no duplicates, no missing buttons.

## 💬 Summarise how you feel about this PR with a gif

![setting up camp](https://media.giphy.com/media/jq4muisEN4U9AUC7u0/giphy.gif)
