### PR TITLE
fix(github): exclude edit button text from issue number in timer description

### DIFF
--- a/src/content/github.js
+++ b/src/content/github.js
@@ -99,8 +99,11 @@ togglbutton.render(
 
     let description = titleElem.textContent
 
-    if (numElem !== null) {
-      description = numElem.textContent + ' ' + description.trim()
+    // The span also contains the "Edit issue title" button for users with
+    // write access, so extract only the issue number from it
+    const issueNumber = numElem && numElem.textContent.match(/#\d+/)
+    if (issueNumber) {
+      description = issueNumber[0] + ' ' + description.trim()
     }
 
     const elementOfBase = document.querySelector(


### PR DESCRIPTION
## 🌟 What does this PR do?

### Issue
Starting a timer from the sidebar of a GitHub issue pre-fills the time entry description with "Edit issue title" injected into it, e.g. `#1234Edit issue title My Example Issue` instead of `#1234 My Example Issue`. Reported by a user via support; started ~1-2 weeks ago after a GitHub UI change. Every entry needs manual cleanup.

### Cause
On the React-based issues UI, the integration builds the description as `numElem.textContent + ' ' + title`, where `numElem` is the first `<span>` following the title (`titleElem.parentElement.querySelector('span')`). That span group contains more than the issue number: for users with write access to the repo, GitHub renders the "Edit issue title" button inside it, so `textContent` returns `#1234Edit issue title`. This is also why it's easy to miss — logged out or without write access, the span only contains the number.

### Solution
Extract only the issue number token from the span with a `/#\d+/` match and prepend that, instead of trusting the span's full text. If no number is found, the description falls back to just the issue title.

## Test Plan

### 1. Clean description on issues with write access
- **Setup:** Toggl Track extension installed and logged in, GitHub integration enabled; a GitHub account with write access to a repo containing an issue (write access is required to reproduce — it's what makes GitHub render the edit button).
- **Steps:** Open the issue → click the Toggl timer button at the top of the right-hand sidebar → inspect the pre-filled description in the popup
- **Expected:** Description is `#<number> <issue title>` with no "Edit issue title" text.

### 2. No regression without write access
- **Setup:** Same extension setup; a public issue in a repo the account cannot edit.
- **Steps:** Open the issue → click the Toggl timer button in the sidebar → inspect the description
- **Expected:** Description is still `#<number> <issue title>`.

## 💬 Summarise how you feel about this PR with a gif

![cut it out](https://media.giphy.com/media/gduDvlMT5Wsv2JNDu5/giphy.gif)
