### PR TITLE
fix(basecamp): show timer button on Basecamp 5 to-dos inside named lists

### DIFF
--- a/src/content/basecamp.js
+++ b/src/content/basecamp.js
@@ -72,8 +72,9 @@ togglbutton.render(
   }
 );
 
-// Basecamp 3
-togglbutton.render('article.todolist .todos li.todo:not(.toggl)', { observe: true }, function (
+// Basecamp 3. The :has(.checkbox__content) guard keeps this from also matching
+// Basecamp 5 named lists (also article.todolist) and stamping .toggl before BC5 runs.
+togglbutton.render('article.todolist .todos li.todo:not(.toggl):has(.checkbox__content)', { observe: true }, function (
   elem
 ) {
   const parent = $('.checkbox__content', elem);


### PR DESCRIPTION
## 🌟 What does this PR do?

### Issue
In Basecamp 5, the Toggl timer button was missing from to-dos that live inside a **named to-do list** (e.g. "Doing", "Blocked"). It only appeared on the top-level **unlisted/loose** to-dos. Since most users keep their to-dos organized in lists, the button looked entirely absent to them. Reported by a user via support (#browser-extension-support).

### Cause
Basecamp 5 renders the two contexts with different containers:
- Unlisted/loose to-dos sit in a `div.todolist.todolist--loose`.
- Named lists sit in an `article.todolist`.

The `article.todolist` markup collides with the legacy **Basecamp 3** render block, whose selector is `article.todolist .todos li.todo`. That selector matches BC5 named-list rows, and the BC3 block is registered before the BC5 block. The core's `renderTo` stamps the `.toggl` marker class on every matched element *before* invoking the renderer, inside a try/catch that swallows errors. So for each named-list row the BC3 block: (1) marked it `.toggl`, then (2) threw when its renderer dereferenced `.checkbox__content`, which does not exist in BC5 markup (BC5 uses `.checkbox-field__content` / `.todo__content`). The error was swallowed, the row stayed marked `.toggl`, and the BC5 block's `:not(.toggl)` guard then skipped it — leaving no button. Loose to-dos use a `div`, never matched the BC3 selector, so they rendered fine.

### Solution
Narrowed the Basecamp 3 selector to `article.todolist .todos li.todo:not(.toggl):has(.checkbox__content)`. The `.checkbox__content` wrapper is unique to genuine BC3 markup, so the BC3 block no longer claims BC5 named-list rows, and the Basecamp 5 render block handles them and injects the button. No regression risk for real BC3 accounts: the BC3 renderer already dereferences `.checkbox__content` unconditionally, so any row lacking it would have thrown today anyway — the guard only excludes rows that were never getting a button.

## Test Plan

### 1. Timer button on Basecamp 5 to-dos inside a named list
- **Setup:** Toggl Track extension installed and logged in, Basecamp integration enabled; a Basecamp 5 account with a project whose To-dos tool contains a **named list** with at least one to-do.
- **Steps:** Open the project → open the To-dos tool → look at a to-do row inside the named list
- **Expected:** A minimal Toggl timer button appears inline after the to-do title. Clicking it starts a time entry with the to-do title as description and the Basecamp project name (from the breadcrumb) matched as the Toggl project.

### 2. Unlisted/loose to-dos still work (no regression)
- **Setup:** Same account; the To-dos tool also has top-level unlisted (loose) to-dos.
- **Steps:** Look at an unlisted to-do row on the same page
- **Expected:** Exactly one timer button per row — no duplicates, no missing buttons.

## 💬 Summarise how you feel about this PR with a gif

![the button was in the bag all along](https://media.giphy.com/media/xHyQcefa5Zgdy8aVa3/giphy.gif)
