### PR TITLE
fix(github): prevent TypeError in getPaneDescription and add unit tests

### DIFF
--- a/src/content/github.js
+++ b/src/content/github.js
@@ -10,11 +10,12 @@ const getPaneDescription = async (elem) => {
   return new Promise((resolve) => {
     const description = setInterval(() => {
       const titleElem = elem.querySelector('#__primerPortalRoot__ bdi')
-      const numElem = titleElem.parentElement.lastChild
 
-      if (!!titleElem.textContent) {
+      if (titleElem && titleElem.textContent) {
+        const numElem = titleElem.parentElement ? titleElem.parentElement.lastChild : null
+        const prefix = numElem && numElem.textContent ? numElem.textContent + ' ' : ''
         clearInterval(description)
-        resolve(`${numElem.textContent} ${titleElem.textContent.trim()}`)
+        resolve(`${prefix}${titleElem.textContent.trim()}`)
       }
     }, 1000)
   })
@@ -201,3 +202,7 @@ togglbutton.render(
     target.parentNode.insertBefore(wrapper, target)
   },
 )
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { getPaneDescription }
+}

--- a/src/content/github.test.js
+++ b/src/content/github.test.js
@@ -1,0 +1,78 @@
+'use strict'
+
+const assert = require('node:assert')
+
+// Mock environment for content script loading
+global.togglbutton = {
+  render: () => {},
+  createTimerLink: () => {}
+}
+global.$ = () => null
+global.createTag = () => null
+global.window = {
+  location: {
+    pathname: '/owner/repo/pull/1'
+  }
+}
+global.document = {
+  querySelector: () => null,
+  createElement: () => ({ classList: { add: () => {} } })
+}
+
+const { getPaneDescription } = require('./github.js')
+
+async function runTests() {
+  console.log('Running tests...')
+
+  // Test 1
+  try {
+    let callCount = 0
+    const mockElem = {
+      querySelector: (selector) => {
+        callCount++
+        if (callCount < 2) {
+          return null
+        }
+        return {
+          textContent: 'My Issue Title',
+          parentElement: {
+            lastChild: {
+              textContent: '#123'
+            }
+          }
+        }
+      }
+    }
+
+    const desc = await getPaneDescription(mockElem)
+    assert.strictEqual(desc, '#123 My Issue Title')
+    assert.ok(callCount >= 2)
+    console.log('✓ getPaneDescription waits for titleElem to be present and handles it')
+  } catch (err) {
+    console.error('✗ Test 1 failed:', err)
+    process.exit(1)
+  }
+
+  // Test 2
+  try {
+    const mockElem = {
+      querySelector: (selector) => {
+        return {
+          textContent: 'My Issue Title',
+          parentElement: null
+        }
+      }
+    }
+
+    const desc = await getPaneDescription(mockElem)
+    assert.strictEqual(desc, 'My Issue Title')
+    console.log('✓ getPaneDescription handles missing parentElement or numElem')
+  } catch (err) {
+    console.error('✗ Test 2 failed:', err)
+    process.exit(1)
+  }
+
+  console.log('All tests passed successfully.')
+}
+
+runTests()


### PR DESCRIPTION
Add checks to verify if titleElem and its parentElement are defined before accessing their properties in getPaneDescription. Also, add unit tests to cover these safety checks.