### PR TITLE
feat(github): add org/repo as a tag on tracked time entries

### DIFF
--- a/src/content/github.js
+++ b/src/content/github.js
@@ -5,10 +5,22 @@
  */
 'use strict'
 
-// Expose the owner/repo as a tag
-const getRepoTags = () => {
-  const [, owner, repo] = window.location.pathname.split('/')
-  return owner && repo ? [`${owner}/${repo}`] : []
+// Build an owner/repo tag from a GitHub path like /owner/repo/issues/1.
+// Project boards live at /orgs|users/... and don't map to a single repo.
+const repoTag = (pathname) => {
+  const [, owner, repo] = pathname.split('/')
+  return owner && repo && owner !== 'orgs' && owner !== 'users'
+    ? [`${owner}/${repo}`]
+    : []
+}
+
+// Issue and PR pages live at /owner/repo/...
+const getRepoTags = () => repoTag(window.location.pathname)
+
+// Project cards can hold issues from any repo, so read it from the card's issue link
+const getCardRepoTags = (scope) => {
+  const link = scope.querySelector('a[href*="/issues/"], a[href*="/pull/"]')
+  return link ? repoTag(new URL(link.href).pathname) : []
 }
 
 // We need it to get the issue name, the tag value is being changed dynamically
@@ -162,7 +174,7 @@ togglbutton.render(
       className: 'github',
       description: description,
       projectName: projectElem ? projectElem.textContent.trim() : '',
-      tags: getRepoTags,
+      tags: getCardRepoTags(elem),
     })
 
     div.appendChild(link)
@@ -198,7 +210,7 @@ togglbutton.render(
       className: 'github',
       description: getDescription,
       projectName: projectElem && projectElem.textContent,
-      tags: getRepoTags,
+      tags: getCardRepoTags(elem),
     })
 
     const wrapper = createTag(

--- a/src/content/github.js
+++ b/src/content/github.js
@@ -5,6 +5,12 @@
  */
 'use strict'
 
+// Expose the owner/repo as a tag
+const getRepoTags = () => {
+  const [, owner, repo] = window.location.pathname.split('/')
+  return owner && repo ? [`${owner}/${repo}`] : []
+}
+
 // We need it to get the issue name, the tag value is being changed dynamically
 const getPaneDescription = async (elem) => {
   return new Promise((resolve) => {
@@ -67,6 +73,7 @@ togglbutton.render(
       className: 'github',
       description: description,
       projectName: projectName,
+      tags: getRepoTags,
     })
 
     div.appendChild(link)
@@ -120,6 +127,7 @@ togglbutton.render(
       className: 'github',
       description: description,
       projectName: projectElem && projectElem.textContent,
+      tags: getRepoTags,
     })
 
     div.appendChild(link)
@@ -154,6 +162,7 @@ togglbutton.render(
       className: 'github',
       description: description,
       projectName: projectElem ? projectElem.textContent.trim() : '',
+      tags: getRepoTags,
     })
 
     div.appendChild(link)
@@ -189,6 +198,7 @@ togglbutton.render(
       className: 'github',
       description: getDescription,
       projectName: projectElem && projectElem.textContent,
+      tags: getRepoTags,
     })
 
     const wrapper = createTag(


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/toggl/track-extension/blob/master/docs/CONTRIBUTING.md) :heart:

## :star2: What does this PR do?

Adds the repository's `owner/repo` as a tag on GitHub time entries so users can link an entry back to its source repo (and rebuild the issue/PR URL) without clobbering the description, which helps when working across many repositories in a day. On issue and PR pages the repo comes from the `/owner/repo/...` URL; on project boards (which live at `/orgs|users/{name}/projects/N`) it is read from the card's issue/PR link instead, and non-repo paths get no tag.

## :bug: Recommendations for testing

All changes should be tested across Chrome and Firefox. Start a timer from an issue, a PR, a classic project card, and a project side pane, and confirm the created entry carries a tag like `toggl/track-extension` — and that project boards never produce a bogus `orgs/...` tag.

## :memo: Links to relevant issues or information

Follow-up suggested in https://github.com/toggl/track-extension/pull/2439#issuecomment-4885679464; relates to #965, #930, #444, #356, #284, #526.
