### PR TITLE
fix(gitlab): rework n4 custom gitlab script for new UI

### DIFF
--- a/src/content/_custom_nf_gitlab.js
+++ b/src/content/_custom_nf_gitlab.js
@@ -1,109 +1,179 @@
 /**
- * @name Custom Gitlab Script (N4)
+ * @name n4Gitlab
  * @urlAlias nfGitlabScript
- * @urlRegex gitlab.com
+ * @urlRegex git\.n4group\.eu
  */
 'use strict'
 
-// ---------------------------
-// Issues (new GitLab UI)
-// ---------------------------
 togglbutton.render(
-  'span[data-testid="work-item-created"]:not(.toggl)',
+  '[data-testid="work-item-time-tracking"] [data-testid="add-time-entry-button"]:not(.toggl)',
   { observe: true },
-  function (createdSpan) {
-    if (!createdSpan) return
-    createdSpan.classList.add('toggl')
+  function (addTimeButton) {
+    if (!addTimeButton) return
+    addTimeButton.classList.add('toggl')
 
-    const id = getIdFromBody()
-    const prefix = id ? `#${id}` : ''
-
-    const titleEl = document.querySelector('[data-testid="work-item-title"]')
-    const title = titleEl ? titleEl.textContent.trim() : ''
-
-    const description = [prefix, title].filter(Boolean).join(' ')
+    const workItemContainer = addTimeButton.closest('[data-testid="work-item-detail"]') ||
+                              addTimeButton.closest('[data-testid="work-item-container"]') ||
+                              addTimeButton.closest('.work-item-page')
 
     const link = togglbutton.createTimerLink({
       className: 'gitlab',
-      description,
-      tags: tagsSelector,
+      description: () => getDescription(workItemContainer || document),
+      tags: () => tagsSelector(document),
       taskId: (projects, tasks) => extractTaskId(projects, tasks),
-      projectName: (projects, tasks) => extractProjectName(projects, tasks),
+      projectName: (projects, tasks) => extractProjectName(projects, tasks, workItemContainer || document),
     })
 
-    createdSpan.insertAdjacentElement('afterend', link)
-  },
-)
+    link.style.whiteSpace = 'nowrap'
+    link.style.flexShrink = '0'
+    link.style.display = 'inline-flex'
+    link.style.alignItems = 'center'
+    link.style.marginRight = '8px'
 
-// ---------------------------
-// Merge Requests (new GitLab UI)
-// ---------------------------
-togglbutton.render(
-  '.detail-page-description:not(.toggl)',
-  { observe: true },
-  function (descBlock) {
-    if (!descBlock) return
-    descBlock.classList.add('toggl')
+    const wrapper = document.createElement('div')
+    wrapper.style.display = 'flex'
+    wrapper.style.alignItems = 'center'
 
-    const id = getIdFromBody()
-    const prefix = id ? `MR${id}::` : ''
-
-    const titleEl = document.querySelector('[data-testid="title-content"]')
-    const title = titleEl ? titleEl.textContent.trim() : ''
-
-    const description = [prefix, title].filter(Boolean).join(' ')
-
-    const link = togglbutton.createTimerLink({
-      className: 'gitlab',
-      description,
-      tags: tagsSelector,
-      taskId: (projects, tasks) => extractTaskId(projects, tasks),
-      projectName: (projects, tasks) => extractProjectName(projects, tasks),
-    })
-
-    descBlock.insertAdjacentElement('afterbegin', link)
-  },
-)
-
-// ---------------------------
-// Shared helpers
-// ---------------------------
-function getIdFromBody() {
-  const body = document.querySelector('body')
-  return body ? body.getAttribute('data-page-type-id') : ''
-}
-
-function getProjectSelector() {
-  const el = document.querySelector(
-    'a[data-track-label="project_overview"] div[data-testid="nav-item-link-label"]',
-  )
-  return el ? el.textContent.trim() : ''
-}
-
-function tagsSelector() {
-  const nodeList = document.querySelectorAll(
-    '[data-testid="selected-label-content"] span.gl-label-text',
-  )
-
-  const tags = []
-  for (const node of Object.values(nodeList || {})) {
-    const tagName = (node.textContent || '').trim()
-    if (tagName && !tags.includes(tagName)) tags.push(tagName)
+    addTimeButton.parentNode.insertBefore(wrapper, addTimeButton)
+    wrapper.appendChild(link)
+    wrapper.appendChild(addTimeButton)
   }
+)
+
+togglbutton.render(
+  '[data-testid="time-tracker"] [data-testid="add-time-entry-button"]:not(.toggl-mr-ready)',
+  { observe: true },
+  function (addTimeButton) {
+    if (!addTimeButton) return
+    addTimeButton.classList.add('toggl-mr-ready')
+
+    const link = togglbutton.createTimerLink({
+      className: 'gitlab',
+      description: getMrDescription,
+      tags: () => tagsSelector(document),
+      taskId: (projects, tasks) => extractTaskId(projects, tasks),
+      projectName: (projects, tasks) => extractProjectName(projects, tasks, document),
+    })
+
+    link.style.whiteSpace = 'nowrap'
+    link.style.flexShrink = '0'
+    link.style.display = 'inline-flex'
+    link.style.alignItems = 'center'
+    link.style.marginRight = '8px'
+
+    addTimeButton.insertAdjacentElement('beforebegin', link)
+  }
+)
+
+function getDescription(context = document) {
+  let iid = ''
+  const iidEl = context.querySelector('[data-work-item-iid]')
+  if (iidEl) {
+    iid = iidEl.getAttribute('data-work-item-iid') || ''
+  }
+
+  if (!iid) {
+    const match = window.location.pathname.match(/\/(?:issues|work_items)\/(\d+)/)
+    iid = match ? match[1] : ''
+  }
+
+  const prefix = iid ? `#${iid}` : ''
+  const titleEl = context.querySelector('[data-testid="work-item-title"]')
+  const title = titleEl ? titleEl.textContent.trim() : ''
+
+  return [prefix, title].filter(Boolean).join(' ')
+}
+
+function getMrDescription() {
+  const match = window.location.pathname.match(/\/merge_requests\/(\d+)/)
+  const id = match ? match[1] : ''
+  const prefix = id ? `MR${id}::` : ''
+
+  const titleEl = document.querySelector('[data-testid="title-content"]') || document.querySelector('.detail-page-description .title')
+  const title = titleEl ? titleEl.textContent.trim() : ''
+
+  return [prefix, title].filter(Boolean).join(' ')
+}
+
+function getProjectSelector(context = document) {
+  const el = context.querySelector('[data-work-item-full-path]')
+  if (el) {
+    const fullPath = el.getAttribute('data-work-item-full-path')
+    if (fullPath) {
+      const parts = fullPath.split('/')
+      return parts[parts.length - 1]
+    }
+  }
+
+  const el2 = context.querySelector('[full-path]')
+  if (el2) {
+    const fullPath = el2.getAttribute('full-path')
+    if (fullPath) {
+      const parts = fullPath.split('/')
+      return parts[parts.length - 1]
+    }
+  }
+
+  const oldEl = document.querySelector(
+    'a[data-track-label="project_overview"] div[data-testid="nav-item-link-label"]'
+  )
+  if (oldEl) {
+    return oldEl.textContent.trim()
+  }
+
+  const pathParts = window.location.pathname.split('/-/')
+  if (pathParts.length > 0) {
+    const projectPath = pathParts[0]
+    const projectParts = projectPath.split('/')
+    const projectName = projectParts[projectParts.length - 1]
+    if (projectName) return projectName
+  }
+
+  return ''
+}
+
+function tagsSelector(context = document) {
+  const labelContainers = context.querySelectorAll('.gl-label')
+  const tags = []
+
+  for (const container of labelContainers) {
+    const link = container.querySelector('a.gl-label-link')
+    if (link) {
+      try {
+        const href = link.getAttribute('href')
+        if (href) {
+          const url = new URL(href, window.location.origin)
+          const labelName = url.searchParams.get('label_name') || url.searchParams.get('label_name[]')
+          if (labelName) {
+            if (!tags.includes(labelName)) tags.push(labelName)
+            continue
+          }
+        }
+      } catch (e) {}
+    }
+
+    const text1El = container.querySelector('.gl-label-text')
+    const text2El = container.querySelector('.gl-label-text-scoped')
+
+    const text1 = text1El ? text1El.textContent.trim() : ''
+    const text2 = text2El ? text2El.textContent.trim() : ''
+
+    const fullText = text2 ? `${text1}::${text2}` : (text1 || container.textContent.trim())
+    if (fullText && !tags.includes(fullText)) tags.push(fullText)
+  }
+
   return tags
 }
 
 function extractN4GitlabTogglTaskCode() {
-  const tags = tagsSelector()
+  const tags = tagsSelector(document)
   if (!Array.isArray(tags) || tags.length === 0) return null
 
-  const GITLAB_LABEL_REGEX = /togg(e|)l(::|:)/gim
+  const GITLAB_LABEL_REGEX = /togge?l::?/im
   const REMOVE_TRAILING_DESCRIPTION = / .*/
 
   for (const tag of tags) {
     if (GITLAB_LABEL_REGEX.test(tag)) {
-      // Reset regex lastIndex since we use 'g' flag
-      GITLAB_LABEL_REGEX.lastIndex = 0
       return tag
         .replace(GITLAB_LABEL_REGEX, '')
         .toUpperCase()
@@ -116,11 +186,11 @@ function extractN4GitlabTogglTaskCode() {
 
 function extractTaskId(projects, tasks) {
   const code = extractN4GitlabTogglTaskCode()
-  if (!code) return {}
+  if (!code) return null
 
   const keys = Object.keys(tasks || {})
   const matchKey = keys.find((k) => (tasks[k]?.name || '').startsWith(code))
-  return matchKey ? tasks[matchKey].id : {}
+  return matchKey ? tasks[matchKey].id : null
 }
 
 function extractTaskProjectId(code, projects, tasks) {
@@ -131,15 +201,15 @@ function extractTaskProjectId(code, projects, tasks) {
   return matchKey ? tasks[matchKey].project_id : null
 }
 
-function extractProjectName(projects, tasks) {
+function extractProjectName(projects, tasks, context = document) {
   const code = extractN4GitlabTogglTaskCode()
 
-  if (!code) return getProjectSelector() || null
+  if (!code) return getProjectSelector(context) || null
 
   const projectId = extractTaskProjectId(code, projects, tasks)
-  if (!projectId) return getProjectSelector() || null
+  if (!projectId) return getProjectSelector(context) || null
 
   const keys = Object.keys(projects || {})
   const matchKey = keys.find((k) => projects[k]?.id === projectId)
-  return matchKey ? projects[matchKey].name : getProjectSelector() || null
+  return matchKey ? projects[matchKey].name : getProjectSelector(context) || null
 }


### PR DESCRIPTION
## :star2: What does this PR do?

Replaces `src/content/_custom_nf_gitlab.js` with a rewritten version, tested against a self-hosted GitLab instance.

Key changes:
- **Layout anchoring:** Toggl button now sits inside GitLab's native "Time tracking" sidebar (next to add-time-entry) for both Issues/Work Items and Merge Requests.
- **Label collection:** refactored to run globally at `document` level, fixing the new UI's encapsulation of labels in side-drawers and boards.
- Unminified source, no duplicate injection loops.

Registry entry (`nfGitlabScript` in `src/custom-scripts.js`) already exists — no change needed there.

## :bug: Recommendations for testing

Test button injection + description/tag/project resolution on Issues, Work Items, and Merge Requests, across Chrome and Firefox. Verify on both a self-hosted instance and `gitlab.com`.

## :memo: Links to relevant issues or information

Reformatted to repo style (no-semi) by hand; `@toggl/prettier` not run locally.